### PR TITLE
repl-init-script fix

### DIFF
--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -9,7 +9,7 @@
 (defn repl-server [project host port]
   (let [init-form [:init `#(let [is# ~(:repl-init-script project)
                                  mn# '~(:main project)]
-                             (when (and is# (.exists (File. str)))
+                             (when (and is# (.exists (File. (str is#))))
                                (load-file is#))
                              (if mn#
                                (doto mn# require in-ns)


### PR DESCRIPTION
In the section dealing with repl-init-script in repl.clj it has:
    (File. str) 
rather than 
    (File. (str is#)) 
leading to a class cast exception when running lein repl with that option set.
