### PR TITLE
Finish getting path quoting right for boot classpath #828

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -55,7 +55,7 @@ do
     fi
 done
 
-export LEIN_HOME=${LEIN_HOME:-"$HOME/.lein"}
+export LEIN_HOME="${LEIN_HOME:-"$HOME/.lein"}"
 
 for f in "$LEIN_HOME/leinrc" ".leinrc"; do
   if [ -e "$f" ]; then
@@ -139,9 +139,7 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
 else # Not running from a checkout
     add_path CLASSPATH "$LEIN_JAR"
 
-    # TODO: unify setting this; it's a complete mess. Should be able
-    # to easily modify jvm opts without losing bootclasspath
-    export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-"-Xbootclasspath/a:$LEIN_JAR"}"
+    BOOTCLASSPATH="-Xbootclasspath/a:$LEIN_JAR"
 
     if [ ! -r "$LEIN_JAR" -a "$1" != "self-install" ]; then
         "$0" self-install
@@ -190,7 +188,7 @@ if [ "$1" = "self-install" ]; then
       exit 1
     fi
     echo "Downloading Leiningen to $LEIN_JAR now..."
-    mkdir -p $(dirname "$LEIN_JAR")
+    mkdir -p "$(dirname "$LEIN_JAR")"
     LEIN_URL="https://github.com/downloads/technomancy/leiningen/leiningen-$LEIN_VERSION-standalone.jar"
     $HTTP_CLIENT "$LEIN_JAR.pending" "$LEIN_URL"
     if [ $? == 0 ]; then
@@ -285,6 +283,7 @@ else
         export TRAMPOLINE_FILE
         "$LEIN_JAVA_CMD" \
             -client -XX:+TieredCompilation \
+            "${BOOTCLASSPATH[@]}" \
             $LEIN_JVM_OPTS \
             -Dfile.encoding=UTF-8 \
             -Dmaven.wagon.http.ssl.easy=false \


### PR DESCRIPTION
This appears to work. I tried running bin/lein within a normal checkout and a tweaked lein with LEIN_VERSION=2.0.0-preview10. Using the tweaked lein, I could run with HOME set to paths containing spaces and other scary characters: &#;.

I grabbed a leiningen checkout into a directory path containing a space, and ran "bin/lein test". Three tests failed, which appeared to be problems with turning file paths into URLs and back and getting %20 instead of the space character. I doubt those failures were caused by bin/lein (and suspect they are not important, but didn't really look that hard).
