### PR TITLE
Add bin/lein-pkg to the list of files that get version substitutions.

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -5,7 +5,7 @@ set -e -u
 CURRENT_VERSION=$1
 RELEASE_VERSION=$2
 
-for f in bin/lein bin/lein.bat project.clj leiningen-core/project.clj; do
+for f in bin/lein bin/lein-pkg bin/lein.bat project.clj leiningen-core/project.clj; do
     sed -i s/$CURRENT_VERSION/$RELEASE_VERSION/ $f
 done
 


### PR DESCRIPTION
Currently lein-pkg is forgotten about, which means it is always pointing to
the 2.0.0-SNAPSHOT version. This means packagers much edit this file
themselves.
