### PR TITLE
Include commented out :url option in default project.clj

### DIFF
--- a/src/leiningen/new/default/project.clj
+++ b/src/leiningen/new/default/project.clj
@@ -1,3 +1,4 @@
 (defproject {{name}} "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
+  ;; :url "http://FIXME"
   :dependencies [[clojure "1.3.0"]])


### PR DESCRIPTION
To encourage more libraries on clojars to have links back to the project source
