### PR TITLE
Show uncaught exceptions when using grenchman, don't display "Suppressed exit" when calling exit

### DIFF
--- a/leiningen-core/src/leiningen/core/main.clj
+++ b/leiningen-core/src/leiningen/core/main.clj
@@ -112,7 +112,7 @@
      (if *exit-process?*
        (do (shutdown-agents)
            (System/exit exit-code))
-       (throw (ex-info "Suppressed exit" {:exit-code exit-code}))))
+       (throw (ex-info "Suppressed exit" {:exit-code exit-code :suppress-msg true}))))
   ([] (exit 0)))
 
 (defn abort


### PR DESCRIPTION
Fixes #1438 and #1439
