### PR TITLE
Rely less on undocumented features

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -419,8 +419,8 @@
         (if (or (-> left meta :prepend)
                 (-> right meta :prepend))
           (-> (concat right left)
-              (with-meta (merge (meta left)
-                                (select-keys (meta right) [:displace]))))
+              (with-meta (merge (or (meta left) {})
+                                (select-keys (or (meta right) {}) [:displace]))))
           (concat left right))
 
         (= (class left) (class right)) right


### PR DESCRIPTION
We simply guard against nil leaking into `merge` or `select-keys`. This does not change semantics.

I caught this with a linter I'm building.
