### PR TITLE
Allow ":" as root path for update-in

### DIFF
--- a/src/leiningen/update_in.clj
+++ b/src/leiningen/update_in.clj
@@ -22,5 +22,4 @@ task name and arguments to the task:
                                      [clojure.core/update-in project keys-vec f]
                                      [f project]))
                     (apply (map read-string update-args)))]
-    (println "Project map" project)
     (main/apply-task task-name project task-args)))


### PR DESCRIPTION
I've implemented accepting `:` as root path to `update-in`. We can discuss whether this is the way to go.
