### PR TITLE
fix https://github.com/technomancy/leiningen/issues/1292

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -110,7 +110,7 @@ rem the paths inside the bootstrap file do not already contain double quotes but
 ) else (
     :: Not running from a checkout.
     if not exist "%LEIN_JAR%" goto NO_LEIN_JAR
-    set CLASSPATH="%LEIN_JAR%"
+    set CLASSPATH=%LEIN_JAR%
   
     if exist ".lein-classpath" (
         for /f %%i in (.lein-classpath) do set CONTEXT_CP=%%i 


### PR DESCRIPTION
The issue was caused by double-quoting the `LEIN_JAR` value, which this pull request simply reverts. This pull request is tested on both Windows 7 (32-bit) and Windows XP (32-bit).
