### PR TITLE
Fix for fix for #893

### DIFF
--- a/src/leiningen/trampoline.clj
+++ b/src/leiningen/trampoline.clj
@@ -10,7 +10,7 @@
 (def ^:dynamic *trampoline?* false)
 
 (defn- trampoline-file []
-  (System/getenv "TRAMPOLINE_FILE"))
+  (or (System/getenv "TRAMPOLINE_FILE") ".trampoline"))
 
 (defn- win-batch? []
   (.endsWith (trampoline-file) ".bat"))


### PR DESCRIPTION
Required in order for lein trampoline repl to work. I did this rather brutally and blindly, so I'm not sure if this is the right fix, but it works for me.

Without this patch, I get:

```
java.lang.NullPointerException
    at clojure.lang.Reflector.invokeInstanceMethod(Reflector.java:26)
    at leiningen.trampoline$win_batch_QMARK_.invoke(trampoline.clj:16)
    at leiningen.trampoline$trampoline_command_string.invoke(trampoline.clj:30)
    at leiningen.trampoline$write_trampoline.invoke(trampoline.clj:37)
    at leiningen.trampoline$trampoline.doInvoke(trampoline.clj:61)
    at clojure.lang.RestFn.invoke(RestFn.java:442)
```

Another workaround is to make sure I always have TRAMPOLINE_FILE set in my env, but I don't really want to have to do that in every shell I might want to run lein trampoline repl from.
