### PR TITLE
protecting parameters against contained spaces

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -32,8 +32,8 @@ done
 export LEIN_HOME=${LEIN_HOME:-"$HOME/.lein"}
 
 for f in "$LEIN_HOME/leinrc" ".leinrc"; do
-  if [ -e $f ]; then
-    source $f
+  if [ -e "$f" ]; then
+    source "$f"
   fi
 done
 


### PR DESCRIPTION
if the path to the leiningen jar contains spaces, the script 
will not be able to load leiningen

this change fixes this behavior
