### PR TITLE
Update leiningen-core/src/leiningen/core/project.clj

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -260,7 +260,7 @@
   (if-let [pr (:plugin-repositories project)]
     (if (:omit-default-repositories project)
       (assoc project :repositories pr)
-      (update-in project [:repositories] merge pr))
+      (update-in project [:repositories] concat pr))
     project))
 
 (defn load-plugins


### PR DESCRIPTION
use concat instead of merge to merge values, :plugin-repositories and :repositories are lists again 

with merge you will end up with a value for :repositories like [[repo {:url url}]([pluginrepo {:url url}])]
instead of [[repo {:url url}] [pluginrepo {:url url}]]
