### PR TITLE
Add fallback for LEIN_HOME environment variable

### DIFF
--- a/leiningen-core/src/leiningen/core/user.clj
+++ b/leiningen-core/src/leiningen/core/user.clj
@@ -5,7 +5,10 @@
 (defn leiningen-home
   "Return full path to the user's Leiningen home directory."
   []
-  (.getAbsolutePath (doto (io/file (System/getenv "LEIN_HOME")) .mkdirs)))
+  (let [lein-home (System/getenv "LEIN_HOME")
+        lein-home (or (and lein-home (io/file lein-home))
+                      (io/file (System/getProperty "user.home") ".lein"))]
+    (.getAbsolutePath (doto lein-home .mkdirs))))
 
 (def init
   "Load the user's ~/.lein/init.clj file, if present."


### PR DESCRIPTION
When using leiningen-core outside of lein, LEIN_HOME, which is set be the lein shell wrapper,
is not set. Fall back to using the system property for user.home to calculate the lein
home directory
