### PR TITLE
Fix bug where manifest is missing its last line.

### DIFF
--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -28,14 +28,15 @@
         :else (str manifest "\n" (name k) ": " v)))
 
 (defn ^:internal make-manifest [project]
-  (Manifest.
-   (ByteArrayInputStream.
-    (.getBytes
-     (reduce (partial manifest-entry project)
-             "Manifest-Version: 1.0"
-             (merge default-manifest (:manifest project)
-                    (if-let [main (:main project)]
-                      {"Main-Class" (.replaceAll (str main) "-" "_")})))))))
+  (-> (reduce (partial manifest-entry project)
+              "Manifest-Version: 1.0"
+              (merge default-manifest (:manifest project)
+                     (if-let [main (:main project)]
+                       {"Main-Class" (.replaceAll (str main) "-" "_")})))
+      (str "\n")  ;; Add an endline character to make Manifest happy.
+      .getBytes
+      ByteArrayInputStream.
+      Manifest.))
 
 (defn ^:internal manifest-map [manifest]
   (let [attrs (.getMainAttributes manifest)]

--- a/test/leiningen/test/jar.clj
+++ b/test/leiningen/test/jar.clj
@@ -14,11 +14,13 @@
                    :manifest {"hello" "world"}})
 
 (deftest test-manifest
-  (is (= {"Main-Class" "foo.one_two.three_four.bar", "hello" "world"}
-         (-> mock-project
-             make-manifest
-             manifest-map
-             (select-keys ["hello" "Main-Class"])))))
+  (let [mm (-> mock-project
+               make-manifest
+               manifest-map)]
+    (is (= {"Main-Class" "foo.one_two.three_four.bar", "hello" "world"}
+           (select-keys mm ["hello" "Main-Class"])))
+    (is (= #{"Manifest-Version" "Main-Class" "hello" "Created-By" "Built-By" "Build-Jdk"}
+           (-> mm keys set)))))
 
 (deftest test-jar-fails
   (binding [*err* (java.io.PrintWriter. (platform-nullsink))]


### PR DESCRIPTION
Despite the [documentation on java.util.jar.Manifest](http://docs.oracle.com/javase/6/docs/technotes/guides/jar/jar.html), the Manifest class
seems to require an endline in its input. If not, it drops the last line (at least on my
system, version reported at the bottom).

This fixes bug https://github.com/technomancy/leiningen/issues/1195

$ java -version
java version "1.7.0_21"
OpenJDK Runtime Environment (IcedTea 2.3.9) (7u21-2.3.9-0ubuntu0.12.04.1)
OpenJDK 64-Bit Server VM (build 23.7-b01, mixed mode)
