### PR TITLE
Issue #1272: Add two options :clean-compile-path? and :clean-native-path?

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -266,9 +266,19 @@
   ;; Including %s will splice the :target-path into this value. Note that this
   ;; is not where to *look* for existing native libraries; use :jvm-opts with
   ;; -Djava.library.path=... instead for that.
+  :clean-compile-path? true
+  ;; Let `lein clean` remove files under :compile-path even if it isn't
+  ;; under :target-path.
+  ;; If :compile-path is under :target-path, `lein clean` removes all files
+  ;; under :tareget-path including :compile-path regardless of this option.
   :native-path "%s/bits-n-stuff"
   ;; Name of the jar file produced. Will be placed inside :target-path.
   ;; Including %s will splice the project version into the filename.
+  :clean-native-path? true
+  ;; Let `lein clean` remove files under :native-path even if it isn't
+  ;; under :target-path.
+  ;; If :native-path is under :target-path, `lein clean` removes all files
+  ;; under :tareget-path including :native-path regardless of this option.
   :jar-name "sample.jar"
   ;; As above, but for uberjar.
   :uberjar-name "sample-standalone.jar"

--- a/src/leiningen/clean.clj
+++ b/src/leiningen/clean.clj
@@ -25,6 +25,17 @@ Raise an exception if any deletion fails unless silently is true."
     (io/delete-file f silently)))
 
 (defn clean
-  "Remove all files from project's target-path."
+  "Remove all files from project's target-path.
+  When compile-path isn't under target-path, files under it are not removed
+  unless clean-compile-path? is set to true.
+  When native-path isn't under target-path, files under it are not removed
+  unless clean-native-path? is set to true."
   [project]
-  (delete-file-recursively (:target-path project) :silently))
+  (let [{:keys [target-path
+                compile-path clean-compile-path?
+                native-path clean-native-path?]} project]
+    (if clean-compile-path?
+        (delete-file-recursively compile-path :silently))
+    (if clean-native-path?
+        (delete-file-recursively native-path :silently))
+    (delete-file-recursively target-path :silently)))


### PR DESCRIPTION
Add two options :clean-compile-path? and :clean-native-path? to let
`lein clean` remove files under :compile-path and/or :native-path even if
they aren't under :target-path
