### PR TITLE
Force usage of newer dynapath until pomegranate updates.

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -4,11 +4,13 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Library for core functionality of Leiningen."
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [bultitude "0.1.7"]
+                 [bultitude "0.1.7" :exclusions [dynapath]]
                  [classlojure "0.6.6"]
                  [useful "0.8.6"]
                  [robert/hooke "1.3.0"]
-                 [com.cemerick/pomegranate "0.0.14-SNAPSHOT"]]
+                 [com.cemerick/pomegranate "0.0.14-SNAPSHOT" :exclusions [org.tcrawley/dynapath]]
+                 ;; depend on this directly until pomegranate upgrades
+                 [org.tcrawley/dynapath "0.2.3"]]
   ;; until the pomegratate snapshot is released:
   :repositories [["sonatype"
                   "https://oss.sonatype.org/content/repositories/snapshots/"]]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[leiningen-core "2.1.0-SNAPSHOT"]
                  [org.clojure/data.xml "0.0.3"]
-                 [bultitude "0.2.1"]
+                 [bultitude "0.2.1" :exclusions [dynapath]]
                  [stencil "0.3.1"]
                  [org.apache.maven.indexer/indexer-core "4.1.3"
                   :exclusions [org.apache.maven/maven-model


### PR DESCRIPTION
This fixes the issue causing the build failures. The root of it is
that dynapath was allowing pomegranate to modify the boot classloader,
which caused multiple copies of the same class to be loaded.
