### PR TITLE
export $SCRIPT as leiningen.script

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -289,6 +289,7 @@ else
             -Dfile.encoding=UTF-8 \
             -Dmaven.wagon.http.ssl.easy=false \
             -Dleiningen.original.pwd="$ORIGINAL_PWD" \
+            -Dleiningen.script="$SCRIPT" \
             -classpath "$CLASSPATH" \
             clojure.main -m leiningen.core.main "$@"
 


### PR DESCRIPTION
Apologies, I've never made a PR for modifying the bash script, I'm not sure what the process is. 

This exposes the path where lein started to the clojure code. That's useful in lein2 version of lein-daemon (https://github.com/arohner/lein-daemon/tree/lein2), because it calls lein again, as a background process, to fork.  
