### PR TITLE
Allow override of gpg executable using LEIN_GPG

### DIFF
--- a/leiningen-core/src/leiningen/core/user.clj
+++ b/leiningen-core/src/leiningen/core/user.clj
@@ -31,14 +31,21 @@
          (println "Error reading profiles.clj from" (leiningen-home))
          (println (.getMessage e)))))
 
+(defn gpg-program
+  "Lookup the gpg program to use, defaulting to 'gpg'"
+  []
+  (or (System/getenv "LEIN_GPG") "gpg"))
+
 (defn credentials-fn
   "Decrypt map from credentials.clj.gpg in Leiningen home if present."
   ([] (let [cred-file (io/file (leiningen-home) "credentials.clj.gpg")]
         (if (.exists cred-file)
           (credentials-fn cred-file))))
   ([file]
-     (let [{:keys [out err exit]} (try (shell/sh "gpg" "--batch" "--quiet"
-                                                 "--decrypt" (str file))
+     (let [{:keys [out err exit]} (try (shell/sh
+                                        (gpg-program)
+                                        "--quiet" "--batch"
+                                        "--decrypt" (str file))
                                        (catch java.io.IOException e
                                          {:exit 1 :err (.getMessage e)}))]
        (if (pos? exit)

--- a/src/leiningen/deploy.clj
+++ b/src/leiningen/deploy.clj
@@ -4,6 +4,7 @@
             [leiningen.core.classpath :as classpath]
             [leiningen.core.main :as main]
             [leiningen.core.eval :as eval]
+            [leiningen.core.user :as user]
             [clojure.java.io :as io]
             [leiningen.pom :as pom]
             [leiningen.jar :as jar]))
@@ -41,7 +42,7 @@
 
 (defn sign [file]
   (let [exit (binding [*out* (java.io.StringWriter.)]
-               (eval/sh "gpg" "--yes" "-ab" file))]
+               (eval/sh (user/gpg-program) "--yes" "-ab" file))]
     (when-not (zero? exit)
       (main/abort "Could not sign" file))
     (str file ".asc")))

--- a/src/leiningen/deps.clj
+++ b/src/leiningen/deps.clj
@@ -3,6 +3,7 @@
   (:require [leiningen.core.classpath :as classpath]
             [leiningen.core.main :as main]
             [leiningen.core.eval :as eval]
+            [leiningen.core.user :as user]
             [cemerick.pomegranate.aether :as aether]
             [clojure.pprint :as pp]
             [clojure.java.io :as io])
@@ -25,7 +26,7 @@
 (defn- fetch-key [signature err]
   (if (re-find #"Can't check signature: public key not found" err)
     (let [key (second (re-find #"using \w+ key ID (.+)" err))
-          exit (eval/sh "gpg" "--recv-keys" key)]
+          exit (eval/sh (user/gpg-program) "--recv-keys" key)]
       (if (zero? exit)
         (check-signature signature)
         :no-key))
@@ -35,7 +36,7 @@
   (let [err (java.io.StringWriter.)
         out (java.io.StringWriter.)
         exit (binding [*err* (java.io.PrintWriter. err), *out* out]
-               (eval/sh "gpg" "--verify" (str signature)))]
+               (eval/sh (user/gpg-program) "--verify" (str signature)))]
     (if (zero? exit)
       :signed ; TODO distinguish between signed and trusted
       (fetch-key signature (str err)))))


### PR DESCRIPTION
On some platforms, eg. Mac, it may be more desirable to use an executable
other than 'gpg' for signing and encryption, and it may not be possible to
symlink to
'gpg'. This allows the gpg executable used in lein to be specified via
LEIN_GPG.

You can use ~/.lein/leinrc or ~/.leinrc to set LEIN_GPG by adding
'export LEIN_GPG=your-gpg' to either of those files.
