### PR TITLE
Update to bultitude 0.2.2 across the board.

### DIFF
--- a/leiningen-core/pom.xml
+++ b/leiningen-core/pom.xml
@@ -46,18 +46,12 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.1</version>
     </dependency>
     <dependency>
       <groupId>bultitude</groupId>
       <artifactId>bultitude</artifactId>
-      <version>0.1.7</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>dynapath</artifactId>
-          <groupId>dynapath</groupId>
-        </exclusion>
-      </exclusions>
+      <version>0.2.2</version>
     </dependency>
     <dependency>
       <groupId>classlojure</groupId>
@@ -89,6 +83,11 @@
       <groupId>org.tcrawley</groupId>
       <artifactId>dynapath</artifactId>
       <version>0.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.wagon</groupId>
+      <artifactId>wagon-http</artifactId>
+      <version>2.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -4,7 +4,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Library for core functionality of Leiningen."
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [bultitude "0.2.1" :exclusions [dynapath]]
+                 [bultitude "0.2.2"]
                  [classlojure "0.6.6"]
                  [useful "0.8.6"]
                  [robert/hooke "1.3.0"]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[leiningen-core "2.1.0-SNAPSHOT"]
                  [org.clojure/data.xml "0.0.3"]
-                 [bultitude "0.2.1" :exclusions [dynapath]]
+                 [bultitude "0.2.2"]
                  [stencil "0.3.1"]
                  [org.apache.maven.indexer/indexer-core "4.1.3"
                   :exclusions [org.apache.maven/maven-model


### PR DESCRIPTION
This eliminates the need to exclude dynapath, since pomegranate and
bultitude now use the same version. This also updates core's pom.xml
with other recent version updates.
