### PR TITLE
Support higher-order tasks and aliases that use trampolines in lein.bat

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -223,26 +223,18 @@ goto EOF
 :: characters inside the TRAMPOLINE_FILE.
 setLocal DisableDelayedExpansion
 
-if "%1" == "trampoline" (goto RUN_TRAMPOLINE) else (goto RUN_NORMAL)
-
-:RUN_TRAMPOLINE
 set "TRAMPOLINE_FILE=%TEMP%\lein-trampoline-%RANDOM%.bat"
+del "%TRAMPOLINE_FILE%" 2>nul
+
 "%LEIN_JAVA_CMD%" -client %LEIN_JVM_OPTS% ^
  -Dclojure.compile.path="%DIR_CONTAINING%/target/classes" ^
  -Dleiningen.original.pwd="%ORIGINAL_PWD%" ^
- -Dleiningen.trampoline-file="%TRAMPOLINE_FILE%" ^
- -cp "%CLASSPATH%" clojure.main -e "(use 'leiningen.core.main)(apply -main (map str '(%*)))"
+ -cp "%CLASSPATH%" clojure.main -m leiningen.core.main %*
 
 if not exist "%TRAMPOLINE_FILE%" goto EOF
 call "%TRAMPOLINE_FILE%"
 del "%TRAMPOLINE_FILE%"
 goto EOF
-
-:RUN_NORMAL
-"%LEIN_JAVA_CMD%" -client %LEIN_JVM_OPTS% ^
- -Dclojure.compile.path="%DIR_CONTAINING%/target/classes" ^
- -Dleiningen.original.pwd="%ORIGINAL_PWD%" ^
- -cp "%CLASSPATH%" clojure.main -m leiningen.core.main %*
 
 :EOF
 


### PR DESCRIPTION
lein.bat had a separate code path for commands that started `lein trampoline ...`
I have removed this and made all cases set `TRAMPOLINE_FILE`, so that things like this alias work:

``` clojure
{"dumbrepl" ["trampoline" "run" "-m" "clojure.main"]}
```

Also tweaked the handling of double quotes for `JAVA_CMD`, they were getting doubled in my last patch (though this didn't seem to break anything).
