### PR TITLE
Add default REPL history file locations, per-project and globally

### DIFF
--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -87,7 +87,13 @@
     (Integer. p)))
 
 (defn options-for-reply [project & {:keys [attach port]}]
-  (let [repl-options (:repl-options project)]
+  (let [history-file (if (:root project)
+                       ;; we are in project
+                       "./.lein-repl-history"
+                       ;; outside of project
+                       (str (io/file (user/leiningen-home) "repl-history")))
+        repl-options (merge {:history-file history-file}
+                            (:repl-options project))]
     (clojure.set/rename-keys
       (merge
         repl-options


### PR DESCRIPTION
When lein repl is launched in a directory with project.clj ("in project"), the
location is ./.lein-repl-history.

When lein repl is running in a directory without project.clj ("globally"), the
location is ~/.lein/repl-history.

Fixes #751
