### PR TITLE
Call setWriteable on file before trying to delete it

### DIFF
--- a/src/leiningen/clean.clj
+++ b/src/leiningen/clean.clj
@@ -21,11 +21,8 @@ Raise an exception if any deletion fails unless silently is true."
     (when (real-directory? f)
       (doseq [child (.listFiles f)]
         (delete-file-recursively child silently)))
-    (io/delete-file f silently)
-    ;; This sometimes helps release files for deletion on windows, but
-    ;; is slow as the dickens.
-    (when (= :windows (eval/get-os))
-      (System/gc))))
+    (.setWritable f true)
+    (io/delete-file f silently)))
 
 (defn clean
   "Remove all files from project's target-path."


### PR DESCRIPTION
Trying to fix https://github.com/technomancy/leiningen/issues/460 issue in windows.
Windows guys could you please check this?
