### PR TITLE
Added support of maven <plugin> in pom.xml (pom-plugin tag)

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -361,6 +361,12 @@
   ;; Extensions here will be propagated to the pom but not used by Leiningen.
   :extensions [[org.apache.maven.wagon/wagon-webdav "1.0-beta-2"]
                [foo/bar-baz "1.0"]]
+  
+  ;; Plugins here will be propagated to the pom but not used by Leiningen.
+  :pom-plugins [[com.theoryinpractise/clojure-maven-plugin "1.3.13"             	            
+                 [:configuration [:sourceDirectories [:sourceDirectory "src"]]]]
+                [org.apache.tomcat.maven/tomcat7-maven-plugin "2.1"]]
+
   ;; Include <scm> tag in generated pom.xml file. All key/value pairs
   ;; appear exactly as configured. If absent, Leiningen will try to
   ;; use information from a .git directory.

--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -237,13 +237,14 @@
         [:directory (:target-path project)]
         [:outputDirectory (:compile-path project)]
         [:plugins
-	        (if-let [plugins (seq (:plugins project))]
+	        (if-let [plugins (seq (:pom-plugins project))]
 	                       (for [[dep version configuration] plugins]
 	                         [:plugin
 	                          [:groupId (or (namespace dep) (name dep))]
 	                          [:artifactId (name dep)]
 	                          [:version version]                           
-                            ;place for maven configuration tag                            
+                            ;place for maven configuration tag    
+                            [:configuration configuration]
                            ]                            
                           ))
          


### PR DESCRIPTION
_Changes_
added :pom-plugins tag to project.clj
added example to sample.project.clj

_Motivation_
1. plugins section is commonly used in maven. 
2. lein pom should generate pom.xml with plugins section
3. tag :extensions has similar behavior
4. using pom-addition is inappropriate in this case as it generates code outside of build section.
