### PR TITLE
Allow plugins to whitelist modified keys that are used during jar/uberjar creation

### DIFF
--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -190,7 +190,7 @@ propagated to the compilation phase and not stripped out."
 (defn- retain-whitelisted-keys
   "Retains the whitelisted keys from the original map in the new one."
   [new original]
-  (merge new (select-keys original (into whitelist-keys (:whitelist original)))))
+  (merge new (select-keys original (into whitelist-keys (:jar-project-whitelist original)))))
 
 (defn- compile-main? [{:keys [main source-paths] :as project}]
   (and main (not (:skip-aot (meta main)))

--- a/src/leiningen/uberjar.clj
+++ b/src/leiningen/uberjar.clj
@@ -137,7 +137,7 @@ as well as defining a -main function."
        (with-open [out (-> standalone-filename
                            (FileOutputStream.)
                            (ZipOutputStream.))]
-         (let [whitelisted (select-keys project (into jar/whitelist-keys (:whitelist project)))
+         (let [whitelisted (select-keys project (into jar/whitelist-keys (:jar-project-whitelist project)))
                project (-> (project/unmerge-profiles project [:default])
                            (merge whitelisted))
                deps (->> (classpath/resolve-dependencies :dependencies project)


### PR DESCRIPTION
I have a plugin that adds some build metadata to the version key in the project per semver.org (i.e. 0.1.0-SNAPSHOT+a3fefed).  The version key is not in the whitelist defined in jar.clj, so this modification is lost when the profiles are unmerged from the 'new' project and only the whitelisted keys are re-merged into the original.  As a result, the generated jar file ends with 0.1.0-SNAPSHOT.jar rather than 0.1.0-SNAPSHOT+a3fefed.jar.  This pull request would allow plugins to add a vector of keys they have modified to `:whitelist` to be included during this re-merge as below:
`(assoc project :whitelist [:version :manifest])`

As a side note, I think this occurs because the middleware is defined in a plugin in a profile and is not rerun after the profiles are unmerged.  If I explicitly tell the middleware to be run with the top-level `:middleware` key, the changes are re-applied correctly.
