### PR TITLE
Fix for Issue #1095

### DIFF
--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -213,6 +213,6 @@ Subcommands:
                     (trampoline-repl project port)
                     (let [port (server project false)]
                       (client project host port)))
-         ":headless" (server project host port true)
+         ":headless" (start-server project nil true)
          ":connect" (client project host (or (first opts) port))
          (main/abort "Unknown subcommand")))))


### PR DESCRIPTION
For `:headless` I simply changed from calling `server` to directly calling `start-server`, which is the one that calls `eval-in-project`. This makes it work for `trampoline` as well.

Now that I've done it (and it seems to work), I wonder whether there is really any need to involve `eval/prep-blocker` and `nrepl.ack/wait-for-ack` (which is what `start-server` does) in any scenario.
- `eval-in-project` synchronously calls `prep` so there's no need to synchronize via promise;
- I'm not sure exactly in what scenario `wait-for-ack` is called for, but our case doesn't seem to need it.

It would be great if someone else could confirm this because it could mean a great reduction in the complexity of the `repl` task.
