### PR TITLE
Test :provided profile interpretation by the uberjar task

### DIFF
--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -27,6 +27,8 @@
 
 (def native-project (read-test-project "native"))
 
+(def provided-project (read-test-project "provided"))
+
 (def overlapped-sourcepaths-project (read-test-project "overlapped-sourcepaths"))
 
 ;; grumble, grumble; why didn't this make it into clojure.java.io?

--- a/test/leiningen/test/uberjar.clj
+++ b/test/leiningen/test/uberjar.clj
@@ -1,7 +1,8 @@
 (ns leiningen.test.uberjar
   (:use [leiningen.uberjar] :reload)
   (:use [clojure.test]
-        [leiningen.test.helper :only [sample-no-aot-project]])
+        [clojure.java.shell :only [sh]]
+        [leiningen.test.helper :only [sample-no-aot-project provided-project]])
   (:import [java.util.zip ZipFile]))
 
 (deftest test-uberjar
@@ -15,3 +16,10 @@
     (is (entries "nom/nom/nom.clj"))
     (is (entries "org/codehaus/janino/Compiler$1.class"))
     (is (not (some #(re-find #"dummy" %) entries)))))
+
+(deftest test-uberjar-provided
+  (let [-Xbootclasspath "-Xbootclasspath/a:leiningen-core/lib/clojure-1.4.0.jar"
+        filename "test_projects/provided/target/provided-0-standalone.jar"
+        _ (uberjar provided-project)]
+    (is (= 1 (:exit (sh "java" "-jar" filename))))
+    (is (= 0 (:exit (sh "java" -Xbootclasspath "-jar" filename))))))

--- a/test_projects/provided/project.clj
+++ b/test_projects/provided/project.clj
@@ -1,0 +1,7 @@
+(defproject provided "0"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies []
+  :java-source-paths ["src"]
+  :main provided.core.Example
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.4.0"]]}})

--- a/test_projects/provided/src/provided/core/Example.java
+++ b/test_projects/provided/src/provided/core/Example.java
@@ -1,0 +1,14 @@
+package provided.core;
+
+import clojure.lang.RT;
+
+public class Example {
+
+public static void
+main(String... args) {
+    System.exit(
+        RT.intCast(
+            RT.var("clojure.core", "read-string").invoke("0")));
+}
+
+}


### PR DESCRIPTION
As promised, a test-case for the "provided" dependency behavior of the `:provided` profile.
