### PR TITLE
Override install instead of adding before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-before_script: cd leiningen-core; lein deps; lein install; cd ..
+install: cd leiningen-core; lein deps; lein install; cd ..
 script: bin/lein test
 branches:
   only:


### PR DESCRIPTION
We don't want default Clojure builder's `install` command to be executed
