### PR TITLE
cache gpg credentials, be okay with asking for a passphrase

### DIFF
--- a/leiningen-core/src/leiningen/core/user.clj
+++ b/leiningen-core/src/leiningen/core/user.clj
@@ -26,12 +26,12 @@
     (if (.exists profiles-file)
       (read-string (slurp profiles-file)))))
 
-(defn credentials
+(defn credentials-fn
   ([] (let [cred-file (io/file (leiningen-home) "credentials.clj.gpg")]
         (when (.exists cred-file)
-         (credentials cred-file))))
+         (credentials-fn cred-file))))
   ([file]
-     (let [{:keys [out err exit]} (try (shell/sh "gpg" "--batch" "--quiet"
+     (let [{:keys [out err exit]} (try (shell/sh "gpg" "--quiet"
                                                  "--decrypt" (str file))
                                        (catch java.io.IOException e
                                          {:exit 1 :err (.getMessage e)}))]
@@ -40,3 +40,5 @@
            (println "Could not decrypt credentials from" (str file))
            (println err))
          (read-string out)))))
+
+(def credentials (memoize credentials-fn))


### PR DESCRIPTION
Memoizes the credentials method, also removes the `--batch` operation, so people can be prompted to enter their passphrase (once, since it's memoized).

Example in action:

```
∴ lein deploy clojars                                                           

You need a passphrase to unlock the secret key for
user: "Matthew Lee Hinman <lee@writequit.org>"
4096-bit RSA key, ID CC42E614, created 2012-05-22 (main key ID 3ACECAE0)

Created /Users/hinmanm/src/clj/itsy/target/itsy-0.1.0-SNAPSHOT.jar
Wrote /Users/hinmanm/src/clj/itsy/pom.xml
Retrieving itsy/itsy/0.1.0-SNAPSHOT/maven-metadata.xml (1k)
    from https://clojars.org/repo/
Sending itsy/itsy/0.1.0-SNAPSHOT/itsy-0.1.0-20120531.212210-3.jar (7k)
    to https://clojars.org/repo/
Sending itsy/itsy/0.1.0-SNAPSHOT/itsy-0.1.0-20120531.212210-3.pom (3k)
    to https://clojars.org/repo/
Retrieving itsy/itsy/maven-metadata.xml (1k)from https://clojars.org/repo/
Sending itsy/itsy/0.1.0-SNAPSHOT/maven-metadata.xml (1k)
    to https://clojars.org/repo/
Sending itsy/itsy/maven-metadata.xml (1k)to https://clojars.org/repo/
lein deploy clojars  17.31s user 0.96s system 74% cpu 24.413 total
```
