### PR TITLE
Fix for dependency resolution conflict: sisu-inject-plexus 1.4.3 vs. 2.2.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  [org.apache.maven.indexer/indexer-core "4.1.3"
                   :exclusions [org.apache.maven/maven-model
                                org.sonatype.aether/aether-api
-                               org.sonatype.aether/aether-util]]
+                               org.sonatype.aether/aether-util
+                               org.sonatype.sisu/sisu-inject-plexus]]
                  [reply "0.1.0-beta11" :exclusions [ring/ring-core]]
                  [clj-http "0.4.2"]]
   ;; checkout-deps don't work with :eval-in :leiningen


### PR DESCRIPTION
Fixes:

Recalculating Leiningen's classpath.
Failing dependency resolution because
[org.apache.maven.indexer/indexer-core "4.1.3" :exclusions [[org.apache.maven/maven-model] [org.sonatype.aether/aether-api] [org.sonatype.aether/aether-util]]] -> [org.sonatype.sisu/sisu-inject-plexus "1.4.3"]
is overrulling
[leiningen-core "2.0.0-SNAPSHOT"] -> [com.cemerick/pomegranate "0.0.13" :exclusions [[org.slf4j/slf4j-api]]] -> [org.sonatype.aether/aether-connector-wagon "1.13.1"] -> [org.sonatype.sisu/sisu-inject-plexus "2.2.3"]
Please use [org.apache.maven.indexer/indexer-core "4.1.3" :exclusions [[org.apache.maven/maven-model] [org.sonatype.aether/aether-api] [org.sonatype.aether/aether-util]] :exclusions [org.sonatype.sisu/sisu-inject-plexus]] to get [org.sonatype.sisu/sisu-inject-plexus "2.2.3"] or use [leiningen-core "2.0.0-SNAPSHOT" :exclusions [org.sonatype.sisu/sisu-inject-plexus]] to get [org.sonatype.sisu/sisu-inject-plexus "1.4.3"].Failing dependency resolution because
[org.apache.maven.indexer/indexer-core "4.1.3" :exclusions [[org.apache.maven/maven-model] [org.sonatype.aether/aether-api] [org.sonatype.aether/aether-util]]] -> [org.sonatype.sisu/sisu-inject-plexus "1.4.3"] -> [org.codehaus.plexus/plexus-utils "2.0.5"]
is overrulling
[leiningen-core "2.0.0-SNAPSHOT"] -> [com.cemerick/pomegranate "0.0.13" :exclusions [[org.slf4j/slf4j-api]]] -> [org.sonatype.aether/aether-connector-wagon "1.13.1"] -> [org.codehaus.plexus/plexus-utils "2.0.7"]
Please use [org.apache.maven.indexer/indexer-core "4.1.3" :exclusions [[org.apache.maven/maven-model] [org.sonatype.aether/aether-api] [org.sonatype.aether/aether-util]] :exclusions [org.codehaus.plexus/plexus-utils]] to get [org.codehaus.plexus/plexus-utils "2.0.7"] or use [leiningen-core "2.0.0-SNAPSHOT" :exclusions [org.codehaus.plexus/plexus-utils]] to get [org.codehaus.plexus/plexus-utils "2.0.5"].Failing dependency resolution because
[org.apache.maven.indexer/indexer-core "4.1.3" :exclusions [[org.apache.maven/maven-model] [org.sonatype.aether/aether-api] [org.sonatype.aether/aether-util]]] -> [org.sonatype.sisu/sisu-inject-plexus "1.4.3"] -> [org.codehaus.plexus/plexus-classworlds "2.2.3"]
is overrulling
[leiningen-core "2.0.0-SNAPSHOT"] -> [com.cemerick/pomegranate "0.0.13" :exclusions [[org.slf4j/slf4j-api]]] -> [org.sonatype.aether/aether-connector-wagon "1.13.1"] -> [org.codehaus.plexus/plexus-classworlds "2.4"]
Please use [org.apache.maven.indexer/indexer-core "4.1.3" :exclusions [[org.apache.maven/maven-model] [org.sonatype.aether/aether-api] [org.sonatype.aether/aether-util]] :exclusions [org.codehaus.plexus/plexus-classworlds]] to get [org.codehaus.plexus/plexus-classworlds "2.4"] or use [leiningen-core "2.0.0-SNAPSHOT" :exclusions [org.codehaus.plexus/plexus-classworlds]] to get [org.codehaus.plexus/plexus-classworlds "2.2.3"].
