### PR TITLE
Added a default-key-manager function that emulates JSSE

### DIFF
--- a/leiningen-core/src/leiningen/core/ssl.clj
+++ b/leiningen-core/src/leiningen/core/ssl.clj
@@ -37,7 +37,6 @@
             pwd (when-not (= "" pass) (.toCharArray pass))
             store (if (= "" prov) (KeyStore/getInstance type) (KeyStore/getInstance type prov))
             kmf (KeyManagerFactory/getInstance (KeyManagerFactory/getDefaultAlgorithm))]
-        (println (str "key manager properties: " props))
         (.load store fis pwd)
         (when fis (.close fis))
         (.init kmf store pwd)


### PR DESCRIPTION
Reads javax.net.ssl.keyStore\* properties and uses them to create a KeyManagerFactory which is used by make-sslcontext to create an SSLContext that can use keystores for reading client SSL certificates.
