### PR TITLE
More nuanced merging of project defaults.

### DIFF
--- a/test_projects/uberjar-merging/project.clj
+++ b/test_projects/uberjar-merging/project.clj
@@ -8,6 +8,7 @@
                  [janino "2.5.15"]
                  [org.platypope/method-fn "0.1.0"]]
   :uberjar-exclusions [#"DUMMY"]
+  :uberjar-merge-with {#"\.properties$" [slurp str spit]}
   :test-selectors {:default (fn [m] (not (:integration m)))
                    :integration :integration
                    :int2 :int2


### PR DESCRIPTION
Add new internal `::default` project entry metadata tag.  Items tagged as `::default` are displaced from the right.  Any non-displaced `::default` items have their `::default` tags removed.  This allows switching the project -> default merge to `meta-merge` by marking the defaults project settings should entirely override as `::default`.
