### PR TITLE
Support for automatic activation of profiles via new `:active?` expression

### DIFF
--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -109,6 +109,46 @@ Multiple profiles may be executed in series with colons:
 
     $ lein with-profile 1.3:1.4 test :database
 
+You may also add/remove profiles from the active profile list by prefixing their
+names with `+` and `-` respectively. Refer to `lein help with-profile` for more
+details.
+
+
+## Activating Profiles Automatically
+
+You might want to activate some profiles implicitly based on certain
+conditions. In order to activate a profile implicitly, set the `:active?` key to a
+boolean expression.
+
+In the following example, profile `:sticky` gets always activated:
+
+```clj
+...
+    :profiles {:sticky {:active? true
+                        ... }
+```
+
+In the following example, lein activates the `:linux` profile only when it is running on Linux:
+
+```clj
+...
+    :profiles {:linux {:active? (= (System/getProperty "os.name") "Linux")
+                       :dependencies [[org.blah/linux-specific-dep "1.1.0"]] }
+```
+
+
+The value of keyword `:active?` may also be a predicate function receiving the
+lein project as its only argument:
+
+```clj
+...
+    :profiles {:non-gpl {:active? (fn [project]
+                                    (not (= (-> project :license :name) "GPL" )))
+                         :dependencies [[org.blah/impure-lib "2.0.0"]] }
+```
+
+You can override the implicit activation of a profile using `lein with-profile -profilename`. Refer to `lein help with-profile` for more details.
+
 ## Composite Profiles
 
 Sometimes it is useful to define a profile as a combination of other

--- a/leiningen-core/dev-resources/autoprofiles.clj
+++ b/leiningen-core/dev-resources/autoprofiles.clj
@@ -1,0 +1,24 @@
+(defproject autoprofiles "0.0.1"
+  :description "Test automatic activation of profiles via :active? expression"
+
+  :profiles {
+
+             :no_activation {:no_activation true }
+
+             :literal_false {:active? false
+                             :literal_false true }
+
+             :literal_true {:active? true
+                            :literal_true true }
+
+             :expression_true {:active? (< 1 2)
+                               :expression_true true }
+
+             :expression_false {:active? (> 1 2)
+                                :expression_false true }
+
+             :fn_false {:active? (fn [project] (not (= (:name project) "autoprofiles" ))  )
+                        :fn_false true }
+
+             :fn_true {:active? (fn [project] (= (:name project) "autoprofiles" )  )
+                       :fn_true true } } )

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -516,3 +516,22 @@
                 [["central" {:url "http://repo1.maven.org/maven2/"
                              :snapshots false}]
                  ["clojars" {:url "https://clojars.org/repo/"}]]}})))))))
+
+
+
+(deftest test-read-auto-profiles
+  (let [actual (read (.getFile (io/resource "autoprofiles.clj")))]
+
+    (testing "Profiles with truthy `:active?` expressions/functions must be active"
+      (is (:literal_true actual))
+      (is (:expression_true actual))
+      (is (:fn_true actual)))
+
+    (testing "Profiles with falsy or missing `:active?` expressions must not be active"
+      (is (not (:no_activation actual)))
+      (is (not (:literal_false actual)))
+      (is (not (:expression_false actual)))
+      (is (not (:fn_false actual))))
+
+    (testing "The `:active?` entry must NOT leak out of the profiles and into the project"
+      (is (nil? (:active? actual))))))


### PR DESCRIPTION
My immediate use-case for this feature is to be able to automatically activate different profiles depending on which OS lein is running.

I opted for a more general solution so that the user can use any activation predicate.

As for the syntax, I just picked one approach of may options. Instead of using :active? we could have used it as metadata ^{:active expr }, which is probably more "correct", but I thought it added quite a bit of noise to the project definition (specially for  non-Clojure experts)

I also added a pointer on PROFILES.md to the `with-profile` docs, because that page didn't say anything about prefixing profile names with `-`/`+`.

Thanks,
Fernando
