### PR TITLE
Make "/etc/leiningen" profile inclusion clearer.

### DIFF
--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -38,7 +38,7 @@ that you don't want committed in version control.
 User-wide profiles can also be specified in `~/.lein/profiles.clj`. These will be
 available in all projects managed by Leiningen, though those profiles will be
 overridden by profiles of the same name specified in the project.
-System-wide profiles can be placed in `/etc/leiningen`. They are treated
+System-wide profiles can be placed in `/etc/leiningen/profiles.clj`. They are treated
 the same as user profiles, but with lower precedence.
 
 You can also define user-wide profiles within `clj`-files inside


### PR DESCRIPTION
It's unclear from the doc if `/etc/leiningen` is a directory (which would contain a `profiles.clj` as `~/.lein/` would) or if it is a file containing analogous contents to `~/.lein/profiles.clj`.
