### PR TITLE
Added replace/displace to the profile merging.

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -90,7 +90,13 @@
 (defn- profile-key-merge
   "Merge profile values into the project map based on their type."
   [key result latter]
-  (cond (= :dependencies key)
+  (cond (-> result meta :displace)
+        latter
+
+        (-> latter meta :replace)
+        latter
+
+        (= :dependencies key)
         (merge-dependencies result latter)
 
         (= :repositories key)

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -59,4 +59,14 @@
            (-> {:resources-path ["resources"]
                 :profiles {:blue {:resources-path ["blue-resources"]}}}
                (merge-profiles [:qa :tes :blue])
+               :resources-path)))
+    (is (= ["/etc/myapp" "test/hi" "blue-resources"]
+           (-> {:resources-path ^:displace ["resources"]
+                :profiles {:blue {:resources-path ["blue-resources"]}}}
+               (merge-profiles [:qa :tes :blue])
+               :resources-path)))
+    (is (= ["replaced"]
+           (-> {:resources-path ["resources"]
+                :profiles {:blue {:resources-path ^:replace ["replaced"]}}}
+               (merge-profiles [:blue :qa :tes ])
                :resources-path)))))


### PR DESCRIPTION
Hi, I hope you like the patch.  This relates to #379.  It adds ^:displace and ^:replace to modify the standard profile merging behaviour. 
