### PR TITLE
Added support of maven plugins in project.clj.

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -236,8 +236,18 @@
                           [:version version]]))))
         [:directory (:target-path project)]
         [:outputDirectory (:compile-path project)]
+        [:plugins
+	        (if-let [plugins (seq (:plugins project))]
+	                       (for [[dep version configuration] plugins]
+	                         [:plugin
+	                          [:groupId (or (namespace dep) (name dep))]
+	                          [:artifactId (name dep)]
+	                          [:version version]                           
+                            ;place for maven configuration tag                            
+                           ]                            
+                          ))
+         
         (if (or (seq extra-src) (seq extra-test))
-          [:plugins
            [:plugin
             [:groupId "org.codehaus.mojo"]
             [:artifactId "build-helper-maven-plugin"]
@@ -258,7 +268,7 @@
                 [:goals [:goal "add-test-source"]]
                 [:configuration
                  (vec (concat [:sources]
-                              (map (fn [x] [:source x]) extra-test)))]])]]])])))
+                              (map (fn [x] [:source x]) extra-test)))]])]])]])))
 
 (defmethod xml-tags ::parent
   ([_ [dep version & opts]]


### PR DESCRIPTION
It's possible to add definition :plugins in project definition.
Example: 
 :plugins [[com.theoryinpractise/clojure-maven-plugin "1.3.13"]
           [org.apache.tomcat.maven/tomcat7-maven-plugin "2.1"]]
