### PR TITLE
Fix 'repl :connect <port>' when used outside of a project [fixes #1344]

### DIFF
--- a/test/leiningen/test/repl.clj
+++ b/test/leiningen/test/repl.clj
@@ -74,10 +74,19 @@
        "7"                   "repl-host:7"
        "myhost:9"            "myhost:9"
        "http://localhost:20" "http://localhost:20")
+  (with-redefs [repl-host (constantly "repl-host")
+                repl-port (constantly 0)]
+    (is (= "repl-host:1" (connect-string {} ["1"])))
+    (is (= "repl-host:123" (connect-string {} ["123"])))
+    (is (re-find
+         #"Port is required"
+         (lthelper/abort-msg connect-string {} []))))
   (is (= "127.0.0.1:4242" (connect-string lthelper/sample-project [])))
+  (is (= "127.0.0.1:4343" (connect-string lthelper/sample-project ["4343"])))
   (is (re-find
        #"Port is required"
-       (lthelper/abort-msg connect-string lthelper/with-resources-project []))))
+       (lthelper/abort-msg connect-string lthelper/with-resources-project [])))
+  (is (= "127.0.0.1:4242" (connect-string lthelper/with-resources-project ["4242"]))))
 
 (deftest test-options-for-reply
   (is (= (lthelper/fix-path-delimiters "/home/user/.lein-repl-history")


### PR DESCRIPTION
connect-string now verifies that the string ends with a port after the
string is fully formed, aborting if no port is found. This also
includes improvements to the repl help text, and more test coverage
for connect-string.
