### PR TITLE
tasks in help.clj is sorted.

### DIFF
--- a/src/leiningen/help.clj
+++ b/src/leiningen/help.clj
@@ -2,8 +2,8 @@
   "Display a list of tasks or help for a given task."
   (:use [leiningen.util.ns :only [namespaces-matching]]))
 
-(def tasks (set (filter #(re-find #"^leiningen\.(?!core|util)[^\.]+$" (name %))
-                        (namespaces-matching "leiningen"))))
+(def tasks (sort (set (filter #(re-find #"^leiningen\.(?!core|util)[^\.]+$" (name %))
+                              (namespaces-matching "leiningen")))))
 
 (defn- get-arglists [task]
   (for [args (:arglists (meta task))]


### PR DESCRIPTION
I find more useful if "lein help" returns a sorted sequence since I can look for elements in O(log n) time (and I can know if there is both update and upgrade tasks in less than O(n) time).
