### PR TITLE
Keep init-file when using LEIN_FAST_TRAMPOLINE

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -197,8 +197,9 @@ leiningen.core.utils/platform-nullsink instead."
   "Calculate vector of strings needed to evaluate form in a project subprocess."
   [project form]
   (let [init-file (File/createTempFile "form-init" ".clj")]
-    (spit init-file (pr-str `(-> (java.io.File. ~(.getCanonicalPath init-file))
-                                 (.deleteOnExit))))
+    (if-not (System/getenv "LEIN_FAST_TRAMPOLINE")
+      (spit init-file (pr-str `(-> (java.io.File. ~(.getCanonicalPath init-file))
+                                   (.deleteOnExit)))))
     (spit init-file (pr-str form) :append true)
     `(~(or (:java-cmd project) (System/getenv "JAVA_CMD") "java")
       ~@(classpath-arg project)


### PR DESCRIPTION
Otherwise the memoized startup will fail because of the missing init-file:

```
→ lein trampoline test
Exception in thread "main" java.io.FileNotFoundException: /tmp/form-init5088991943718769025.clj (Datei oder Verzeichnis nicht gefunden)
```

Still an issue: The init-file will most likely be deleted on reboot.
