### PR TITLE
Renamed .classpath to .lein_classpath

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -73,8 +73,8 @@ CLOJURE_JAR="$HOME/.m2/repository/org/clojure/clojure/1.2.1/clojure-1.2.1.jar"
 NULL_DEVICE=/dev/null
 
 # apply context specific CLASSPATH entries
-if [ -f .classpath ]; then
-    CLASSPATH="`cat .classpath`:$CLASSPATH"
+if [ -f .lein_classpath ]; then
+    CLASSPATH="`cat .lein_classpath`:$CLASSPATH"
 fi
 
 # normalize $0 on certain BSDs

--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -38,7 +38,7 @@ set CLASSPATH="%CLASSPATH%";%DEV_PLUGINS%;%UNIQUE_USER_PLUGINS%;test;src
 
 :: Apply context specific CLASSPATH entries
 set CONTEXT_CP=""
-if exist ".classpath" set /P CONTEXT_CP=<.classpath
+if exist ".lein_classpath" set /P CONTEXT_CP=<.lein_classpath
 if NOT "%CONTEXT_CP%"=="" set CLASSPATH="%CONTEXT_CP%";%CLASSPATH%
 
 if exist "%~f0\..\..\src\leiningen\core.clj" (

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -100,8 +100,8 @@ for more details.
 ## CLASSPATH
 
 Custom classpath elements can be added to Leiningen's startup command
-by adding a '.classpath' file the the working directory.  When present,
-the content from '.classpath' will be prepended to the classpath before
+by adding a '.lein_classpath' file the the working directory.  When present,
+the content from '.lein_.classclasspath' will be prepended to the classpath before
 invoking the JVM.
 
 ## Have Fun


### PR DESCRIPTION
I received word that this filename is used by other tools like eclipse and unfortunately eclipse uses an xml format so it's definitely not compatible.  I had considered calling it .lein_classpath in the first place and now that I revisit it, I think it's a better name.
