### PR TITLE
Reworked classpath setup: bin/lein

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -136,16 +136,8 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
     else
         add_path CLASSPATH "$LEIN_DIR/leiningen-core/lib/*"
     fi
-
-    if [ -f .lein-classpath ]; then
-        add_path CLASSPATH "$(cat .lein-classpath)"
-    fi
 else # Not running from a checkout
     add_path CLASSPATH "$LEIN_JAR"
-    # apply context specific CLASSPATH entries
-    if [ -f .lein-classpath ]; then
-        add_path CLASSPATH "$LEIN_JAR" "$(cat .lein-classpath)"
-    fi
 
     export LEIN_JVM_OPTS=${LEIN_JVM_OPTS:-"-Xbootclasspath/a:$LEIN_JAR"}
 
@@ -256,6 +248,11 @@ else
     if [ "$OSTYPE" = "cygwin" ]; then
         # When running on Cygwin, use Windows-style paths for java
         ORIGINAL_PWD=`cygpath -w "$ORIGINAL_PWD"`
+    fi
+
+    # apply context specific CLASSPATH entries
+    if [ -f .lein-classpath ]; then
+        add_path CLASSPATH "$(cat .lein-classpath)"
     fi
 
     if [ $DEBUG ]; then


### PR DESCRIPTION
Currently the classpath on cygwin system's is broken when using checkouts, because .lein-classpath contains a native windows classpath but the classpath is transformed again before starting the Leiningen java process.

This results in broken classpath and thus ClassNotFoundException:

```
juergen@shirley:~/clojure/leiningen → cygpath.exe -wp "$(cat .lein-classpath)"

F;F:\clojure\leiningen\leiningen-core\test;F;F:\cl.....
```

Currently the classpath is directly modified/setup in multiple places of the lein bash script. I created a cygwin/unix-portable bash function to setup the classpath.  

In my opinion, that makes the classpath-setup much more readable and maintainable. What do you think about it?
