### PR TITLE
Fix for Issue #589: lein 2 leaves 'stale' directories all over the place

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -55,7 +55,7 @@
                       (str/join "+" (map name keys)))
         current-value (pr-str (map (juxt identity project) keys))
         old-value (and (.exists file) (slurp file))]
-    (when (and (:target-path project) (not= current-value old-value))
+    (when (and (:name project) (:target-path project) (not= current-value old-value))
       (apply f args)
       (.mkdirs (.getParentFile file))
       (spit file (doall current-value)))))


### PR DESCRIPTION
when macro checks whether it's a project or not with the :name key. It's not included in the project map by default.
