### PR TITLE
Decouple init-project from l.c.project/read

### DIFF
--- a/leiningen-core/src/leiningen/core/main.clj
+++ b/leiningen-core/src/leiningen/core/main.clj
@@ -125,7 +125,8 @@ or by executing \"lein upgrade\". ")
   "Run a task or comma-separated list of tasks."
   [& args]
   (user/init)
-  (let [project (if (.exists (io/file "project.clj")) (project/read))]
+  (let [project (if (.exists (io/file "project.clj"))
+                  (project/init-project (project/read)))]
     (when (:min-lein-version project)
       (verify-min-version project))
     (when-let [{:keys [host port]} (classpath/get-proxy-settings)]

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -204,7 +204,7 @@
     (require (symbol m-ns)))
   ((resolve middleware-name) project))
 
-(defn- init-project
+(defn init-project
   "Initializes a project: loads plugins, hooks, applies middleware,
    adds dependencies to Leiningen's classpath if required (i.e. eval-in-leiningen),
    etc.  Any profiles should have already been merged into the project."
@@ -221,11 +221,10 @@
   [project profiles-to-apply]
   (let [merged (reduce merge-profile project
                        (profiles-for project profiles-to-apply))]
-    (init-project
-      (vary-meta (normalize merged) merge
-        {:without-profiles (normalize (:without-profiles (meta project) project))
-         :included-profiles (concat (:included-profiles (meta project))
-                                    profiles-to-apply)}))))
+    (vary-meta (normalize merged) merge
+               {:without-profiles (normalize (:without-profiles (meta project) project))
+                :included-profiles (concat (:included-profiles (meta project))
+                                           profiles-to-apply)})))
 
 (defn conj-dependency
   "Add a dependency into the project map if it's not already present. Warn the

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -90,9 +90,10 @@
   (assoc project :seven 7))
 
 (deftest test-middleware
-  (is (= 7 (:seven (read (.getFile (io/resource "p2.clj")))))))
+  (is (= 7 (:seven (init-project (read (.getFile (io/resource "p2.clj"))))))))
 
 (deftest test-init-project
   (is (= 7 (:seven (-> (.getFile (io/resource "p3.clj"))
                      read
-                     (merge-profiles [:middler]))))))
+                     (merge-profiles [:middler])
+                     init-project)))))

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -14,7 +14,8 @@
 
 (defn- read-test-project [name]
   (with-redefs [user/profiles (constantly {})]
-    (project/read (format "test_projects/%s/project.clj" name))))
+    (project/init-project
+     (project/read (format "test_projects/%s/project.clj" name)))))
 
 (def sample-project (read-test-project "sample"))
 


### PR DESCRIPTION
Reading a project should be side affect free. init-project modifies the current
classloader (and possible installs a new context classloader), so should not be
part of leiningen.core.project/read.
