### PR TITLE
Fix for incorrect escaping of parameters on Windows

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -174,13 +174,12 @@ leiningen.core.utils/platform-nullsink instead."
             (.resurrect System/in))
           exit-value)))))
 
-;; work around java's command line handling on windows
-;; http://bit.ly/9c6biv This isn't perfect, but works for what's
-;; currently being passed; see http://www.perlmonks.org/?node_id=300286
-;; for some of the landmines involved in doing it properly
 (defn- form-string [form eval-in]
   (if (and (= (get-os) :windows) (not= :trampoline eval-in))
-    (let [s (pr-str (pr-str form))] (subs s 1 (dec (.length s))))
+    ;; On windows if a parameter is in double quotes, then all we need
+    ;; to worry about are double quotes, which we must escape by
+    ;; doubling them.
+    (string/replace (pr-str form) "\"" "\"\"")
     (pr-str form)))
 
 (defn- classpath-arg [project]


### PR DESCRIPTION
fixes #863 - exception when running lein check

The issues regarding the escaping of `>`, `<`, `^`, `|`, `&`, etc with `^`'s don't apply inside double-quoted strings.  All we need inside a double-quoted string is to escape `"` by doubling them, ie: `""`.

This patch assumes that `form` isn't a string literal, eg `"hello"`, else we'd end up with extra quotes, but I think that is a safe assumption - nobody will need to eval a string literal.
