### PR TITLE
Add LEIN_SILENT option to supress *info* output

### DIFF
--- a/leiningen-core/src/leiningen/core/main.clj
+++ b/leiningen-core/src/leiningen/core/main.clj
@@ -93,10 +93,10 @@
   [& args]
   (when *debug* (apply println args)))
 
-(def ^:dynamic *info* true)
+(def ^:dynamic *info* (not (System/getenv "LEIN_SILENT")))
 
 (defn info
-  "Print unless *info* has been rebound to false."
+  "Print if *info* (from LEIN_SILENT environment variable) is truthy"
   [& args]
   (when *info* (apply println args)))
 


### PR DESCRIPTION
If a LEIN_SILENT environment variable is set as truthy, then _info_ will be set to false and output will be supressed. See #1387. Default is still true since LEIN_SILENT will return `nil` if not set.

Examples (in bash):

``` bash
$ LEIN_SILENT=true lein pom` 
=> No output
```

Note that, because `System/getenv` returns a string, any string value will return truthy including `LEIN_SILENT=false`:

``` bash
$ LEIN_SILENT=false lein pom` 
=> No output
```

You should erase the `LEIN_SILENT` variable to return to the default behavior:

``` bash
$ set LEIN_SILENT
$ lein pom
=> Wrote /path/to/pom.xml
```
