### PR TITLE
update tests template to :require from :use

### DIFF
--- a/resources/leiningen/new/default/test.clj
+++ b/resources/leiningen/new/default/test.clj
@@ -1,6 +1,6 @@
 (ns {{namespace}}-test
-  (:use clojure.test
-        {{namespace}}))
+  (:require [clojure.test :refer :all]
+            [{{namespace}} :refer :all]))
 
 (deftest a-test
   (testing "FIXME, I fail."


### PR DESCRIPTION
Little patch to update the default test template from the effectively deprecated (use) operation  to (require).
