### PR TITLE
Changes to support Solaris

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/ksh
 
 LEIN_VERSION="1.6.2"
 export LEIN_VERSION
@@ -41,12 +41,19 @@ if [ "$LEIN_HOME" = "" ]; then
   fi
 fi
 
+# Solaris doesn't include a rev command, so when running there, make sure LEIN_REV points to a replacement.
+if [ "$LEIN_REV" = "" ]; then
+    LEIN_REV="rev"
+fi
+
+# Other Solaris notes:  change the first line of this script to #!/bin/ksh, and make sure /usr/xpg6/bin/tr is ahead of other tr binaries, especially /usr/ucb/tr
+
 DEV_PLUGINS="$(ls -1 lib/dev/*jar 2> /dev/null)"
 USER_PLUGINS="$(ls -1 "$LEIN_HOME"/plugins/*jar 2> /dev/null)"
 
 artifact_name () {
     echo "$1" | sed -e "s/.*\/\(.*\)/\1/" | \
-        rev | sed -e "s/raj[-[:digit:].]*-\(.*\)/\1/" | rev
+        $LEIN_REV | sed -e "s/raj[-[:digit:].]*-\(.*\)/\1/" | $LEIN_REV
 }
 
 unique_user_plugins () {

--- a/bin/lein-rev
+++ b/bin/lein-rev
@@ -1,0 +1,11 @@
+#!/bin/ksh
+awk '
+/../ {	# no need to process lines with less than 2 characters
+len = length($0)
+line = ""
+for ( i=1; i<=len; ++i )
+line = substr($0, i, 1) line
+print line; next
+}
+{print}
+' "$@"


### PR DESCRIPTION
lein shell script modified to run under Solaris, lein-rev shell script added because Solaris doesn't have that command.

I can easily imagine you will hate these proposed changes, and won't integrate.  But I need to provide my own copy of rev.....
