### PR TITLE
Respect $LEIN_HOME when staving the standalone jar

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -68,7 +68,7 @@ unique_user_plugins () {
 LEIN_PLUGIN_PATH="$(echo "$DEV_PLUGINS" | tr \\n :)"
 LEIN_USER_PLUGIN_PATH="$(echo "$(unique_user_plugins)" | tr \\n :)"
 CLASSPATH="$CLASSPATH:$LEIN_PLUGIN_PATH:$LEIN_USER_PLUGIN_PATH:test/:src/"
-LEIN_JAR="$HOME/.lein/self-installs/leiningen-$LEIN_VERSION-standalone.jar"
+LEIN_JAR="$LEIN_HOME/self-installs/leiningen-$LEIN_VERSION-standalone.jar"
 CLOJURE_JAR="$HOME/.m2/repository/org/clojure/clojure/1.2.1/clojure-1.2.1.jar"
 NULL_DEVICE=/dev/null
 


### PR DESCRIPTION
I ran `LEIN_HOME=/tmp/lein /usr/bin/lein` but it still touches `~/.lein` ... this patch fixes it.
