### PR TITLE
zsh error

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -83,7 +83,7 @@ fi
 
 HTTP_CLIENT="wget --no-check-certificate -O"
 if type -p curl >/dev/null 2>&1; then
-    if [ $https_proxy != "" ]; then
+    if [ "$https_proxy" != "" ]; then
         CURL_PROXY="-x $https_proxy"
     fi
     HTTP_CLIENT="curl $CURL_PROXY --insecure -f -L -o"


### PR DESCRIPTION
It seems that when using zsh as shell and having no https proxy, the following error happened
[zitpcx16106] ~ $ lein repl
/afs/desy.de/user/p/pfix/local/bin/lein: line 86: [: !=: unary operator expected
REPL started; server listening on localhost:48076.
user=>

This change should fix that.

Best regards,
Pirmin
