### PR TITLE
Fix for issue #1113: file paths with spaces passed incorrectly as javac arguments on Windows

### DIFF
--- a/src/leiningen/javac.clj
+++ b/src/leiningen/javac.clj
@@ -54,6 +54,9 @@
       (vec (map (comp name str) (flatten (concat specials others)))))
     opts))
 
+(defn- safe-quote [s]
+  (str "\"" (string/replace s "\\" "\\\\") "\""))
+
 ;; Tool's .run method expects the last argument to be an array of
 ;; strings, so that's what we'll return here.
 (defn- javac-options
@@ -64,9 +67,9 @@
     (.deleteOnExit options-file)
     (with-open [options-file (io/writer options-file)]
       (doto options-file
-        (.write (format "-cp %s\n" (classpath/get-classpath-string project)))
-        (.write (format "-d %s\n" (:compile-path project)))
-        (.write (string/join "\n" files))))
+        (.write (format "-cp %s\n" (safe-quote (classpath/get-classpath-string project))))
+        (.write (format "-d %s\n" (safe-quote (:compile-path project))))
+        (.write (string/join "\n" (map safe-quote files)))))
     (into-array String
                 (concat (normalize-javac-options (:javac-options project))
                         args


### PR DESCRIPTION
The bug is from a commit from Feb 6 which changes how the classpath is passed to javac as @argfiles parameter.

SHA-1: 3867d4d17ce7785e83db1b1f1e8dc67f5074d251

According to the [javac specification](http://docs.oracle.com/javase/6/docs/technotes/tools/windows/javac.html):

> An argument file can include javac options and source filenames in any combination. The arguments within a file can be space-separated or newline-separated. If a filename contains embedded spaces, put the whole filename in double quotes, and double each backslash ("My Files\\Stuff.java").
