### PR TITLE
Described *1-*3,*e in repl-welcome

### DIFF
--- a/resources/repl-welcome
+++ b/resources/repl-welcome
@@ -3,3 +3,4 @@
   Source: (source function-name-here)
  Javadoc: (javadoc java-object-or-class-here)
     Exit: Control+D or (exit) or (quit)
+ Results: Stored in vars *1, *2, *3, an exception in *e


### PR DESCRIPTION
I have learned only by chance about the fact that REPL stores evaluation results in *1 - *3 and the last exception in *e. I am certainly not the only one unaware of this so it would be good to include it in the welcome message.

(For random visitors: they are defined in clojure's [`./src/clj/clojure/main.clj`](https://github.com/clojure/clojure/blob/master/src/clj/clojure/main.clj).)
