### PR TITLE
Test migration

### DIFF
--- a/test/leiningen/test/compile.clj
+++ b/test/leiningen/test/compile.clj
@@ -1,4 +1,4 @@
-(ns test-compile
+(ns leiningen.test.compile
   (:refer-clojure :exclude [compile])
   (:use [leiningen.compile] :reload)
   (:use [clojure.test]

--- a/test/leiningen/test/core.clj
+++ b/test/leiningen/test/core.clj
@@ -1,4 +1,4 @@
-(ns test-core
+(ns leiningen.test.core
   (:use [leiningen.core] :reload-all)
   (:use [clojure.test]))
 

--- a/test/leiningen/test/deploy.clj
+++ b/test/leiningen/test/deploy.clj
@@ -1,4 +1,4 @@
-(ns test-deploy
+(ns leiningen.test.deploy
   (:use [leiningen.deploy] :reload)
   (:use [clojure.test]
         [clojure.java.io :only [file]]

--- a/test/leiningen/test/deps.clj
+++ b/test/leiningen/test/deps.clj
@@ -1,4 +1,4 @@
-(ns test-deps
+(ns leiningen.test.deps
   (:use [leiningen.core :only [read-project defproject]]
         [leiningen.deps :only [deps]] :reload-all)
   (:use [clojure.test]

--- a/test/leiningen/test/help.clj
+++ b/test/leiningen/test/help.clj
@@ -1,4 +1,4 @@
-(ns test-help
+(ns leiningen.test.help
   (:use [leiningen.help]
         [clojure.test]))
 

--- a/test/leiningen/test/install.clj
+++ b/test/leiningen/test/install.clj
@@ -1,4 +1,4 @@
-(ns test-install
+(ns leiningen.test.install
   (:use [leiningen.core :only [read-project defproject home-dir]]
         [leiningen.compile :only [get-os]]
         [leiningen.install] :reload)

--- a/test/leiningen/test/jar.clj
+++ b/test/leiningen/test/jar.clj
@@ -1,4 +1,4 @@
-(ns test-jar
+(ns leiningen.test.jar
   (:use [clojure.test]
         [leiningen.core :only [defproject read-project]]
         [leiningen.jar]

--- a/test/leiningen/test/javac.clj
+++ b/test/leiningen/test/javac.clj
@@ -1,4 +1,4 @@
-(ns test-javac
+(ns leiningen.test.javac
   (:use [clojure.test]
         [clojure.java.io :only [file]]
         [leiningen.javac :only [javac]]

--- a/test/leiningen/test/new.clj
+++ b/test/leiningen/test/new.clj
@@ -1,4 +1,4 @@
-(ns test-new
+(ns leiningen.test.new
   (:require [leiningen.new] :reload)
   (:use [clojure.test]
         [clojure.java.io :only [file]]

--- a/test/leiningen/test/plugin.clj
+++ b/test/leiningen/test/plugin.clj
@@ -1,4 +1,4 @@
-(ns test-plugin
+(ns leiningen.test.plugin
   (:use [leiningen.plugin]
         [leiningen.util.file :only (unique-lein-tmp-dir
                                     delete-file-recursively)]

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -1,4 +1,4 @@
-(ns test-pom
+(ns leiningen.test.pom
   (:use [leiningen.core :only [read-project defproject]]
         [leiningen.util.maven :only [make-model]]
         [leiningen.pom :only [pom]])

--- a/test/leiningen/test/run.clj
+++ b/test/leiningen/test/run.clj
@@ -1,4 +1,4 @@
-(ns test-run
+(ns leiningen.test.run
   (:use [clojure.test]
         [clojure.java.io :only [delete-file]]
         [leiningen.core :only [read-project]]

--- a/test/leiningen/test/test.clj
+++ b/test/leiningen/test/test.clj
@@ -1,4 +1,4 @@
-(ns test-test
+(ns leiningen.test.test
   (:refer-clojure :exclude [test])
   (:use [leiningen.test]
         [leiningen.util.file :only [tmp-dir]]

--- a/test/leiningen/test/uberjar.clj
+++ b/test/leiningen/test/uberjar.clj
@@ -1,4 +1,4 @@
-(ns test-uberjar
+(ns leiningen.test.uberjar
   (:use [leiningen.uberjar] :reload)
   (:use [clojure.test]
         [leiningen.jar :only [get-jar-filename get-default-uberjar-name jar]]


### PR DESCRIPTION
Moved test namespaces to leiningen.test.*

(Phil: I didn't commit this to master because it's a largish change and I wanted your approval for it.)
