### PR TITLE
#949 Allow specification of artifact signing key.

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -160,6 +160,9 @@
                               ;; If a repository contains releases only setting
                               ;; :snapshots to false will speed up dependencies.
                               :snapshots false
+                              ;; Disable signing releases for this repo.
+                              ;; (Not recommended.)
+                              :sign-releases false
                               ;; You can also set the policies for how to handle
                               ;; :checksum failures to :fail, :warn, or :ignore.
                               :checksum :fail
@@ -191,7 +194,15 @@
   ;; the deploy task will give preference to repositories specified in
   ;; :deploy-repositories, and repos listed there will not be used for
   ;; dependency resolution.
-  :deploy-repositories [["releases" "http://blueant.com/archiva/internal/releases"]
+  :deploy-repositories [["releases" {:url "http://blueant.com/archiva/internal/releases"
+                                     ;; Select a GPG private key to use for
+                                     ;; signing. (See "How to specify a user
+                                     ;; ID" in GPG's manual.) GPG will
+                                     ;; otherwise pick the first private key
+                                     ;; it finds in your keyring.
+                                     ;; Currently only works in :deploy-repositories
+                                     ;; or as a top-level (global) setting.
+                                     :signing {:gpg-key "0xAB123456"}}]
                         ["snapshots" "http://blueant.com/archiva/internal/snapshots"]]
   ;; Fetch dependencies from mirrors. Mirrors override repositories when the key
   ;; in the :mirrors map matches either the name or URL of a specified
@@ -201,6 +212,8 @@
             #"clojars" {:name "Internal nexus"
                         :url "http://mvn.local/nexus/releases"
                         :repo-manager true}}
+  ;; Defaults for signing options. Defers to per-repository settings.
+  :signing {:gpg-key "root@eruditorum.org"}
   ;; Prevent Leiningen from checking the network for dependencies.
   ;; This wouldn't normally be set in project.clj; it would come from a profile.
   :offline? true

--- a/test/leiningen/test/deploy.clj
+++ b/test/leiningen/test/deploy.clj
@@ -42,3 +42,21 @@
                         {"snapshots" {:url (-> "deploy-only-repo"
                                                repo-path repo-url)}})
                       "deploy-only-repo")))
+
+(deftest signing
+  (testing "GPG invocation"
+    (is (= (signing-args "foo.jar" nil)
+           ["--yes" "-ab" "--" "foo.jar"]))
+    (is (= (signing-args "foo.jar" {:gpg-key "123456"})
+           ["--yes" "-ab" "--default-key" "123456" "--" "foo.jar"])))
+  (testing "Key selection"
+    (is (= (:gpg-key (signing-opts {:signing {:gpg-key "key-project"}}
+                                   ["repo" {:signing {:gpg-key "key-repo"}}]))
+           "key-repo"))
+    (is (= (:gpg-key (signing-opts {:signing {:gpg-key "key-project"}}
+                                   ["repo" {}]))
+           "key-project")))
+  (testing "Whether to sign"
+    (is (= (sign-for-repo? ["foo" {:sign-releases true}]) true))
+    (is (= (sign-for-repo? ["foo" {:sign-releases false}]) false))
+    (is (= (sign-for-repo? ["foo" {}]) true))))


### PR DESCRIPTION
Add :signing {:gpg-key "..."} option to project maps (global value)
and to :deploy-repositories maps (per-repo value). Does not yet work
in :repositories specs.

Also:
- Document per-repo :sign-releases option
- Delete unused defn deploy/signature-for
