### PR TITLE
Fixes classpath issue under msys

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -27,7 +27,7 @@ function make_native_path {
     # ensure we have native paths
     if $cygwin && [[ "$1"  == /* ]]; then
     echo -n "$(cygpath -wp "$1")"
-    elif [[ "$OSTYPE" == "msys" && "$1"  == /* ]]; then
+    elif [[ "$OSTYPE" == "msys" && "$1"  == /?/* ]]; then
     echo -n "$(sh -c "(cd $1 2</dev/null && pwd -W) || echo $1 | sed 's/^\\/\([a-z]\)/\\1:/g'")"
     else
     echo -n "$1"
@@ -40,7 +40,11 @@ function add_path {
     shift
     while [ -n "$1" ];do
         # http://bashify.com/?Useful_Techniques:Indirect_Variables:Indirect_Assignment
-    export ${path_var}="${!path_var}${delimiter}$(make_native_path "$1")"
+        if [[ -z ${!path_var} ]]; then
+          export ${path_var}="$(make_native_path "$1")"
+        else
+          export ${path_var}="${!path_var}${delimiter}$(make_native_path "$1")"
+        fi
     shift
     done
 }


### PR DESCRIPTION
Proposed fix for:
https://github.com/technomancy/leiningen/issues/1382

I would like to have some automated tests for this but I am not sure of the best way to package them reliably. Please let me know if there is an established method for testing against the shell script without setting up an msys install in this repo.

Manual verification process:
On Windows: (My system is Windows 7 x64)
- Install MinGW
- Install Cmder or preferred console emulator
- Install lein script via non-windows instructions here: http://leiningen.org/
  - Download lein script from stable https://raw.github.com/technomancy/leiningen/stable/bin/lein 
  - Place it on your $PATH where your shell can find it (eg. ~/bin)
  - Set it to be executable (chmod a+x ~/bin/lein)
- Run lein, receive error:

```
Exception in thread "main" java.lang.NoClassDefFoundError: clojure/main
Caused by: java.lang.ClassNotFoundException: clojure.main
        ...
Could not find the main class: clojure.main.  Program will exit.
```
- Apply patch
- Run lein successfully.
