### PR TITLE
Issue #1276: cleanup wrong-arg-num err msg on 0-arg tasks

### DIFF
--- a/leiningen-core/src/leiningen/core/main.clj
+++ b/leiningen-core/src/leiningen/core/main.clj
@@ -185,8 +185,9 @@
       (abort "Couldn't find project.clj, which is needed for" task-name))
     (when-not (matching-arity? task args)
       (abort "Wrong number of arguments to" task-name "task."
-             "\nExpected" (string/join " or " (map next (:arglists
-                                                         (meta task))))))
+             "\nExpected" (string/join " or " (map (comp vec next)
+                                                   (:arglists
+                                                    (meta task))))))
     (debug "Applying task" task-name "to" args)
     (apply task project args)))
 

--- a/leiningen-core/test/leiningen/zero.clj
+++ b/leiningen-core/test/leiningen/zero.clj
@@ -1,0 +1,4 @@
+(ns leiningen.zero)
+
+(defn zero [project]
+  (println "a dummy task for tests"))


### PR DESCRIPTION
0 arg task arglist was printing as `""` since passing `[project]` to
`next` resulted in `nil` which prints as `""`. Used `(comp vec next)`
instead to force it into `[]` which prints as `"[]"`.
