### PR TITLE
Include namespace metadata in test-selector predicates, fixes #242

### DIFF
--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -15,7 +15,8 @@
      (leiningen.core.injected/add-hook
       (resolve 'clojure.test/test-var)
       (fn test-var-with-selector [test-var# var#]
-        (when (reduce #(or %1 (%2 (assoc (meta var#) ::var var#)))
+        (when (reduce #(or %1 (%2 (merge (-> var# meta :ns meta)
+                                         (assoc (meta var#) ::var var#))))
                       false ~selectors)
           (test-var# var#))))))
 

--- a/test/leiningen/test/test.clj
+++ b/test/leiningen/test/test.clj
@@ -10,12 +10,11 @@
                 (f)
                 (.delete (java.io.File. tmp-dir "lein-test-ran"))))
 
-(defn ran? [& expected]
+(defn ran? []
   (let [ran-file (io/file tmp-dir "lein-test-ran")]
     (and (.exists ran-file)
-         (= (set expected)
-            (set (for [ran (.split (slurp ran-file) "\n")]
-                   (read-string ran)))))))
+         (set (for [ran (.split (slurp ran-file) "\n")]
+                (read-string ran))))))
 
 (deftest test-project-selectors
   (is (= [:default :integration :int2 :no-custom]
@@ -24,16 +23,20 @@
 
 (deftest test-default-selector
   (test sample-no-aot-project ":default")
-  (is (ran? :regular :int2 :not-custom)))
+  (is (= (ran?) #{:regular :int2 :not-custom})))
 
 (deftest test-basic-selector
   (test sample-no-aot-project ":integration")
-  (is (ran? :integration)))
+  (is (= (ran?) #{:integration :integration-ns})))
 
 (deftest test-complex-selector
   (test sample-no-aot-project ":no-custom")
-  (is (ran? :integration :regular :int2)))
+  (is (= (ran?) #{:integration :integration-ns :regular :int2})))
 
 (deftest test-two-selectors
   (test sample-no-aot-project ":integration" ":int2")
-  (is (ran? :integration :int2)))
+  (is (= (ran?) #{:integration :integration-ns :int2})))
+
+(deftest test-override-namespace-selector
+  (test sample-no-aot-project ":int2")
+  (is (= (ran?) #{:integration-ns :int2})))

--- a/test_projects/sample_no_aot/test/namespace.clj
+++ b/test_projects/sample_no_aot/test/namespace.clj
@@ -1,0 +1,11 @@
+(ns ^:integration namespace
+  (:use [clojure.test]
+        [selectors :only [record-ran]]))
+
+(deftest integration-test
+  (record-ran :integration-ns)
+  (is true))
+
+(deftest ^:int2 int2-integration-test
+  (record-ran :integration-ns)
+  (is true))


### PR DESCRIPTION
More specific metadata wins, e.g. deftest trumps its namespace.

Also tweaked the tests a bit so that actual/expected results are now
shown in the output.
