### PR TITLE
Fixed test for empty CONTEXT_CP

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -37,9 +37,9 @@ call :BUILD_UNIQUE_USER_PLUGINS
 set CLASSPATH="%CLASSPATH%";%DEV_PLUGINS%;%UNIQUE_USER_PLUGINS%;test;src
 
 :: Apply context specific CLASSPATH entries
-set CONTEXT_CP=""
+set CONTEXT_CP=
 if exist ".classpath" set /P CONTEXT_CP=<.classpath
-if NOT "%CONTEXT_CP%"=="""" set CLASSPATH="%CONTEXT_CP%";%CLASSPATH%
+if NOT "%CONTEXT_CP%"=="" set CLASSPATH="%CONTEXT_CP%";%CLASSPATH%
 
 if exist "%~f0\..\..\src\leiningen\core.clj" (
     :: Running from source checkout.


### PR DESCRIPTION
Line 42 of lein.bat currently tests for an empty CONTEXT_CP by checking whether "%CONTEXT_CP%" == "".  Since CONTEXT_CP is initialized to "", if nothing is appended to CONTEXT_CP in line 41, "%CONTEXT_CP%" is actually """".  This results in line 42 prepending """" to the CLASSPATH, which caused lein to mis-parse CLASSPATH and crash on my system.

I've updated the test in line 42 to "%CONTEXT_CP%" == """".

Edit: As mtyaka suggested, it's better to init CONTEXT_CP to be empty.
