### PR TITLE
Re-enable rlwrap and completion dictionary

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -246,7 +246,7 @@ else
 						if [ -r "${RLWRAP_CLJ_WORDS_FILE}" ]; then 
 							RLWRAP_CLJ_WORDS_OPTION="-f ${RLWRAP_CLJ_WORDS_FILE}"; 
 						fi
-            RLWRAP="${RLWRAP} -p ${RLWRAP_PROMPT_COLOR:-"Black"} -b \"(){}[],^%$#@\";:'\" ${RLWRAP_CLJ_WORDS_OPTION}"
+            RLWRAP="${RLWRAP} -p${RLWRAP_PROMPT_COLOR:-"Black"} -b \"(){}[],^%$#@\";:'\" ${RLWRAP_CLJ_WORDS_OPTION}"
         fi
     fi
 


### PR DESCRIPTION
Reinstated rlwrap usage and added clj-words completion option in lein script only
This is only valid for 1.7.0-SNAPSHOT branch - 2.0 branch has rlwrap enabled (plus many more changes)
Removed test for internal tasks that would disable rlwrap use for plugins - $TERM test should suffice

ok - always pass the trampoline cmd-directive - no more if - only added the rlwrap - and no exec… - we'll get it right eventually ;-)
