### PR TITLE
fix(jar): Add directory entries to the jar file

### DIFF
--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -20,6 +20,8 @@
        (project/project-with-profiles-meta
          project (merge @project/default-profiles (:profiles project)))))))
 
+(def with-resources-project (read-test-project "with-resources"))
+
 (def sample-project (read-test-project "sample"))
 
 (def sample-failing-project (read-test-project "sample_failing"))
@@ -77,3 +79,10 @@ because if not absolute then .getAbsolutePath will resolve them relative to curr
     (throw (new RuntimeException (str "bad usage, passed: `" in-str-or-file "`")))
     :else
     (.getAbsolutePath (io/as-file in-str-or-file))))
+
+(defn entries [zipfile]
+  (enumeration-seq (.entries zipfile)))
+
+(defn walkzip [fileName f]
+  (with-open [z (java.util.zip.ZipFile. fileName)]
+    (reduce #(conj %1 (f %2)) [] (entries z))))

--- a/test/leiningen/test/jar.clj
+++ b/test/leiningen/test/jar.clj
@@ -6,7 +6,8 @@
         [leiningen.core.eval :only [platform-nullsink]]
         [leiningen.test.helper :only [tricky-name-project sample-failing-project
                                       sample-no-aot-project sample-project
-                                      overlapped-sourcepaths-project]])
+                                      overlapped-sourcepaths-project
+                                      with-resources-project walkzip]])
   (:import (java.util.jar JarFile)))
 
 (def long-line
@@ -31,6 +32,13 @@
 (deftest test-jar-fails
   (binding [*err* (java.io.PrintWriter. (platform-nullsink))]
     (is (thrown? Exception (jar sample-failing-project)))))
+
+(deftest test-directory-entries-added-to-jar
+  (with-out-str
+    (let [jar (first (vals (jar with-resources-project)))
+          entry-names (set (walkzip jar #(.getName %)))]
+      (is (entry-names "nested/dir/"))
+      (is (not (some #(.startsWith % "/") entry-names))))))
 
 (deftest test-no-aot-jar-succeeds
   (with-out-str

--- a/test_projects/with-resources/project.clj
+++ b/test_projects/with-resources/project.clj
@@ -1,0 +1,10 @@
+;; This project is used for leiningen's test suite, so don't change
+;; any of these values without updating the relevant tests. If you
+;; just want a basic project to work from, generate a new one with
+;; "lein new".
+
+(defproject project-with-resources "0.5.0-SNAPSHOT"
+  :dependencies [[org.clojure/clojure "1.3.0"]
+                 [janino "2.5.15"]]
+
+  :resource-paths ["resources"])

--- a/test_projects/with-resources/resources/nested/dir/sample.txt
+++ b/test_projects/with-resources/resources/nested/dir/sample.txt
@@ -1,0 +1,1 @@
+Do not remove me!


### PR DESCRIPTION
Fixes #1303

According to the [jar file specification](http://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html)

> For resource files with non-empty directory prefixes, mappings are also
> recorded at the directory level.  Only for classes with null package
> name, and resource files which reside in the root directory, will the
> mapping be recorded at the individual file level.

If needed, directory entries may be excluded using `:jar-exclusions`
regex like `#"^.*/$"`.
