### PR TITLE
Small fix to lein shell script to work around use of /bin/sh on Solaris

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -21,6 +21,7 @@ if [ `whoami` = "root" ] && [ "$LEIN_ROOT" = "" ]; then
     read _
 fi
 
+NOT_FOUND=1
 ORIGINAL_PWD="$PWD"
 while [ ! -r "$PWD/project.clj" ] && [ "$PWD" != "/" ] && [ ! $NOT_FOUND ]
 do


### PR DESCRIPTION
Initializing NOT_FOUND prior to entering loop, to avoid error using /bin/sh on Solaris

Please refer to this thread on the mailing list.
