### PR TITLE
Add :included-profiles metadata to project map in merge-profiles. See issue 392.

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -174,7 +174,8 @@
   (let [merged (reduce merge-profile project
                        (profiles-for project profiles-to-apply))]
     (with-meta (normalize merged)
-      {:without-profiles (normalize project)})))
+      {:without-profiles (normalize project)
+       :included-profiles profiles-to-apply})))
 
 (defn ensure-dynamic-classloader []
   (let [thread (Thread/currentThread)


### PR DESCRIPTION
With a list of the profile names that have been merged into the project map in the metadata, you can know which profiles have already been merged, fetch those profiles for additional processing, reapply some subset of the merged profiles to the original map using the :without-profiles metadata, or report errors to the user using the profile names. 
