### PR TITLE
Read default dev-dependencies from settings map in ~/.lein/init.clj, write same to project.clj

### DIFF
--- a/src/leiningen/new.clj
+++ b/src/leiningen/new.clj
@@ -1,16 +1,22 @@
 (ns leiningen.new
   "Create a new project skeleton."
-  (:use [leiningen.core :only [ns->path abort]]
+  (:use [leiningen.core :only [ns->path abort user-settings]]
         [clojure.java.io :only [file]]
         [clojure.string :only [join]])
   (:import (java.util Calendar)))
+
+(defn get-user-settings [key]
+  (when-let [settings (key (user-settings))]
+    (str key  "[" (apply str settings) "]")))
 
 (defn write-project [project-dir project-name]
   (.mkdirs (file project-dir))
   (spit (file project-dir "project.clj")
         (str "(defproject " project-name " \"1.0.0-SNAPSHOT\"\n"
              "  :description \"FIXME: write description\"\n"
-             "  :dependencies [[org.clojure/clojure \"1.2.1\"]])\n")))
+             "  :dependencies [[org.clojure/clojure \"1.2.1\"]]\n"
+             "  " (get-user-settings :dev-dependencies)
+             ")"  )))
 
 (defn write-implementation [project-dir project-clj project-ns]
   (.mkdirs (.getParentFile (file project-dir "src" project-clj)))


### PR DESCRIPTION
Phil,
I asked on the Clojure google group about how to get lein to automatically insert default dev dependencies into a newly created project.clj file.  Robin Ramael pointed me to a project called Spawn, but that seemed more heavyweight than I needed.  I looked around in the lein source and found I could do what I wanted with very few changes to a single file.  There seemed to already be some machinery to read a settings map from ~/.lein/init.clj, so I created the map and put the machinery to use.  Works fine for me. 

BTW, thanks you for creating lein.  I was tired of my hair catching fire; can't afford to lose any more.
Seriously, lein does a lot of useful gruntwork so I don't have to. Automation at its finest. I appreciate it.

David Cabana

I 
