### PR TITLE
Rename `hooks` to `activate` in hooks code sample

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -163,7 +163,7 @@ meant to apply to and a function to perform the wrapping:
 
 ;; Place the body of the activate function at the top-level for
 ;; compatibility with Leiningen 1.x
-(defn hooks []
+(defn activate []
   (robert.hooke/add-hook #'leiningen.test/form-for-testing-namespaces
                          add-test-var-println))
 ```


### PR DESCRIPTION
I'm not sure, if `hooks` was there on purpose, but if it was, it would need additional explainations.
