### PR TITLE
Better error message for require failures

### DIFF
--- a/src/leiningen/run.clj
+++ b/src/leiningen/run.clj
@@ -11,14 +11,11 @@
     (symbol (name given) "-main")))
 
 (defn run-form
-  "Construct a form to run the given main defn or class with arguments."
+  "Construct a form to run the given main defn with arguments."
   [given args]
   `(let [v# (resolve '~(normalize-main given))]
      (binding [*command-line-args* '~args]
-       (if (ifn? v#)
-         (v# ~@args)
-         (Reflector/invokeStaticMethod
-           ~(name given) "main" (into-array [(into-array String '~args)]))))))
+       (v# ~@args))))
 
 (defn- run-main
   "Loads the project namespaces as well as all its dependencies and then calls
@@ -26,9 +23,8 @@
   [project given & args]
   (try (eval/eval-in-project project (run-form given args)
                              ;; TODO: why are we using both init and resolve?
-                             `(try (require '~(symbol (namespace
-                                                       (normalize-main given))))
-                                   (catch FileNotFoundException _#)))
+                             ` (require '~(symbol (namespace
+                                                   (normalize-main given)))))
        (catch clojure.lang.ExceptionInfo e
          (main/abort))))
 

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -36,6 +36,8 @@
 
 (def more-gen-classes-project (read-test-project "more-gen-classes"))
 
+(def bad-require-project (read-test-project "bad-require"))
+
 (defn abort-msg
   "Catches main/abort thrown by calling f on its args and returns its error
  message."

--- a/test/leiningen/test/run.clj
+++ b/test/leiningen/test/run.clj
@@ -4,7 +4,9 @@
         [clojure.java.io :only [delete-file]]
         ;; [leiningen.javac :only [javac]]
         [leiningen.run]
-        [leiningen.test.helper :only [tmp-dir tricky-name-project]]))
+        [leiningen.test.helper :only [bad-require-project
+                                      tmp-dir
+                                      tricky-name-project]]))
 
 (def out-file (format "%s/lein-test" tmp-dir))
 
@@ -25,6 +27,18 @@
   (is (= "nom::bbb" (slurp out-file)))
   (run tricky-name-project "--" "-m")
   (is (= "nom:-m" (slurp out-file))))
+
+(deftest test-bad-require-error-msg
+  (let [sw (java.io.StringWriter.)]
+    (binding [*err* sw]
+      (try (run bad-require-project)
+           (catch clojure.lang.ExceptionInfo e nil)))
+    (let [e-msg (str sw)]
+      ;; Don't throw the old ClassNotFoundException
+      (is (not (re-find #"ClassNotFoundException: bad-require.core" e-msg)))
+      ;; Do show a relevant error message
+      (is (re-find #"FileNotFoundException" e-msg))
+      (is (re-find #"this/namespace/does/not/exist.clj" e-msg)))))
 
 ;; TODO: re-enable
 ;; (deftest test-run-java-main

--- a/test_projects/bad-require/.gitignore
+++ b/test_projects/bad-require/.gitignore
@@ -1,0 +1,12 @@
+/target
+/lib
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+.lein-deps-sum
+.lein-failures
+.lein-plugins
+.lein-repl-history

--- a/test_projects/bad-require/project.clj
+++ b/test_projects/bad-require/project.clj
@@ -1,0 +1,7 @@
+(defproject bad-require "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :main bad-require.core)

--- a/test_projects/bad-require/src/bad_require/core.clj
+++ b/test_projects/bad-require/src/bad_require/core.clj
@@ -1,0 +1,4 @@
+(ns bad-require.core
+  (:require [this.namespace.does.not.exist]))
+
+(defn -main [])


### PR DESCRIPTION
lein run tries to support invoking static methods on classes by
swallowing FileNotFoundExceptions when requiring the namespace to run,
which can obscure the real error when there's a real issue loading a
namespace.

Phil said he wasn't interested in keeping the (undocumented) feature
around, so the easiest fix to the error message problem was to remove
that feature.

Added a test as well.
