### PR TITLE
Fixing #211

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,6 @@
                  [lancet "1.0.1"]
                  [jline "0.9.94" :exclusions [junit]]
                  [robert/hooke "1.1.2"]
-                 [org.apache.maven/maven-ant-tasks "2.0.10" :exclusions [ant]]]
+                 [org.apache.maven/maven-ant-tasks "2.1.3" :exclusions [ant]]]
   :disable-implicit-clean true
   :eval-in-leiningen true)

--- a/sample.project.clj
+++ b/sample.project.clj
@@ -116,9 +116,9 @@
   :repl-retry-limit 1000
   ;; Emit warnings on all reflection calls.
   :warn-on-reflection true
-  ;; Set this in order to only use the :repositories you list below. Note that 
-  ;; a bug in maven-ant-tasks prevents Leiningen from excluding Maven Central,
-  ;; so in effect this simply omits Clojars.
+  ;; Set this in order to only use the :repositories you list below. Note that,
+  ;; if any artifacts are not found, Maven Central will still be reported to
+  ;; have been checked, even though it was not.
   :omit-default-repositories true
   :repositories {"java.net" "http://download.java.net/maven/2"
                  "sonatype"

--- a/todo.org
+++ b/todo.org
@@ -16,7 +16,6 @@ See also https://github.com/technomancy/leiningen/issues
     Try a custom classloader approach?
   - Use Aether instead of maven-ant-tasks?
     http://www.sonatype.com/people/2010/08/introducing-aether/
-    Could also allow us to fix :omit-default-repositories wrt central
   - classifiers for specifying what clojure version to use?
     As more versions of Clojure start to exist, libraries may want to
     publish different branches that target different versions of
@@ -29,6 +28,7 @@ See also https://github.com/technomancy/leiningen/issues
     lein-clojars task doesn't support DSA keys
 * For 1.6.2
   - [X] resources with eval-in-leiningen (#248)
+  - [X] fix :omit-default-repositories wrt central (#211)
   - [ ] signed deps for plugins (#247)
   - [ ] investigate interactive failures with 1.3 (#234)
   - [ ] remove bashisms (#246)


### PR DESCRIPTION
Upgrade to maven-ant-tasks 2.1.3, explicitly add disabled "central" repository when :omit-default-repositories is true. Fixes #211.

maven-ant-tasks 2.1.3 includes [two](http://jira.codehaus.org/browse/MANTTASKS-195) [fixes](http://jira.codehaus.org/browse/MANTTASKS-206) compared to 2.0.10 that made it impossible to override/disable the "central" repo.  Other changes since 2.0.10 (which can be seen [here](http://maven.apache.org/ant-tasks/release-notes.html)) appear to be innocuous w.r.t. leiningen; all tests pass with the upgraded dependency.

Note that, when artifact cannot be downloaded, the "central" repository will still be listed as one of the checked repos.  This is because there is _always_ a "central" repo — even if you disable it entirely and/or redirect it to a useless URL.

This change doesn't include any tests, unfortunately.  The only way I can see being able to test this in an automated fashion would be if lein allowed one to override the local repository path for a project (a useful thing in its own right), so that the test could verify e.g. the failure to resolve and download a known-available artifact from central/clojars when :omit-default-repositories is true.

As a bonus, it looks like maven-ant-tasks 2.1.3 fixes other issues with 2.0.10, including the latter's refusal to pick up certain things from `settings.xml` (e.g. mirrors and default repositories defined in always-enabled profiles).
