### PR TITLE
Allow :scm to be set by a parent directory

### DIFF
--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -1,3 +1,4 @@
+<!-- TODO update for with-profile +/- syntax -->
 # Profiles
 
 In Leiningen 2.x you can change the configuration of your project by


### PR DESCRIPTION
A pattern that I've seen in many Leiningen library/plugin projects is to have the library live in a top-level repository, and the plugin live in a sub-repository. This causes an issue with the new Clojars, since the plugin doesn't have the `:scm` metadata properly set. See https://github.com/dgrnbrg/guzheng or https://github.com/ztellman/sleight for example projects using this convention.

I propose that there should be a way to specify that the repository is in another directory. Since this pattern always has the repository in a parent (or grandparent) directory, there could be an option in project.clj called `:scm-in-parent-dir?` which, when true, would cause Leiningen to search up the directory tree until it found a repository that contained project.clj, and then it would use that as the repo.
