### PR TITLE
Update dependency name in profile example

### DIFF
--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -17,7 +17,7 @@ and they will be merged into the project map when that profile is
 active.
 
 The example below adds a "dummy-data" resources directory during
-development and a dependency upon "midje" that's only used for tests.
+development and a dependency upon "expectations" that's only used for tests.
 
 ```clj
 (defproject myproject "0.5.0-SNAPSHOT"


### PR DESCRIPTION
It looks like in cab18f6bfeeee0a2808922ca130dd7538b0effda the dependency changed from midje to expectations, but the explanation text still referred to midje.

Not a big deal, but could confuse somebody.
