### PR TITLE
Use newnew plugin 0.2.8 with the directory structure fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[leiningen-core "2.0.0-SNAPSHOT"]
                  [clucy "0.2.3"]
-                 [lein-newnew "0.2.7"]
+                 [lein-newnew "0.2.8"]
                  [reply "0.1.0-beta5"]
                  [org.clojure/data.xml "0.0.3"]
                  [bultitude "0.1.5"]


### PR DESCRIPTION
Bump `lein-newnew` to 0.2.8 to get [this fix](https://github.com/Raynes/lein-newnew/pull/26) in.
