### PR TITLE
Nicer formatting for `lein deps :tree`

### DIFF
--- a/src/leiningen/deps.clj
+++ b/src/leiningen/deps.clj
@@ -3,6 +3,16 @@
   (:require [leiningen.core.classpath :as classpath]
             [clojure.pprint :as pp]))
 
+;;; TODO: Get rid of this recursion
+(defn- print-tree
+  ([tree level increment]
+     (doseq [[n c] tree]
+       (println (str (apply str (repeat level \space))) n)
+       (when c
+         (print-tree c (+ level increment) increment))))
+  ([tree increment]
+     (print-tree tree 0 increment)))
+
 (defn deps
   "Download all dependencies.
 
@@ -11,6 +21,5 @@ You should never need to invoke this manually."
      (deps project nil))
   ([project tree]
      (if (= tree ":tree")
-       (do (pp/pprint (classpath/dependency-hierarchy :dependencies project))
-           (flush))
+       (print-tree (classpath/dependency-hierarchy :dependencies project) 4)
        (classpath/resolve-dependencies :dependencies project))))


### PR DESCRIPTION
This patch adds nicer formatting to `lein deps :tree`. You can see example output in the README of my project: [lein-deps-tree](https://github.com/the-kenny/lein-deps-tree).

There's one issue: The function utilizes non-tail recursion for output. This shouldn't be a problem, except for projects with very deeply nested dependency graphs.

This code is also affected by #491 as it re-uses the same code for acquiring the dependency graph.
