### PR TITLE
Hooked clojure.test report function should pass invocation through to original fn

### DIFF
--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -69,7 +69,8 @@
                                    first meta :ns ns-name)))
                       (if (= :begin-test-ns (:type m#))
                         (clojure.test/with-test-out
-                          (println "\nlein test" (ns-name (:ns m#))))
+                          (println "\nlein test" (ns-name (:ns m#)))
+                          (apply report# m# args#))
                         (apply report# m# args#))))
                 summary# (binding [clojure.test/*test-out* *out*]
                            (apply ~'clojure.test/run-tests selected-namespaces#))]

--- a/test/leiningen/test/test.clj
+++ b/test/leiningen/test/test.clj
@@ -44,3 +44,13 @@
 (deftest test-only-selector
   (test sample-no-aot-project ":only" "selectors/regular")
   (is (= (ran?) #{:regular})))
+
+(def called? (atom false))
+
+(defmethod clojure.test/report :begin-test-ns [_]
+  (reset! called? true))
+
+(deftest test-report-call-through
+  (is (true? @called?))
+  (reset! called? false))
+


### PR DESCRIPTION
Currently Leiningen is intercepting the call to report, not letting it pass through to the function it's hooking.  I have a custom report function that worked under lein 1 but never gets called in lein 2.  

Couldn't think of a great way to test it, other than just adding the multi-method and checking that it's being called.
