### PR TITLE
fix typo in lein script

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -177,7 +177,7 @@ if [ "$1" = "self-install" ]; then
         mv -f "$LEIN_JAR.pending" "$LEIN_JAR"
     else
         rm "$LEIN_JAR.pending" 2> /dev/null
-        downoad_failed_message "$LEIN_URL"
+        download_failed_message "$LEIN_URL"
         if [ $SNAPSHOT = "YES" ]; then
             echo "See README.md for SNAPSHOT-specific build instructions."
         fi


### PR DESCRIPTION
This is branched off the preview branch.

We ran into a problem on one of our build machines that caused lein to try to invoke the "downoad_failed_message" function, but the function is actually named "download_failed_message".
