### PR TITLE
Fixes issue 1144. 

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -268,7 +268,7 @@ else
 
     if ([ "$LEIN_FAST_TRAMPOLINE" != "" ] || [ -r .lein-fast-trampoline ]) &&
         [ -r project.clj ]; then
-        INPUTS="$@ $(cat project.clj) $LEIN_VERSION $(cat "$LEIN_HOME/profiles.clj")"
+        INPUTS="$@ $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj")"
         INPUT_CHECKSUM=$(echo $INPUTS | shasum - | cut -f 1 -d " ")
         # Just don't change :target-path in project.clj, mkay?
         TRAMPOLINE_FILE="target/trampolines/$INPUT_CHECKSUM"

--- a/bin/lein-pkg
+++ b/bin/lein-pkg
@@ -76,7 +76,7 @@ export JVM_OPTS="${JVM_OPTS:-"$JAVA_OPTS"}"
 
 if ([ "$LEIN_FAST_TRAMPOLINE" != "" ] || [ -r .lein-fast-trampoline ]) &&
     [ -r project.clj ]; then
-    INPUTS="$@ $(cat project.clj) $(cat "$LEIN_HOME/profiles.clj")"
+    INPUTS="$@ $(cat project.clj) $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj")"
     INPUT_CHECKSUM=$(echo $INPUTS | shasum - | cut -f 1 -d " ")
     # Just don't change :target-path in project.clj, mkay?
     TRAMPOLINE_FILE="target/trampolines/$INPUT_CHECKSUM"


### PR DESCRIPTION
The fast trampoline functionality now works properly in the absence of a `.lein/profiles.clj` file.
