### PR TITLE
Allow lein to run when called with no tasks and no .lein-classpath

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 LEIN_VERSION="2.0.0-SNAPSHOT"
 export LEIN_VERSION


### PR DESCRIPTION
In that case, $1 isn't set, causing sh to barf on the test.
