### PR TITLE
added support for project centric lein installations

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -33,8 +33,15 @@ do
 done
 
 if [ "$LEIN_HOME" = "" ]; then
+  if [ -d "$ORIGINAL_PWD/.lein" ]; then
+    echo "Running in project mode."
+    LEIN_HOME="$ORIGINAL_PWD/.lein"
+  else
     LEIN_HOME="$HOME/.lein"
+  fi
+
 fi
+
 
 DEV_PLUGINS="$(ls -1 lib/dev/*jar 2> /dev/null)"
 USER_PLUGINS="$(ls -1 "$LEIN_HOME"/plugins/*jar 2> /dev/null)"


### PR DESCRIPTION
added check for $ORIGINAL_PWD/.lein to exist and choose it over $HOME/.lein as LEIN_HOME. this allows project specific lein installations.
