### PR TITLE
Add LEIN_SUPPRESS_USER_LEVEL_REPO_WARNINGS

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -376,17 +376,18 @@
 
         :else (or profile {})))
 
-(defn- warn-user-repos []
-  (let [profiles (filter #(->> (val %)
+(defn- warn-user-repos [profiles]
+  (let [has-url? (fn [entry] (or (string? entry) (:url entry)))
+        profiles (filter #(->> (second %)
                                :repositories
-                               vals
-                               (some :url))
-                         (user/profiles))]
+                               (map second)
+                               (some has-url?))
+                         profiles)]
     (when (and (seq profiles)
                (not (System/getenv "LEIN_SUPPRESS_USER_LEVEL_REPO_WARNINGS")))
       (println
        "WARNING: :repositories detected in user-level profiles!"
-       (vec (map key profiles)))
+       (vec (map first profiles)))
       (println "See https://github.com/technomancy/leiningen/wiki/Repeatability"))))
 
 (alter-var-root #'warn-user-repos memoize)
@@ -409,7 +410,7 @@
   the profiles.clj file in the project root, and the :profiles key from the
   project map."
   [project]
-  (warn-user-repos)
+  (warn-user-repos (user/profiles))
   (warn-user-profile (:profiles project))
   (merge @default-profiles (user/profiles)
          (:profiles project) (project-profiles project)))

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -1,7 +1,7 @@
 (ns leiningen.core.test.project
   (:refer-clojure :exclude [read])
   (:use [clojure.test]
-        [leiningen.core.project])
+        [leiningen.core.project :as project])
   (:require [leiningen.core.user :as user]
             [leiningen.core.classpath :as classpath]
             [clojure.java.io :as io]))
@@ -393,3 +393,45 @@
                                [org.clojure/clojure "1.3.0" :classifier "sources"]
                                [org.clojure/clojure "1.3.0"]]})
              (:dependencies)))))
+
+(deftest test-warn-user-repos
+  (if (System/getenv "LEIN_SUPPRESS_USER_LEVEL_REPO_WARNINGS")
+    (testing "no output with suppression"
+      (is (= ""
+             (with-out-str
+               (#'project/warn-user-repos
+                {:user {:repositories
+                        {"central" {:url "http://repo1.maven.org/maven2/"
+                                    :snapshots false}
+                         "clojars" {:url "https://clojars.org/repo/"}}}})))))
+    (testing "with no suppression,"
+      (testing "no warning without user level repo"
+        (is (= "" (with-out-str (#'project/warn-user-repos {})))
+            "No warning in base case"))
+      (testing "Warning with user level repo"
+        (is (re-find
+             #"WARNING: :repositories .* [:user].*"
+             (with-out-str
+               (#'project/warn-user-repos
+                {:user {:repositories
+                        {"central" {:url "http://repo1.maven.org/maven2/"
+                                    :snapshots false}
+                         "clojars" {:url "https://clojars.org/repo/"}}}})))))
+      (testing "Warning with user level repo"
+        (is (re-find
+             #"WARNING: :repositories .* [:user].*"
+             (with-out-str
+               (#'project/warn-user-repos
+                {:user {:repositories
+                        {"central" "http://repo1.maven.org/maven2/"
+                         "clojars" "https://clojars.org/repo/"}}})))))
+      (testing "Warning with user level repo"
+        (is (re-find
+             #"WARNING: :repositories .* [:user].*"
+             (with-out-str
+               (#'project/warn-user-repos
+                {:user
+                 {:repositories
+                  [["central" {:url "http://repo1.maven.org/maven2/"
+                               :snapshots false}]
+                   ["clojars" {:url "https://clojars.org/repo/"}]]}}))))))))


### PR DESCRIPTION
Can be used to suppress warnings about repositories in user level profiles. 
Also adds the list of profiles containing :repositories when not suppressed.
