### PR TITLE
Disable snapshots from maven central

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -127,7 +127,7 @@
 
 (def default-repositories
   (with-meta
-    [["central" {:url "http://repo1.maven.org/maven2/"}]
+    [["central" {:url "http://repo1.maven.org/maven2/" :snapshots false}]
      ["clojars" {:url "https://clojars.org/repo/"}]]
     {:reduce add-repo}))
 


### PR DESCRIPTION
Maven central was being checked for snapshots (unless special cased in aether).
