### PR TITLE
Remove superfluous exclusion of slf4j

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -8,8 +8,7 @@
                  [classlojure "0.6.6"]
                  [useful "0.8.6"]
                  [robert/hooke "1.3.0"]
-                 [com.cemerick/pomegranate "0.0.13"
-                  :exclusions [org.slf4j/slf4j-api]]]
+                 [com.cemerick/pomegranate "0.0.13"]]
   :scm {:dir ".."}
   ;; This is only used when releasing Leiningen. Can't put it in a
   ;; profile since it must be installed using lein1


### PR DESCRIPTION
The dependencies for pomegranate were cleaned up as of pomegranate-0.0.8. We no longer need to exclude slf4j. (Hard to claim this is important; I just happened to notice that it was not needed.)
