### PR TITLE
Fix merge-profiles so that :included-profiles metadata is added to if it...

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -175,7 +175,8 @@
                        (profiles-for project profiles-to-apply))]
     (with-meta (normalize merged)
       {:without-profiles (normalize project)
-       :included-profiles profiles-to-apply})))
+       :included-profiles (concat (:included-profiles (meta project))
+                                  profiles-to-apply)})))
 
 (defn ensure-dynamic-classloader []
   (let [thread (Thread/currentThread)


### PR DESCRIPTION
... is already present, instead of overwriting it.

Without this fix, calling merge-profiles on a project map that has already had merge-profiles called on it will result in incorrect metadata about which profiles have been merged.
