### PR TITLE
Provide a default version for leiningen

### DIFF
--- a/leiningen-core/src/leiningen/core/main.clj
+++ b/leiningen-core/src/leiningen/core/main.clj
@@ -189,7 +189,13 @@
     (apply task project args)))
 
 (defn leiningen-version []
-  (or (System/getenv "LEIN_VERSION") "2.2.0-SNAPSHOT"))
+  (with-open [reader (-> "META-INF/maven/leiningen/leiningen/pom.properties"
+                         io/resource
+                         io/reader)]
+    (or (System/getenv "LEIN_VERSION")
+        (-> (doto (java.util.Properties.)
+              (.load reader))
+            (.getProperty "version")))))
 
 (defn ^:internal version-satisfies? [v1 v2]
   (let [v1 (map #(Integer. %) (re-seq #"\d+" (first (string/split v1 #"-" 2))))


### PR DESCRIPTION
For odd cases where leiningen is called without the wrapper shell script, any occurence of `:min-lein-version` will throw an exception since `leiningen-version` will return nil.

This fixes jenkinsci/leiningen-plugin#1 for instance.
I see two other ways to fix this:
- have the version be propagated from project.clj directly, through substitution
- let leiningen-version return a string that always passes or always fails (not sure which is best) the `:min-lein-version` requirement
