### PR TITLE
Fix NoClassDefFoundError when path has spaces

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -24,7 +24,7 @@ if "x%LEIN_HOME%" == "x" (
     set LEIN_HOME=!USERPROFILE!\.lein
 )
 
-if "x%LEIN_JAR%" == "x" set LEIN_JAR=!LEIN_HOME!\self-installs\leiningen-!LEIN_VERSION!-standalone.jar
+if "x%LEIN_JAR%" == "x" set "LEIN_JAR=!LEIN_HOME!\self-installs\leiningen-!LEIN_VERSION!-standalone.jar"
 
 if "%1" == "self-install" goto SELF_INSTALL
 if "%1" == "upgrade"      goto UPGRADE
@@ -110,7 +110,7 @@ rem the paths inside the bootstrap file do not already contain double quotes but
 ) else (
     :: Not running from a checkout.
     if not exist "%LEIN_JAR%" goto NO_LEIN_JAR
-    set CLASSPATH=%LEIN_JAR%
+    set CLASSPATH="%LEIN_JAR%"
   
     if exist ".lein-classpath" (
         for /f %%i in (.lein-classpath) do set CONTEXT_CP=%%i 


### PR DESCRIPTION
Fix NoClassDefFoundError when LEIN_HOME has spaces.

Related to issue #1238
