### PR TITLE
Support nested `do` chains, remove implicit help.

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -190,7 +190,8 @@
             ;; For complex aliases, a docstring may be attached. The docstring
             ;; will be printed instead of the expansion when running `lein help`.
             "test!" ^{:doc "Recompile sources and fetch deps before testing."}
-            ["do" "clean," "deps," "test"]}
+            ;; Nested vectors are supported for the "do" task
+            ["do" "clean" ["test" ":integration"] ["deploy" "clojars"]]}
 
   ;;; # Running Project Code
   ;; Normally Leiningen runs the javac and compile tasks before

--- a/src/leiningen/do.clj
+++ b/src/leiningen/do.clj
@@ -5,14 +5,28 @@
 (defn- conj-to-last [coll x]
   (update-in coll [(dec (count coll))] conj x))
 
+(defn- butlast-char
+  "Removes the last character in the string."
+  [s]
+  (subs s 0 (dec (count s))))
+
+(defn- pop-if-last
+  "Pops the collection if (pred (peek coll)) is truthy."
+  [coll pred]
+  (if (pred (peek coll))
+    (pop coll)
+    coll))
+
 (defn ^:internal group-args
-  ([args] (reduce group-args [[]] args))
+  ([args]  (-> (reduce group-args [[]] args)
+               (pop-if-last empty?)))
   ([groups arg]
-     (if (.endsWith arg ",")
-       (-> groups
-           (conj-to-last (subs arg 0 (dec (count arg))))
-           (conj []))
-       (conj-to-last groups arg))))
+     (cond (coll? arg) (-> (pop-if-last groups empty?)
+                           (conj arg []))
+           (.endsWith arg ",") (-> groups
+                                   (conj-to-last (butlast-char arg))
+                                   (conj []))
+           :else (conj-to-last groups arg))))
 
 (defn ^:no-project-needed ^:higher-order do
   "Higher-order task to perform other tasks in succession.

--- a/test/leiningen/test/do.clj
+++ b/test/leiningen/test/do.clj
@@ -4,7 +4,7 @@
         [leiningen.do]))
 
 (deftest test-group-args-empty-args
-  (is (= [[]] (group-args []))))
+  (is (= [] (group-args []))))
 
 (deftest test-group-args-single-task
   (is (= [["pom"]] (group-args ["pom"]))))
@@ -22,3 +22,14 @@
           ["test" "test-compile"]]
          (group-args '("help" "help," "help" "version," "version,"
                        "test" "test-compile")))))
+
+(deftest test-group-existing-collections
+  (is (= [["clean"] ["test" ":integration"] '("deploy" "clojars")]
+         (group-args ["clean" ["test" ":integration"]
+                      '("deploy" "clojars")])))
+  (is (= [["foo" "bar"] ["baz" "quux"]]
+         (group-args [["foo" "bar"] ["baz" "quux"]])))
+  (is (= [["foo" "bar"] ["baz"]]
+         (group-args [["foo" "bar"] "baz"])))
+  (is (= [["combinations"] ["work"] ["as" "well"]]
+         (group-args ["combinations," "work" ["as" "well"]]))))


### PR DESCRIPTION
Should support all kinds of nested vectors for the `do` task, as specified in #1359.

`:prep-task` hasn't been handled, because it already is a vector of tasks, which can be vectors themselves (see the sample project for an example). So unless I've read #1359 wrongly, there shouldn't be a need to modify that one.
