### PR TITLE
Fixed parsing error when CLASSPATH var is empty

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -9,7 +9,7 @@ esac
 
 # Make sure classpath is in unix format for manipulating, then put
 # it back to windows format when we use it
-if [ "$OSTYPE" = "cygwin" ] && [ $CLASSPATH != "" ]; then
+if [ "$OSTYPE" = "cygwin" ] && [ "$CLASSPATH" != "" ]; then
     CLASSPATH=`cygpath -up $CLASSPATH`
 fi
 


### PR DESCRIPTION
The error:
$ lein

/home/pbauer/bin/lein: line 12: [: !=: unary operator expected
...

The fix:
On line 12, $CLASSPATH is compared to to "" (!= operator).
If $CLASSPATH is actually empty, this causes a parsing error unless the var is surrounded in double quote marks.
