### PR TITLE
[stable] Prepend LEIN_JAR to CLASSPATH when running standalone

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -114,7 +114,7 @@ if [ -r "$BIN_DIR/../src/leiningen/core.clj" ]; then
     fi
 else
     # Not running from a checkout
-    CLASSPATH="$CLASSPATH:$LEIN_JAR"
+    CLASSPATH="$LEIN_JAR:$CLASSPATH"
 
     if [ ! -r "$LEIN_JAR" -a "$1" != "self-install" ]; then
         "$0" self-install


### PR DESCRIPTION
Otherwise lein does not work when managing projects that use an incompatible Clojure version (e.g. using Lein stable with ClojureScript One)
