### PR TITLE
Replace `whoami` with `id -u` test

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -14,7 +14,7 @@ if [ "$OSTYPE" = "cygwin" ] && [ "$CLASSPATH" != "" ]; then
     CLASSPATH=`cygpath -up $CLASSPATH`
 fi
 
-if [ `whoami` = "root" ] && [ "$LEIN_ROOT" = "" ]; then
+if [ `id -u` -eq 0 ] && [ "$LEIN_ROOT" = "" ]; then
     echo "WARNING: You're currently running as root; probably by accident."
     echo "Press control-C to abort or Enter to continue as root."
     echo "Set LEIN_ROOT to disable this warning."


### PR DESCRIPTION
`id -u` is in the POSIX and LSB specs [1](http://pubs.opengroup.org/onlinepubs/009695399/utilities/id.html), while `whoami` is not.
Furthermore, the username of UID 0 can be changed (and is sometimes
recommended in a misguided attempt to increase security).

FreeBSD users logged in as `toor` would also slip through the cracks.

```
 http://refspecs.linuxfoundation.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/command.html
```
