### PR TITLE
clarify `lein deps` docs

### DIFF
--- a/src/leiningen/deps.clj
+++ b/src/leiningen/deps.clj
@@ -80,8 +80,8 @@ USAGE: lein deps :verify
 Check signatures of each dependency. ALPHA: subject to change.
 
 USAGE: lein deps
-Force Leiningen to download the dependencies it needs. This usage is
-deprecated as it should happen automatically on demand.
+Force Leiningen to download the dependencies it needs. This happens
+automatically.
 
 Normally snapshot dependencies will be checked once every 24 hours; to
 force them to be updated, use `lein -U $TASK`."

--- a/zsh_completion.zsh
+++ b/zsh_completion.zsh
@@ -18,7 +18,7 @@ _lein() {
      "clean[Remove all files from project's target-path.]" \
      "compile[Compile Clojure source into \.class files.]" \
      "deploy[Build jar and deploy to remote repository.]" \
-     "deps[Download :dependencies.]" \
+     "deps[Show details about dependencies.]" \
      "help[Display a list of tasks or help for a given task.]" \
      "install[Install current project to the local repository.]" \
      "jack-in[Jack in to a Clojure SLIME session from Emacs.]" \


### PR DESCRIPTION
Usage doesn't seem to be "deprecated" technically. Also still in popular usage: https://gist.github.com/stuartsierra/8587363
