### PR TITLE
minor fix to search: "group (aliased as g)"

### DIFF
--- a/src/leiningen/search.clj
+++ b/src/leiningen/search.clj
@@ -101,7 +101,7 @@
     "d"           MAVEN/DESCRIPTION
     "desc"        MAVEN/DESCRIPTION
     "description" MAVEN/DESCRIPTION
-    (throw (IllegalArgumentException. (format "search over the field %s is not supported; known fields: id, description (aliased as d), group (aliased as group)" s)))))
+    (throw (IllegalArgumentException. (format "search over the field %s is not supported; known fields: id, description (aliased as d), group (aliased as g)" s)))))
 
 (defn- split-query
   "Splits \"field:query\" into \"field\" and \"query\""


### PR DESCRIPTION
I botched a "lein search" and was surprised by the error message:

```
java.lang.IllegalArgumentException: search over the field classifier is not supported; known fields: id, description (aliased as d), group (aliased as group)
```

"group (aliased as group)" ... say what?

This commit changes the error message to point out the "g" alias.
