### PR TITLE
Clarify order-dependent conflict resolutions.

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -57,6 +57,31 @@
   version ranges as they cause all kinds of problems and exhibit
   unintuitive behaviour.
 
+**Q:** I have two dependencies, X and Y, which depends on Z. How is the version
+  of Z decided?  
+**A:** The decision depends on which depth and which order the dependencies come
+  in the `:dependency` vector: The dependency at the lowest depth will be
+  picked. If there are multiple dependencies on that depth, the first of those
+  will be picked. For instance, in the dependency graph
+```
+ [Z "1.0.9"]
+ [X "1.3.2"]
+   [Z "2.0.1"]
+```
+  the direct dependency (`[Z "1.0.9"]`) is picked, as it has the lowest depth.
+  For the dependency graph
+```
+ [X "1.3.2"]
+   [Z "2.0.1"]
+ [Y "1.0.5"]
+   [Z "2.1.3"]
+```
+  the dependency X comes first, and therefore `[Z "2.0.1"]` is picked. If we
+  place Y before X however, `[Z "2.1.3"]` will be picked.
+  
+  Note that this only applies to soft dependencies, and `lein deps :tree` will
+  only warn if the latest version is not chosen.
+
 **Q:** I'm behind an HTTP proxy; how can I fetch my dependencies?  
 **A:** Set the `$http_proxy` environment variable in Leiningen 2.x. You can also
   set `$http_no_proxy` for a list of hosts that should be reached directly, bypassing

--- a/src/leiningen/deps.clj
+++ b/src/leiningen/deps.clj
@@ -70,7 +70,8 @@
   "Show details about dependencies.
 
 USAGE: lein deps :tree
-Show the full dependency tree for the current project.
+Show the full dependency tree for the current project. Each dependency is only
+shown once within a tree.
 
 USAGE: lein deps :plugin-tree
 Show the full dependency tree for the plugins in the current project.


### PR DESCRIPTION
Should clarify how soft, transitive versions are chosen, based upon the confusion brought up in #1337. I also added in a sentence mentioning that each dependency within a dependency tree is only shown once.

However, I would love some input from @technomancy and @xeqi before merging these in: Does it look okay, and is it appropriate to put this in the FAQ?
