### PR TITLE
1.x

### DIFF
--- a/bin/lein-pkg
+++ b/bin/lein-pkg
@@ -3,6 +3,11 @@
 # This variant of the lein script is meant for downstream packagers.
 # It has all the cross-platform stuff stripped out as well as the
 # logic for running from checkouts and self-upgrading.
+#
+# Note to packagers:
+# rlwrap is now required unless running inside Emacs or in a dumb
+# terminal (this is to improve the 'lein repl' experience).
+# Make sure that your packaging pulls in rlwrap as a dependency
 
 export LEIN_VERSION="1.7.1"
 
@@ -103,10 +108,7 @@ fi
 
 # Use rlwrap if appropriate
 if ([ -z $INSIDE_EMACS ] && [ "$TERM" != "dumb" ]); then
-    which rlwrap > /dev/null
-    if [ $? -eq 0 ]; then
-        RLWRAP="rlwrap -r -m -q '\"'" # custom quote chars
-    fi
+    RLWRAP="rlwrap -r -m -q '\"'" # custom quote chars
     RLWRAP_CLJ_WORDS_FILE=${RLWRAP_CLJ_WORDS_FILE:-"${HOME}/.clj_completions"}
     RLWRAP_CLJ_WORDS_OPTION=""
     if [ -r "${RLWRAP_CLJ_WORDS_FILE}" ]; then


### PR DESCRIPTION
- make rlwrap detection silent
- if rlwrap is not found, skip all the RLWRAP customization; the command-line
  arguments meant for rlwrap result in an invalid invocation
