### PR TITLE
upgrade to bultitude 0.2.1 to stop relying on bultitude private fn

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[leiningen-core "2.1.0-SNAPSHOT"]
                  [org.clojure/data.xml "0.0.3"]
-                 [bultitude "0.1.7"]
+                 [bultitude "0.2.1"]
                  [stencil "0.3.1"]
                  [org.apache.maven.indexer/indexer-core "4.1.3"
                   :exclusions [org.apache.maven/maven-model

--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -109,13 +109,9 @@
    '(fn [m & vars]
       (some #(= (str "#'" %) (-> m ::var str)) vars))])
 
-;; from bultitude's namespaces-in-dir
-(defn- ns-form-for-file [file]
-  (with-open [r (PushbackReader. (io/reader file))] (@#'b/read-ns-form r)))
-
 (defn- convert-to-ns [possible-file]
   (if (and (.endsWith possible-file ".clj") (.exists (io/file possible-file)))
-    (str (ns-form-for-file possible-file))
+    (str (b/ns-form-for-file possible-file))
     possible-file))
 
 (defn- read-args [args project]


### PR DESCRIPTION
The only other noticeable change bultitude has had is [upgrading dynapath](https://github.com/Raynes/bultitude/commit/2353b1f24cf359cd707015d7394e3fdec75c9363). All tests pass except 5 errors which is same as master. Side note, should `lein test` be returning an exit code of 0 when there are errors?
