### PR TITLE
Make sure .travis.yml includes language: clojure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
----
+language: clojure
 before_script: cd leiningen-core; lein deps; lein install; cd ..
 script: bin/lein test
 branches:


### PR DESCRIPTION
There are two reasons for this:
- We will soon roll out first-class support for other JVM languages and Clojure will be hosted on a different machine. Without this language: line Leiningen will still land on Ruby workers.
- :language key will at some point in the future be mandatory.

Finally, you still can override `install:`, `script:` or anything else, so there is no reason to not have `language:` in your .travis.yml.
