### PR TITLE
Optional msg argument to leiningen.core.main/exit. Use it for abort.

### DIFF
--- a/leiningen-core/src/leiningen/core/main.clj
+++ b/leiningen-core/src/leiningen/core/main.clj
@@ -107,11 +107,14 @@
   "Exit the process. Rebind *exit-process?* in order to suppress actual process
   exits for tools which may want to continue operating. Never call
   System/exit directly in Leiningen's own process."
-  ([exit-code]
+  ([exit-code & msg]
      (if *exit-process?*
        (do (shutdown-agents)
            (System/exit exit-code))
-       (throw (ex-info "Suppressed exit" {:exit-code exit-code}))))
+       (throw (ex-info (if (seq msg)
+                         (apply print-str msg)
+                         "Suppressed exit")
+                {:exit-code exit-code}))))
   ([] (exit 0)))
 
 (defn abort
@@ -121,7 +124,7 @@
   (binding [*out* *err*]
     (when (seq msg)
       (apply println msg))
-    (exit 1)))
+    (apply exit 1 msg)))
 
 (defn- next-dist-row [s t x pprev prev]
   (let [t-len (count t)

--- a/leiningen-core/test/leiningen/core/test/helper.clj
+++ b/leiningen-core/test/leiningen/core/test/helper.clj
@@ -9,5 +9,5 @@
       (try
         (apply f args)
         (catch clojure.lang.ExceptionInfo e
-          (when-not (= "Suppressed exit" (.getMessage e))
+          (when-not (:exit-code (ex-data e))
             (throw e)))))))


### PR DESCRIPTION
- New signature: leiningen.core.main/exit [exit-code & msg]
- msg used when _exit-process?_ is false as the Exception message

The following issues have been created for projects which are (lein-junit, test2junit) or _might_ (pallet/pallet, pallet/nrepl-main) be impacted by this change:
- https://github.com/febeling/lein-junit/issues/20
- https://github.com/ruedigergad/test2junit/issues/1
- https://github.com/pallet/pallet/issues/315
- https://github.com/pallet/nrepl-main/issues/1
