### PR TITLE
[lein pom] Extra tests paths are never added to the maven source path

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -231,7 +231,7 @@
                 [:configuration
                  (vec (concat [:sources]
                               (map (fn [x] [:source x]) extra-src)))]])
-             (if (seq extra-src)
+             (if (seq extra-test)
                [:execution
                 [:id "add-test-source"]
                 [:phase "generate-test-sources"]


### PR DESCRIPTION
https://github.com/technomancy/leiningen/blob/master/src/leiningen/pom.clj#L234

Should of course say `(if (seq extra-test)` rather than `(if (seq extra-src))`.
