### PR TITLE
Fix merge-profiles so that it does not clobber existing metadata in the ...

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -173,7 +173,7 @@
   [project profiles-to-apply]
   (let [merged (reduce merge-profile project
                        (profiles-for project profiles-to-apply))]
-    (with-meta (normalize merged)
+    (vary-meta (normalize merged) merge
       {:without-profiles (normalize (:without-profiles (meta project) project))
        :included-profiles (concat (:included-profiles (meta project))
                                   profiles-to-apply)})))


### PR DESCRIPTION
...project map, but instead merges.

Not having this fix makes the repl task fail when there are hooks, since the EIP call will lose the :prepped metadata.
