### PR TITLE
Propogates the file.encoding system property to subprocesses

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -99,6 +99,7 @@
       ~@(:jvm-opts project)
       ~@(map d-property {:clojure.compile.path (:compile-path project)
                          (str (:name project) ".version") (:version project)
+                         :file.encoding (or (System/getProperty "file.encoding") "UTF-8")
                          :clojure.debug (boolean (or (System/getenv "DEBUG")
                                                      (:debug project)))})
       ~@(if (and native-arch-path (.exists native-arch-path))

--- a/leiningen-core/test/leiningen/core/test/eval.clj
+++ b/leiningen-core/test/leiningen/core/test/eval.clj
@@ -28,6 +28,11 @@
          (get-jvm-opts-from-env (str "-Dhello=\"guten tag\" "
                                      "-XX:+HeapDumpOnOutOfMemoryError")))))
 
+(deftest test-file-encoding-in-jvm-args
+  (is (contains? 
+          (set (#'leiningen.core.eval/get-jvm-args project))
+          (str "-Dfile.encoding=" (System/getProperty "file.encoding")))))
+
 (deftest test-get-jvm-args-with-proxy-settings
   ;; Mock get-proxy-settings to return test values
   (with-redefs [classpath/get-proxy-settings


### PR DESCRIPTION
On a coworker's Mac, the default file encoding was apparently
MacRoman. The -Dfile.encoding=UTF-8 that's in the lein shell script
wasn't being propogated to subprocesses which caused rage and the
replacement character.
