### PR TITLE
leiningen passes through nonProxyHosts to pomegranate

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -89,7 +89,8 @@
       {:host (.getHost url)
        :port (.getPort url)
        :username username
-       :password password})))
+       :password password
+       :non-proxy-hosts (System/getenv "http_nonProxyHosts")})))
 
 (defn- update-policies [update checksum [repo-name opts]]
   [repo-name (merge {:update (or update :daily)


### PR DESCRIPTION
To fix issue #700. May want to consider if having a environmental property is the best way of passing non-proxy-hosts into lein. Tested behind a proxy and it works OK.

I did notice that the function get-signature in deps.clj also uses the pomegranate api, but no proxy info is passed on. This would be trivial to fix but I don't know what this code does and whether or not there's an issue.
