### PR TITLE
Add :headless flag to repl task

### DIFF
--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -39,12 +39,16 @@
 (defn ^:no-project-needed repl
   "Start a repl session either with the current project or standalone.
 
+USAGE: lein repl
 This will launch an nREPL server behind the scenes that reply will connect to.
 If a :repl-port key is present in project.clj, that port will be used for the
 server, otherwise it is chosen randomly. If you run this command inside of a
 project, it will be run in the context of that classpath. If the command is
 run outside of a project, it'll be standalone and the classpath will be
-that of Leiningen."
+that of Leiningen.
+
+USAGE: lein repl :headless
+This will launch an nREPL server and wait, rather than connecting reply to it."
   ([] (repl nil))
   ([project]
    (nrepl.ack/reset-ack-port!)


### PR DESCRIPTION
Allow LEIN_REPL_ACK_PORT to be specified for when running :headless, so external programs can be notified when nREPL is done firing up.

Based on this thread on the mailing list a few months ago: http://groups.google.com/group/leiningen/browse_thread/thread/72971a0b758b5071/cf950d86ae834f97?lnk=gst&q=%3Aheadless#cf950d86ae834f97
