### PR TITLE
Helpful new renderer error message

### DIFF
--- a/src/leiningen/new/templates.clj
+++ b/src/leiningen/new/templates.clj
@@ -24,11 +24,9 @@
   (last (string/split s #"/")))
 
 (defn slurp-resource
-  "Reads the contents of a file on the classpath."
-  [resource-path]
-  (if-let [res (io/resource resource-path)]
-    (-> res io/reader slurp)
-    (main/abort (format "Template resource '%s' not found." resource-path))))
+  "Reads the contents of a resource."
+  [resource]
+  (-> resource io/reader slurp))
 
 (defn sanitize
   "Replace hyphens with underscores."
@@ -93,9 +91,11 @@ The additional segment defaults to \"core\"."
   [name]
   (fn [template & [data]]
     (let [path (string/join "/" ["leiningen" "new" (sanitize name) template])]
-      (if data
-        (render-text (slurp-resource path) data)
-        (io/reader (io/resource path))))))
+      (if-let [resource (io/resource path)]
+        (if data
+          (render-text (slurp-resource resource) data)
+          (io/reader resource))
+        (main/abort (format "Template resource '%s' not found." path))))))
 
 ;; Our file-generating function, `->files` is very simple. We'd like
 ;; to keep it that way. Sometimes you need your file paths to be

--- a/test/leiningen/test/new/templates.clj
+++ b/test/leiningen/test/new/templates.clj
@@ -17,3 +17,15 @@
 (deftest paths
   (is (= (name-to-path "foo-bar.baz") "foo_bar/baz")))
 
+(defn- abort-msg [f & args]
+  (with-out-str
+    (binding [*err* *out*]
+      (try
+        (apply f args)
+        (catch clojure.lang.ExceptionInfo e)))))
+
+(deftest renderers
+  (is (= (abort-msg (renderer "my-template") "boom" {})
+         "Template resource 'leiningen/new/my_template/boom' not found.\n"))
+  (is (= (abort-msg (renderer "my-template") "boom")
+         "Template resource 'leiningen/new/my_template/boom' not found.\n")))


### PR DESCRIPTION
Trying to make a renderer error case more helpful to the end user as discussed in Raynes/lein-newnew#61. I ended up changing #'slurp-resource to handle the abort message cleanly and in one place.
