### PR TITLE
Log classpath files at debug in get-classpath

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -227,4 +227,6 @@
                      (for [dep (resolve-dependencies :dependencies project)]
                        (.getAbsolutePath dep)))
         :when path]
-    (normalize-path (:root project) path)))
+    (let [normalized (normalize-path (:root project) path)]
+      (log/debug "classpath:" normalized)
+      normalized)))


### PR DESCRIPTION
Logging the classpath facilitates diagnosis of classpath issues.
