### PR TITLE
read user settings from settings map in ~/.lein/init.clj, write same to project.clj

### DIFF
--- a/src/leiningen/new.clj
+++ b/src/leiningen/new.clj
@@ -1,16 +1,30 @@
 (ns leiningen.new
   "Create a new project skeleton."
-  (:use [leiningen.core :only [ns->path abort]]
+  (:use [leiningen.core :only [ns->path abort user-settings]]
         [clojure.java.io :only [file]]
         [clojure.string :only [join]])
   (:import (java.util Calendar)))
 
+(defn format-settings [settings]
+  (letfn [(format-map [m]
+            (map #(str "  " %1 " " %2)
+                 (map str (keys m))
+                 (map str (vals m))))]
+    (apply str
+           (interpose "\n"
+                      (format-map settings)))))
+
 (defn write-project [project-dir project-name]
-  (.mkdirs (file project-dir))
-  (spit (file project-dir "project.clj")
-        (str "(defproject " project-name " \"1.0.0-SNAPSHOT\"\n"
-             "  :description \"FIXME: write description\"\n"
-             "  :dependencies [[org.clojure/clojure \"1.2.1\"]])\n")))
+  (let [default-settings {:dependencies [['org.clojure/clojure "1.2.1"]]}
+        settings  (merge-with #(if %2 %2 %1)
+                              default-settings
+                              (user-settings))]
+    (.mkdirs (file project-dir))
+    (spit (file project-dir "project.clj")
+          (str "(defproject " 'project-name " \"1.0.0-SNAPSHOT\"\n"
+               "  :description \"FIXME: write description\"\n"
+               (format-settings (into (sorted-map) settings))
+               ")" ))))
 
 (defn write-implementation [project-dir project-clj project-ns]
   (.mkdirs (.getParentFile (file project-dir "src" project-clj)))


### PR DESCRIPTION
Phil,
I think I understood the spirit, if not the detail, of your suggestion.   I generalized my approach to pick up all settings present in the user settings map, not just the dev-dependencies.  I put the minimal set of dependencies currently present in new.clj into a map (default-settings), merge that map with the user settings map, then use the result to create the final output. That way I get sane behavior when there is no user settings map.  The user settings override default settings in case of collisions. The output is alphabetized, figured that would make it easier to eyeball.

The changes are still few and confined to the new.clj file. Let me know what you think.
drc
