### PR TITLE
Lein run: Handle args with spaces

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -178,6 +178,6 @@ else
     exec $RLWRAP $JAVA_CMD -Xbootclasspath/a:"$CLOJURE_JAR" -client $JVM_OPTS \
         -Dleiningen.original.pwd="$ORIGINAL_PWD" \
         -cp "$CLASSPATH" $JLINE clojure.main -e "(use 'leiningen.core)(-main)" \
-        $NULL_DEVICE $@
+        $NULL_DEVICE "$@"
     test $CYGWIN_JLINE && stty icanon echo
 fi


### PR DESCRIPTION
Surrounded the $@ with double quotes to prevent arguments with spaces (even quoted ones) from being broken appart into multiple args. This was causing problems with a few utilities I was trying to run using 'lein run' that were breaking apart my arg strings. For example, trying 'lein run "long arg phrase"' resulted in three arguments, "long", "arg", and "phrase". Double quoting the use of $@ in the lein script seems to have healed the problem: only one arg "long arg phrase" is passed. Not sure if a change to lein.bat is also necessary.
