### PR TITLE
Simplify deploy by moving coordinate merging into aether

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -8,7 +8,7 @@
                  [classlojure "0.6.6"]
                  [useful "0.8.6"]
                  [robert/hooke "1.3.0"]
-                 [com.cemerick/pomegranate "0.0.13"]]
+                 [com.cemerick/pomegranate "0.0.14-SNAPSHOT"]]
   :scm {:dir ".."}
   ;; This is only used when releasing Leiningen. Can't put it in a
   ;; profile since it must be installed using lein1


### PR DESCRIPTION
Use the changes in https://github.com/cemerick/pomegranate/issues/52 to simplify the deploy task.
