### PR TITLE
Fixed long line support in make-manifest.

### DIFF
--- a/test/leiningen/test/jar.clj
+++ b/test/leiningen/test/jar.clj
@@ -9,9 +9,13 @@
                                       overlapped-sourcepaths-project]])
   (:import (java.util.jar JarFile)))
 
+(def long-line
+  (apply str (repeat 10000 "a")))
+
 (def mock-project {:name "mock-project" :version "1.0"
                    :main 'foo.one-two.three-four.bar
-                   :manifest {"hello" "world"}})
+                   :manifest {"hello" "world"
+                              "long-line" long-line}})
 
 (deftest test-manifest
   (let [mm (-> mock-project
@@ -19,8 +23,10 @@
                manifest-map)]
     (is (= {"Main-Class" "foo.one_two.three_four.bar", "hello" "world"}
            (select-keys mm ["hello" "Main-Class"])))
-    (is (= #{"Manifest-Version" "Main-Class" "hello" "Created-By" "Built-By" "Build-Jdk"}
-           (-> mm keys set)))))
+    (is (= #{"Manifest-Version" "Main-Class" "hello" "Created-By" "Built-By"
+             "Build-Jdk" "long-line"}
+           (-> mm keys set)))
+    (is (= (get mm "long-line") long-line))))
 
 (deftest test-jar-fails
   (binding [*err* (java.io.PrintWriter. (platform-nullsink))]


### PR DESCRIPTION
Leiningen generates MANIFEST.MF files and then has the Manifest class read, parse, and re-write them. However, Leiningen generates invalid manifest files: it does not break lines the way it should. (The spec says no lines longer than 72 characters.)

This change fixes manifest generation to split long lines. It also adds a regression test which fails in unpatched leiningen.
