### PR TITLE
Added :checkout-deps-shares option 

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -69,6 +69,13 @@
   ;; use a regex that will be matched against filenames in the project root.
   ;; Defaults to #"^$NAME-.*\.jar$".
   :regex-to-clean #"hs_err_pid.*"
+  ;; Load dependencies from checkouts/ directory. Set this to be a vector of
+  ;; functions that take the target project as argument.
+  ;; The default is [:source-path :compile-path :resources-path]
+  ;; but you could also add, for instance, :test-path to share tests, or
+  ;; ~(fn [p] (str (:root p) "/lib/dev/*")) to load also development dependencies
+  ;; from the checked out project (Java 1.6+)
+  :checkout-deps-shares
   ;; Load these namespaces on startup to pick up hooks from them. Hooks
   ;; generally come from plugins, but may be included in your project source.
   :hooks [leiningen.hooks.difftest]

--- a/src/leiningen/classpath.clj
+++ b/src/leiningen/classpath.clj
@@ -25,8 +25,8 @@
                       ;; Note that this resets the leiningen.core/project var!
                       :let [proj (read-dependency-project dep)]
                       :when proj]
-                  (for [d [:source-path :compile-path :resources-path]]
-                    (ensure-absolute (proj d) dep)))))
+                  (for [d (:checkout-deps-shares project [:source-path :compile-path :resources-path])]
+                    (ensure-absolute (d proj) dep)))))
 
 (defn user-plugins []
   (for [jar (.listFiles (file (leiningen-home) "plugins"))


### PR DESCRIPTION
Used to specify other directories added to the classpath from the checked out projects.
