### PR TITLE
REPL plugin should clean up after itself

### DIFF
--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -56,6 +56,7 @@
                port# (-> server# deref :ss .getLocalPort)]
            (println "nREPL server started on port" port#)
            (spit ~(str (io/file (:target-path project) "repl-port")) port#)
+           (.deleteOnExit (io/file ~(:target-path project) "repl-port"))
            @(promise))]
     (if project
       (eval/eval-in-project


### PR DESCRIPTION
When launching `lein repl` standalone outside of a project, the plugin should remove the `repl-port` file when the server is shutdown.

I've started working on a patch for this.  At first glance, it appears any cleanup code in `repl.clj` will be subverted because `reply`'s exit causes the bottom to fall out of `lein` as well.  The only thing I can think of atm is adding a VM shutdown hook, but that seems dirty and hackish.  Ideally, there would be some way for `reply` to hand control back to `lein`.  Thoughts?
