### PR TITLE
^:append as a meta directive for profile key merging

### DIFF
--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -62,12 +62,12 @@ lists/vectors are concatenated. You can add hints via metadata that a
 given value should take precedence (`:replace`), defer to values
 from a different profile (`:displace`) if you want to override this
 logic, or append a collection of values to afore specified property
-(`:reverse`) as opposed to them being prepended by default:
+(`:append`) as opposed to them being prepended by default:
 
 ```clj
 {:profiles {:dev {:prep-tasks ^:replace ["clean" "compile"]
                   :aliases ^:displace {"launch" "run"}
-                  :aot ^:reverse [test.test1, test.test2]}}}
+                  :aot ^:append [test.test1, test.test2]}}}
 ```
 
 The exception to this merge logic is that plugins and dependencies

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -176,7 +176,7 @@
         (and (set? result) (set? latter))
         (set/union latter result)
 
-        (and (-> latter meta :reverse) (coll? result) (coll? latter))
+        (and (-> latter meta :append) (coll? result) (coll? latter))
         (concat result latter)
 
         (and (coll? result) (coll? latter))


### PR DESCRIPTION
I added the ^:append property as a directive for merging profile same-key/value pairs by appending, rather than prepending.
