### PR TITLE
Add add-profile task, which adds profiles to the default

### DIFF
--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -1,3 +1,4 @@
+<!-- TODO update for with-profile +/- syntax -->
 # Profiles
 
 In Leiningen 2.x you can change the configuration of your project by


### PR DESCRIPTION
add-profile works similarly to with-profile, but automatically adds the default profile
if it is not specified.

Fixes #661.
