### PR TITLE
Fix #31: Exclude RSA signature files from being included in uberjars.

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -33,7 +33,7 @@
                               ;; TODO: point to releases-only before 2.0 is out
                               "clojars" {:url "https://clojars.org/repo/"})
                :jar-exclusions [#"^\."]
-               :uberjar-exclusions [#"(?i)^META-INF/[^/]*\.SF$"]})
+               :uberjar-exclusions [#"(?i)^META-INF/[^/]*\.(SF|RSA)$"]})
 
 (defmacro defproject
   "The project.clj file must either def a project map or call this macro."


### PR DESCRIPTION
This problem occurs with Jetty (via ring) as well, because Jetty recently moved to the Eclipse Foundation and they are now signing the JAR files.

Here is a minimal test-case to reproduce -

``` clojure

;; project.clj
(defproject leintest "0.1.0-SNAPSHOT"
  :description "FIXME: write description"
  ;; this fixes the problem
  ;; :uberjar-exclusions [#"(?i)^META-INF/[^/]*\.(SF|RSA)$"]
  :dependencies [[org.clojure/clojure "1.4.0"]
                 ;; bringing in [ring/ring-jetty-adapter "1.1.0"] works as well
                 [org.eclipse.jetty/jetty-server "8.1.4.v20120524"]]
  :main leintest.core)

;; src/leintest/core.clj
(ns leintest.core
  (:gen-class)
  (:import org.eclipse.jetty.server.Server))

(defn -main
  [& args]
  (println "Hello, world!"))
```

I have issued a pull request that augments the previous regexp to exclude .RSA files as well. We might need to keep changing the regexp in the future as and when we discover more file-types.
