### PR TITLE
Add back support for java classes in :main

### DIFF
--- a/src/leiningen/run.clj
+++ b/src/leiningen/run.clj
@@ -61,7 +61,7 @@
         ;; If the class exists, run its main method.
         class#
         (Reflector/invokeStaticMethod
-         ~(name given) "main" (into-array [(into-array String '~args)]))
+         class# "main" (into-array [(into-array String '~args)]))
 
         ;; If the symbol didn't resolve, give a reasonable message
         (= :not-found ns-flag#)


### PR DESCRIPTION
This commit bends over backwards to add back support for java
classes in :main that was removed in 71e609c8a1. The crux of
the complexity was that when we try to require the namespace
relevant to the argument to `lein run`, we could get a
FileNotFoundException for two distinct reasons -- either the
namespace we were trying to run doesn't exist, in which case
we want to check if it was actually a class name; or the
namespace exists but it or some other dependency is trying
to require a namespace that doesn't exist. In the latter case
we definitely want the FileNotFoundException to propagate up
to the top. But distinguishing these two cases by examining
the exception is hacky at best, so the alternative adopted
here is to hold on to the exception, check if a class exists,
and if not, re-throw the exception.

This should handle the majority of use cases correctly. The
test added in 71e609c8a1 is still relevant and still passes.
