### PR TITLE
fix DRIP_INIT not being set when LEIN_JAVA_CMD is drip

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -209,8 +209,9 @@ fi
 export JAVA_CMD="${JAVA_CMD:-"java"}"
 export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-$JAVA_CMD}"
 
-if [[ "$(basename "$LEIN_JAVA_CMD")" == *drip* ]]; then
+if [[ -z "${DRIP_INIT+x}" && "$(basename "$LEIN_JAVA_CMD")" == *drip* ]]; then
     export DRIP_INIT="$(printf -- '-e\n(require (quote leiningen.repl))')"
+    export DRIP_INIT_CLASS="clojure.main"
 fi
 
 # Support $JAVA_OPTS for backwards-compatibility.


### PR DESCRIPTION
I checked the drip code, and discovered you have to have DRIP_INIT_CLASS and DRIP_INIT both set, otherwise DRIP_INIT will get reset to the default of "-e nil". Adding this fix cuts the startup time in half for me when running "lein repl" with drip (~2s to ~1s). 

I also added a check to not overwrite DRIP_INIT if it was already set by the user beforehand.
