### PR TITLE
Report dependency resolving issues for unresolved artifacts instead for just missing artifacts.

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -106,7 +106,7 @@
 
 (defn- print-failures [e]
   (doseq [result (.getArtifactResults (.getResult e))
-          :when (.isMissing result)
+          :when (not (.isResolved result))
           exception (.getExceptions result)]
     (println (.getMessage exception)))
   (doseq [ex (.getCollectExceptions (.getResult e))


### PR DESCRIPTION
### Motivation

If a dependency artifact cannot be retrieved for a reason other than that it is missing, it is not reported by leiningen 2.0.0. This simple patch fixes this.
### To reproduce

In a new project having the dependency `[log4j "1.2.15"]`, a call to `lein deps` would fail. The dependency `[log4j "1.2.15"]` depends on `[com.sun.jmx/jmxri "1.2.1"]`, which cannot be retrieved. The POM is not missing though, so leiningen does not report this and only states it could not resolve the dependencies, i.e. without saying which dependency failed.
