### PR TITLE
Add support for executable files to 'lein new' templates

### DIFF
--- a/src/leiningen/new/templates.clj
+++ b/src/leiningen/new/templates.clj
@@ -141,8 +141,11 @@ The additional segment defaults to \"core\"."
       (doseq [path paths]
         (if (string? path)
           (.mkdirs (template-path dir path data))
-          (let [[path content] path
-                path (template-path dir path data)]
+          (let [[path content & options] path
+                path (template-path dir path data)
+                options (apply hash-map options)]
             (.mkdirs (.getParentFile path))
-            (io/copy content (io/file path)))))
+            (io/copy content (io/file path))
+            (when (:executable options)
+              (.setExecutable path true)))))
       (println "Could not create directory " dir ". Maybe it already exists?"))))

--- a/test/leiningen/test/new/templates.clj
+++ b/test/leiningen/test/new/templates.clj
@@ -3,7 +3,8 @@
         leiningen.new.templates)
   (:require [leiningen.test.helper :refer [abort-msg]]
             [leiningen.core.user :as user]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io])
+  (:import [java.io File]))
 
 (defn- getenv [s]
   (System/getenv s))
@@ -63,3 +64,12 @@
   (is (= (slurp-resource "leiningen/new/template/temp.clj")
          (slurp-resource (io/resource "leiningen/new/template/temp.clj")))))
 
+
+(deftest files
+  (testing "that files marked as executable are set executable"
+    (let [file (File/createTempFile "lein" "template")
+          path [(.getName file) (.getAbsolutePath file) :executable true]]
+      (binding [*dir* (.getParentFile file)]
+        (.deleteOnExit file)
+        (->files {} path)
+        (is (.canExecute file))))))


### PR DESCRIPTION
Paths that are marked with the additional option `:executable true`
will be set executable when template files are rendered.

Fixes #976.
