### PR TITLE
Enabled correct quoting, editor support in rlwrap

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -175,7 +175,8 @@ else
     # doesn't exist everything will still work, it will just have a
     # slower JVM boot.
     test $CYGWIN_JLINE && stty -icanon min 1 -echo
-    exec $RLWRAP $JAVA_CMD -Xbootclasspath/a:"$CLOJURE_JAR" -client $JVM_OPTS \
+    exec $RLWRAP -m -q '"' \
+        $JAVA_CMD -Xbootclasspath/a:"$CLOJURE_JAR" -client $JVM_OPTS \
         -Dleiningen.original.pwd="$ORIGINAL_PWD" \
         -cp "$CLASSPATH" $JLINE clojure.main -e "(use 'leiningen.core)(-main)" \
         $NULL_DEVICE $@


### PR DESCRIPTION
rlwrap's current configuration incorrectly interprets the syntax quote as a string delimiter. This messes with visual hints for closing parens.

-m technically enables multi-line editing, but more usefully enables external editor support with Ctrl-^

Tested with:
~ % rlwrap -v 
rlwrap 0.37
