### PR TITLE
Speed improvement for the "lein help" command.

### DIFF
--- a/leiningen-core/test/leiningen/one_or_two.clj
+++ b/leiningen-core/test/leiningen/one_or_two.clj
@@ -1,4 +1,4 @@
-(ns leiningen.one-or-two)
+(ns leiningen.one-or-two "Dummy task for tests")
 
 (defn one-or-two
   "Dummy task for tests"

--- a/leiningen-core/test/leiningen/var_args.clj
+++ b/leiningen-core/test/leiningen/var_args.clj
@@ -1,4 +1,4 @@
-(ns leiningen.var-args)
+(ns leiningen.var-args "Dummy task for tests.")
 
 (defn var-args [project & args]
   (println "a dummy task for tests."))

--- a/leiningen-core/test/leiningen/zero.clj
+++ b/leiningen-core/test/leiningen/zero.clj
@@ -1,4 +1,4 @@
-(ns leiningen.zero)
+(ns leiningen.zero "Dummy task for tests.")
 
 (defn zero [project]
   (println "a dummy task for tests"))

--- a/src/leiningen/do.clj
+++ b/src/leiningen/do.clj
@@ -1,4 +1,5 @@
 (ns leiningen.do
+  "Higher-order task to perform other tasks in succession."
   (:refer-clojure :exclude [do])
   (:require [leiningen.core.main :as main]))
 

--- a/src/leiningen/plugin.clj
+++ b/src/leiningen/plugin.clj
@@ -1,4 +1,5 @@
 (ns leiningen.plugin
+  "DEPRECATED. Please use the :user profile instead."
   (:require [leiningen.core.main :as main]))
 
 (defn ^:no-project-needed plugin

--- a/src/leiningen/retest.clj
+++ b/src/leiningen/retest.clj
@@ -1,4 +1,5 @@
 (ns leiningen.retest
+  "Run only the test namespaces which failed last time around."
   (:require [leiningen.test :as test]
             [leiningen.core.main :as main]))
 

--- a/src/leiningen/search.clj
+++ b/src/leiningen/search.clj
@@ -1,4 +1,5 @@
 (ns leiningen.search
+  "Search remote maven repositories for matching jars."
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
             [leiningen.core.user :as user]

--- a/src/leiningen/show_profiles.clj
+++ b/src/leiningen/show_profiles.clj
@@ -1,4 +1,5 @@
 (ns leiningen.show-profiles
+  "List all available profiles or display one if given an argument."
   (:require [clojure.string]
             [clojure.pprint :as pprint]
             [leiningen.core.project :as project]))

--- a/src/leiningen/trampoline.clj
+++ b/src/leiningen/trampoline.clj
@@ -1,4 +1,5 @@
 (ns leiningen.trampoline
+  "Run a task without nesting the project's JVM inside Leiningen's."
   (:refer-clojure :exclude [trampoline])
   (:require [clojure.string :as string]
             [leiningen.core.eval :as eval]

--- a/src/leiningen/update_in.clj
+++ b/src/leiningen/update_in.clj
@@ -1,4 +1,5 @@
 (ns leiningen.update-in
+  "Perform arbitrary transformations on your project map."
   (:refer-clojure :exclude [update-in])
   (:require [leiningen.core.main :as main]
             [clojure.core :as clj]))

--- a/src/leiningen/with_profile.clj
+++ b/src/leiningen/with_profile.clj
@@ -1,4 +1,5 @@
 (ns leiningen.with-profile
+  "Apply the given task with the profile(s) specified."
   (:require [clojure.string :as string]
             [leiningen.core.main :as main]
             [leiningen.core.project :as project]


### PR DESCRIPTION
@RyanTM and I reduced the run time of the `lein help` command by making it just read the task source code files instead of actually requiring/compiling them.

This results in a 70% speed improvement on my machine (14 seconds before, 4 seconds after).

This pull request is messy because bultitude doesn't support retrieving the namespace forms from files.  The code added to `help.clj` was mostly copied from bultitude, so it should probably be refactored and moved back to bultitude.

If you like the direction this is going, let me know because I would be willing to make pull requests to bultitude and Leiningen to clean this up.
