### PR TITLE
Changed installation path recommendation in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ upon the first run on unix, so the first run will take longer.
 
 1. Make sure you have JDK 6 or later.
 2. [Download the script](https://raw.github.com/technomancy/leiningen/stable/bin/lein).
-3. Place it on your `$PATH`. (I like to use `~/bin`)
-4. Set it to be executable. (`chmod 755 ~/bin/lein`)
+3. Place it on your `$PATH`. (Copying to `/usr/local/bin` should work)
+4. Set it to be executable. (`chmod 755 /usr/local/bin/lein`)
 
 There is still a lot of extant material on the Web concerning the
 older


### PR DESCRIPTION
I'm running a Clojure workshop. Several people new to the language are not particularly unix savvy. They have been confused by the ~/bin suggestion. I have changed the suggestion to instead point to /usr/local/bin. This directory is more likely to already be in someone's path. Hopefully this will save some users some confusion.
