### PR TITLE
Crash on :aot [does.not.exist]; also regression test; Fixes #1205

### DIFF
--- a/src/leiningen/compile.clj
+++ b/src/leiningen/compile.clj
@@ -36,8 +36,7 @@
   (for [namespace (compilable-namespaces project)
         :let [rel-source (b/path-for namespace)
               source (first (for [source-path (:source-paths project)
-                                  :let [file (io/file source-path rel-source)]
-                                  :when (.exists file)]
+                                  :let [file (io/file source-path rel-source)]]
                               file))]
         :when source
         :let [rel-compiled (.replaceFirst rel-source "\\.clj$" "__init.class")

--- a/test/leiningen/test/compile.clj
+++ b/test/leiningen/test/compile.clj
@@ -83,3 +83,13 @@
 
 ;; (deftest test-compile-java-main
 ;;   (compile dev-deps-project))
+
+
+(deftest bad-aot-test
+  (is (re-find #"does\.not\.exist|does\/not\/exist"
+               (with-out-str
+                 (binding [*err* *out*]
+                   (try
+                     (compile (assoc sample-project
+                                :aot '[does.not.exist]))
+                     (catch clojure.lang.ExceptionInfo _)))))))


### PR DESCRIPTION
Hoping somebody who's at least seen the `compile` code before can
glance at this to make sure it doesn't obviously break anything that
isn't tested.

Original commit msg:

> We want missing namespaces in :aot to not be silently ignored.
> Implemented by removing the file-existence check from the function
> that determines which namespaces need to be compiled.
> 
> This means we won't get the error if you compile an existing namespace
> and subsequently delete the *.clj file. Oh well.
