### PR TITLE
[master] Prepend LEIN_JAR to CLASSPATH when running standalone

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -125,7 +125,7 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
     CLASSPATH="$CLASSPATH:$LEIN_DIR/src:$LEIN_DIR/resources:$LEIN_JAR"
 else
     # Not running from a checkout
-    CLASSPATH="$CLASSPATH:$LEIN_JAR"
+    CLASSPATH="$LEIN_JAR:$CLASSPATH"
 
     if [ ! -r "$LEIN_JAR" -a "$1" != "self-install" ]; then
         "$0" self-install


### PR DESCRIPTION
Otherwise lein does not work when managing projects that use an incompatible Clojure version (e.g. using Lein stable with ClojureScript One)
