### PR TITLE
Update FAQ to add entry about long-term performance

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -92,6 +92,14 @@
 **A:** The wiki has a page covering
   [ways to improve startup time](https://github.com/technomancy/leiningen/wiki/Faster).
 
+**Q:** What if I care more about long-term performance than startup time?
+**A:** Leiningen 2.1.0 onward get a speed boost by disabling optimized
+  compilation (which only benefits long-running processes).  This can
+  negatively affect performance in the long run, or lead to inaccurate
+  benchmarking results.  If want the JVM to fully optimize, you can follow
+  the instructions on the Wiki page covering
+  [performance](https://github.com/technomancy/leiningen/wiki/Faster).
+
 **Q:** What does "Unrecognized VM option 'TieredStopAtLevel=1'" mean?  
 **A:** Old versions of the JVM do not support the directives Leiningen
   uses for tiered compilation which allow the JVM to boot more


### PR DESCRIPTION
As you mentioned, here's a pull request to add a FAQ entry about long-run performance.  I wasn't sure what you would want to say about JVM_OPTS in general, so I stuck to this simpler question for now.  If you don't think this is helpful and would like me to draft something about the general state of affairs with :jvm-opts and startup time instead, let me know.  

I also rearranged the Faster wiki page to make it clearer (in my option) -- hope this is OK.

https://github.com/technomancy/leiningen/wiki/Faster/_compare/5be4541a44146279e26ab4978843dea827fb036e...4fcec5ded3f44262e991f3110ea5a9a0139f11da

(Previously it jumped from 2.1 to enabling tiered compilation in 2.0 back to disabling it in 2.1 without being explicit about this -- I moved the part about disabling in 2.1 up next to the description of tiered compilation in 2.1).
