### PR TITLE
Avoid repetition in help task.

### DIFF
--- a/src/leiningen/help.clj
+++ b/src/leiningen/help.clj
@@ -2,8 +2,19 @@
   "Display a list of tasks or help for a given task."
   (:use [leiningen.util.ns :only [namespaces-matching]]))
 
-(def tasks (sort (filter #(re-find #"^leiningen\.(?!core|util)[^\.]+$" (name %))
-                         (namespaces-matching "leiningen"))))
+(defn- ordered-distinct
+  "Just like distinct, but for ordered coll"
+  ([[x & xs]]
+     (ordered-distinct x xs))
+  ([x xs]
+     (if (seq xs)
+       (if (= x (first xs))
+         (recur x (rest xs))
+         (lazy-seq (cons x (ordered-distinct (first xs) (rest xs)))))
+       nil)))
+
+(def tasks (ordered-distinct (sort (filter #(re-find #"^leiningen\.(?!core|util)[^\.]+$" (name %))
+                                           (namespaces-matching "leiningen")))))
 
 (defn get-arglists [task]
   (for [args (:arglists (meta task))]


### PR DESCRIPTION
I have added (another) method to help task to avoid repetition in the output. At least for me, some of them were output three times.

Anyway, feel free to change ordered-distinct by just distinct. Lately, I have all my programming environment in a pendrive (don't ask, you don't want to know, really), and it felt somehow slow in some cases (I'm talking about a Pentium 4, again, don't ask, please).
