### PR TITLE
Support subtask specific help via 'lein help task subtask'

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -79,6 +79,9 @@ that all your arguments will be strings, so it's up to you to call
 Often more complicated tasks get divided up into subtasks. Placing
 `:subtasks` metadata on a task defn which contains a vector of subtask
 vars will allow `lein help $TASK_CONTAINING_SUBTASKS` to list them.
+This list of subtasks will show the first line of the docstring for each
+subtask. The full help for a subtask can be viewed via 
+`lein help $TASK_CONTAINING_SUBTASKS $SUBTASK`. 
 
 ## Code Evaluation
 

--- a/test/leiningen/test/help.clj
+++ b/test/leiningen/test/help.clj
@@ -20,6 +20,11 @@
     (is (re-find #"template\s+A meta-template for 'lein new' templates."
                  subtask-help))))
 
+(deftest subtask-help-for-new-default
+  (let [subtask-help (help-for-subtask "new" "default")]
+    (is (re-find #"^A general project template." subtask-help))
+    (is (re-find #"Arguments: \(\[name\]\)" subtask-help))))
+
 (deftest test-docstring-formatting
   (is (= "This is an
               AWESOME command


### PR DESCRIPTION
The help task will first look for static help under 'leiningen/help/task-subtask', then for a function name 'help-subtask' in the subtask's namespace, then a docstring on the subtask function. For the latter two options, the arglists are also printed.
