### PR TITLE
document global options in help task, close #1005

### DIFF
--- a/src/leiningen/help.clj
+++ b/src/leiningen/help.clj
@@ -125,6 +125,11 @@ deploying, mixed-source, templates, and copying info."
      (doseq [task-ns (main/tasks)]
        (println (help-summary-for task-ns)))
      (println "\nRun `lein help $TASK` for details.")
+     (println "\nGlobal Options:")
+     (println "  -o             Run a task offline.")
+     (println "  -U             Run a task after forcing update of snapshots.")
+     (println "  -h, --help     Print this help.")
+     (println "  -v, --version  Print Leiningen's version.")
      (when-let [aliases (:aliases project)]
        (println "\nAliases:")
        (doseq [[k v] aliases]


### PR DESCRIPTION
Looks like this:

``` bash
$ lein help
...
Run `lein help $TASK` for details.

Global Options:
  -o             Run a task offline.
  -U             Run a task after forcing update of snapshots.
  -h, --help     Print this help.
  -v, --version  Print Leiningen's version.

See also: readme, faq, tutorial, news, sample, profiles, deploying, mixed-source, templates, and copying.
```
