### PR TITLE
Fix unusual/extra whitespace in sample.project.clj.

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -361,12 +361,10 @@
   ;; Extensions here will be propagated to the pom but not used by Leiningen.
   :extensions [[org.apache.maven.wagon/wagon-webdav "1.0-beta-2"]
                [foo/bar-baz "1.0"]]
-  
   ;; Plugins here will be propagated to the pom but not used by Leiningen.
-  :pom-plugins [[com.theoryinpractise/clojure-maven-plugin "1.3.13"             	            
+  :pom-plugins [[com.theoryinpractise/clojure-maven-plugin "1.3.13"
                  [:configuration [:sourceDirectories [:sourceDirectory "src"]]]]
                 [org.apache.tomcat.maven/tomcat7-maven-plugin "2.1"]]
-
   ;; Include <scm> tag in generated pom.xml file. All key/value pairs
   ;; appear exactly as configured. If absent, Leiningen will try to
   ;; use information from a .git directory.


### PR DESCRIPTION
Looks to have been recently-merged, but had a few lines with carriage returns, plus some line-terminal spaces the carriage returns were apparently protecting from `whitespace-cleanup`.
