### PR TITLE
pom task, adds dev-dependencies to pom.xml with scope test

### DIFF
--- a/src/leiningen/util/maven.clj
+++ b/src/leiningen/util/maven.clj
@@ -147,9 +147,9 @@ the :classifier key (if present) is the classifier on the
 dependency (as a string). The value for the :exclusions key, if
 present, is a seq of symbols, identifying group ids and artifact ids
 to exclude from transitive dependencies."
-  ([dependency]
-     (make-dependency {} dependency))
-  ([project dependency]
+  ([dependency scope]
+     (make-dependency {} dependency scope))
+  ([project dependency scope]
      (when-not (vector? dependency)
        (abort "Dependencies must be specified as vector:" dependency))
      (let [[dep version & extras] dependency
@@ -167,6 +167,7 @@ to exclude from transitive dependencies."
                         (or (namespace dep) (name dep))))
          (.setArtifactId (name dep))
          (.setVersion version)
+         (.setScope scope) 
          (.setClassifier classifier)
          (.setType (or type "jar"))
          (.setExclusions es)))))
@@ -224,7 +225,9 @@ to exclude from transitive dependencies."
                 (.setUrl (:url project))
                 (.setBuild (make-build project)))]
     (doseq [dep (:dependencies project)]
-      (.addDependency model (make-dependency dep)))
+      (.addDependency model (make-dependency dep nil)))
+    (doseq [dev (:dev-dependencies project)]
+      (.addDependency model (make-dependency dev "test")))
     (doseq [repo (repositories-for project)]
       (.addRepository model (make-repository repo)))
     (when-let [scm (make-git-scm (file (:root project) ".git"))]


### PR DESCRIPTION
Hi 

When developing with an IDE such as Netbean, Eclipse or Idea.
The fastest way is for setting up a project is importing a project file. 
But with the existing version of leiningen - the project will not have setup a classpath including dev dependencies. 
With this patch the lein pom task will add dev-dependencies to the pom dependencies with the scope of 'test'
.
