### PR TITLE
Register certificates before calling get-classpath.  Fixes #613

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -89,6 +89,7 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
     mkdir -p "$LEIN_DIR/target/classes"
     export LEIN_JVM_OPTS=${LEIN_JVM_OPTS:-"-Dclojure.compile.path=$LEIN_DIR/target/classes"}
     CLASSPATH="$LEIN_DIR/leiningen-core/src/"
+    CLASSPATH="$CLASSPATH:$LEIN_DIR/leiningen-core/resources/"
     CLASSPATH="$CLASSPATH:$(cat $LEIN_DIR/.lein-classpath 2> /dev/null)"
     CLASSPATH="$CLASSPATH:$LEIN_DIR/leiningen-core/lib/*"
     CLASSPATH="$CLASSPATH:$LEIN_DIR/test:$LEIN_DIR/target/classes"

--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -39,7 +39,7 @@ if exist "%~dp0..\src\leiningen" (
 
     if "x!LEIN_LIBS!" == "x" goto NO_DEPENDENCIES
 
-    set CLASSPATH=!LEIN_LIBS!!LEIN_ROOT!\leiningen-core\src;!LEIN_ROOT!\leiningen-core\test;!LEIN_ROOT!\src;!LEIN_ROOT!\resources
+    set CLASSPATH=!LEIN_LIBS!!LEIN_ROOT!\leiningen-core\src;!LEIN_ROOT!\leiningen-core\resources;!LEIN_ROOT!\leiningen-core\test;!LEIN_ROOT!\src;!LEIN_ROOT!\resources
 
     :: Apply context specific CLASSPATH entries
     if exist "%~dp0..\.lein-classpath" (

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -225,12 +225,12 @@
   "Initializes a project: loads plugins and hooks.
    Adds dependencies to Leiningen's classpath if required."
   [project]
-  (when (= :leiningen (:eval-in project))
-    (doseq [path (classpath/get-classpath project)]
-      (pomegranate/add-classpath path)))
   (let [certs (mapcat ssl/read-certs (:certificates project))
         context (ssl/make-sslcontext (into (ssl/default-trusted-certs) certs))]
     (ssl/register-scheme (ssl/https-scheme context)))
+  (when (= :leiningen (:eval-in project))
+    (doseq [path (classpath/get-classpath project)]
+      (pomegranate/add-classpath path)))
   (load-plugins project)
   (load-hooks project)
   project)


### PR DESCRIPTION
We need to do this as get-classpath can itself trigger the downloading
of dependencies.  This also ensures leiningen-core/resources is added to
the classpath by the wrapper scripts.
