### PR TITLE
Bug fix for leading spaces in JVM_OPTS #856

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -98,7 +98,8 @@
 
 (defn ^:internal get-jvm-opts-from-env [env-opts]
   (and (seq env-opts)
-       (reduce join-broken-arg [] (.split env-opts " "))))
+       (reduce join-broken-arg []
+               (.split (string/trim env-opts) " "))))
 
 (defn- get-jvm-args
   "Calculate command-line arguments for launching java subprocess."


### PR DESCRIPTION
just trim the whole string before trying to deal with it.
