### PR TITLE
Add :java-opts as an alias for :jvm-opts

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -161,7 +161,9 @@
          :resource-paths empty-paths
          :test-paths empty-paths}
         (-> (merge defaults project)
-            (dissoc :eval-in-leiningen :omit-default-repositories)
+            (assoc :jvm-opts (or (:jvm-opts project) (:java-opts project)
+                                 (:jvm-opts defaults)))
+            (dissoc :eval-in-leiningen :omit-default-repositories :java-opts)
             (assoc :eval-in (or (:eval-in project)
                                 (if (:eval-in-leiningen project)
                                   :leiningen, :subprocess))

--- a/sample.project.clj
+++ b/sample.project.clj
@@ -248,6 +248,7 @@
              ;; symbol values will be resolved to find a function to call.
              "Grunge-level" my.plugin/calculate-grunginess}
   ;; You can set JVM-level options here.
+  ;; It is also possible to use :java-opts, which is an alias for :jvm-opts.
   :jvm-opts ["-Xmx1g"]
   ;; Control the context in which your project code is evaluated.
   ;; Defaults to :subprocess, but can also be :leiningen (for plugins)


### PR DESCRIPTION
Fixes issue #829 and allows `:java-opts` as an alias for  `:jvm-opts`. 

Also includes a comment within `sample.project.clj` to inform about this addition.

If both `:java-opts` and `:jvm-opts` exist within `project.clj`, then `:java-opts` will be discarded and `:jvm-opts` will be used.
