### PR TITLE
pass local-repo to install

### DIFF
--- a/src/leiningen/install.clj
+++ b/src/leiningen/install.clj
@@ -12,9 +12,11 @@
   "Install current project to the local repository."
   ([project]
      (let [jarfile (jar/jar project)
-           pomfile (pom/pom project)]
+           pomfile (pom/pom project)
+           local-repo (:local-repo project)]
        (aether/install :coordinates [(symbol (:group project)
                                              (:name project))
                                      (:version project)]
                        :jar-file (io/file jarfile)
-                       :pom-file (io/file pomfile)))))
+                       :pom-file (io/file pomfile)
+                       :local-repo local-repo))))


### PR DESCRIPTION
Currently install always installs to ~/.m2 even if local-repo is present
