### PR TITLE
Checkout project classpath entries are incorrect when using custom paths

### DIFF
--- a/src/leiningen/classpath.clj
+++ b/src/leiningen/classpath.clj
@@ -20,6 +20,13 @@
          (catch Exception e
            (throw (Exception. (format "Problem loading %s" project) e))))))
 
+(defn- ensure-absolute [path root]
+  (.getCanonicalPath
+   (let [f (file path)]
+     (if (.isAbsolute f)
+       f
+       (file root f)))))
+
 (defn checkout-deps-paths [project]
   (apply concat (for [dep (.listFiles (file (:root project) "checkouts"))
                       ;; Note that this resets the leiningen.core/project var!
@@ -27,7 +34,7 @@
                                    (read-dependency-project dep))]
                       :when proj]
                   (for [d [:source-path :compile-path :resources-path]]
-                    (proj d)))))
+                    (ensure-absolute (proj d) dep)))))
 
 (defn user-plugins []
   (for [jar (.listFiles (file (home-dir) "plugins"))


### PR DESCRIPTION
Currently, the checkout logic in the classpath task pulls in custom {source,compile,resource}-paths as relative paths. These paths don't work in the super-project, since they are relative to the root of the checkout project. This patch ensures paths pulled in from checkout deps are absolutized against the path to the checkout dep.

A process note - I could submit this myself, and would be happy to do the merge work, but wanted to make sure I'm not missing something that would make this unnecessary. Thanks!
