### PR TITLE
Issue #1272: Add :clean-targets option

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -163,6 +163,7 @@
    :native-path "%s/native"
    :compile-path "%s/classes"
    :target-path "target/%s"
+   :clean-targets [:target-path]
    :prep-tasks ["javac" "compile"]
    :jar-exclusions [#"^\."]
    :certificates ["clojars.pem"]

--- a/sample.project.clj
+++ b/sample.project.clj
@@ -267,6 +267,18 @@
   ;; is not where to *look* for existing native libraries; use :jvm-opts with
   ;; -Djava.library.path=... instead for that.
   :native-path "%s/bits-n-stuff"
+  ;; Directories under which `lein clean` removes files.
+  ;; Specified by keyword or keyword-chain to get-in path in this defproject.
+  ;; Both a single path and a collection of paths are accepted as each.
+  ;; For example, if the other parts of project are like:
+  ;;   :target-path "target"
+  ;;   :compile-path "classes"
+  ;;   :foobar-paths ["foo" "bar"]
+  ;;   :baz-config {:qux-path "qux"}
+  ;; :clean-targets below lets `lein clean` remove files under "target",
+  ;; "classes", "foo", "bar" and "qux".
+  :clean-targets [:target-path :compile-path :foobar-paths
+                  [:baz-config :qux-path]]
   ;; Name of the jar file produced. Will be placed inside :target-path.
   ;; Including %s will splice the project version into the filename.
   :jar-name "sample.jar"

--- a/src/leiningen/clean.clj
+++ b/src/leiningen/clean.clj
@@ -25,6 +25,13 @@ Raise an exception if any deletion fails unless silently is true."
     (io/delete-file f silently)))
 
 (defn clean
-  "Remove all files from project's target-path."
+  "Remove all files from paths in project's clean-targets."
   [project]
-  (delete-file-recursively (:target-path project) :silently))
+  (doseq [target-key (:clean-targets project)]
+    (if-let [target (cond (vector? target-key) (get-in project target-key)
+                          (keyword? target-key) (target-key project))]
+      ((fn recurse [target]
+         (if (coll? target)
+             (doseq [t target] (recurse t))
+             (delete-file-recursively target :silently)))
+       target))))


### PR DESCRIPTION
Add :clean-targets option to let `lein clean` remove files under
directories other than one specified by :target-path
