### PR TITLE
copy-to-jar :bytes needs to unix-path the :path

### DIFF
--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -91,13 +91,14 @@
             {:type :path :path path})))
 
 (defmethod copy-to-jar :bytes [project jar-os acc spec]
-  (when-not (some #(re-find % (:path spec)) (:jar-exclusions project))
-    (.putNextEntry jar-os (JarEntry. (:path spec)))
-    (let [bytes (if (string? (:bytes spec))
-                  (.getBytes (:bytes spec))
-                  (:bytes spec))]
-      (io/copy (ByteArrayInputStream. bytes) jar-os)))
-  (conj acc (:path spec)))
+  (let [path (unix-path (:path spec))]
+    (when-not (some #(re-find % path) (:jar-exclusions project))
+      (.putNextEntry jar-os (JarEntry. path))
+      (let [bytes (if (string? (:bytes spec))
+                    (.getBytes (:bytes spec))
+                    (:bytes spec))]
+        (io/copy (ByteArrayInputStream. bytes) jar-os)))
+    (conj acc path)))
 
 (defmethod copy-to-jar :fn [project jar-os acc spec]
   (let [f (eval (:fn spec))


### PR DESCRIPTION
All of the other copy-to-jar methods call unix-path on (:path spec),
thus ensuring that files added to the jar from a Windows machine end up
with Unix-style path names.  The byte array variant of copy-to-jar is
the one exception though and the result is that tools such as
lein-cljsbuild will leave Windows-style paths in jar files generated
with the "lein jar" command.
