### PR TITLE
Maven repos seem to want "password" not "passphrase"

### DIFF
--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -66,7 +66,7 @@ projects may also be specified in the `settings` map in `~/.lein/init.clj`:
 Private repositories often need authentication credentials. You'll need to
 provide either a <tt>:username</tt>/<tt>:password</tt> combination or
 a <tt>:private-key</tt> location with or without a
-<tt>:passphrase</tt>. If you want to avoid putting sensitive
+<tt>:passwword</tt>. If you want to avoid putting sensitive
 information into your project.clj file as in the <tt>releases</tt>
 entry above, you can store authentication information in
 <tt>~/.lein/init.clj</tt> as a <tt>leiningen-auth</tt> map keyed off

--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -50,7 +50,7 @@
 
 (defn add-repo-auth
   "Repository credentials (a map containing some of
-   #{:username :password :passphrase :private-key-file}) are discovered
+   #{:username :password :password :private-key-file}) are discovered
    from:
 
    1. Looking up the repository URL in the [:auth :repository-auth]

--- a/src/leiningen/deploy.clj
+++ b/src/leiningen/deploy.clj
@@ -27,7 +27,7 @@ to avoid checking sensitive information into source control:
    :auth {:repository-auth {#\"https://internal.repo/.*\"
                             {:username \"milgrim\" :password \"locative\"}
                             \"s3://s3-repo-bucket/releases\"
-                            {:username \"AKIAIN...\" :passphrase \"1TChrGK4s...\"}}}"
+                            {:username \"AKIAIN...\" :password \"1TChrGK4s...\"}}}"
   ([project repository-name]
      (let [jarfile (jar/jar project)
            pomfile (pom/pom project)


### PR DESCRIPTION
I tried to deploy an artifact to a private Archiva repo today, but it kept giving a 401 error. I sniffed the wire and saw that the basic auth being sent was "username:" with no password. I changed the keyword :passphrase in my profile's auth map to :password, and then I did indeed see "username:password" being sent in the basic auth, and the deploy succeeded. I have to guess that Maven wants "password" as the key not "passphrase".

This patch changes the documentation to instruct using :password instead of :passphrase in the auth map.
