### PR TITLE
fix for #1123: allow mirrors to get credentials from credentials.clj.gpg

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -142,7 +142,9 @@
                         (map add-repo-auth)
                         (map (partial update-policies update checksum)))
      :coordinates (get project dependencies-key)
-     :mirrors mirrors
+     :mirrors (->> mirrors
+                   (map add-repo-auth)
+                   (map (partial update-policies update checksum)))
      :transfer-listener
      (bound-fn [e]
        (let [{:keys [type resource error]} e]


### PR DESCRIPTION
This commit has been manually tested, but I wasn't able to get the included tests working on my system.
