### PR TITLE
Fix add-profiles so they can be merged by name

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -732,13 +732,13 @@ atomic (non-composite) profile keywords."
    to preserve project map metadata. Note that these profiles are not merged,
    merely made available to merge by name."
   [project profiles-map]
-  ;; Merge new profiles into both the project and without-profiles meta
-  (vary-meta (update-in project [:profiles] merge profiles-map)
-             merge
-             {:without-profiles (update-in (:without-profiles (meta project)
-                                                              project)
-                                           [:profiles] merge
-                                           profiles-map)}))
+  (-> (update-in project [:profiles] merge profiles-map)
+      (vary-meta merge
+                 {:without-profiles
+                  (update-in (:without-profiles (meta project) project)
+                             [:profiles]
+                             merge profiles-map)})
+      (vary-meta update-in [:profiles] merge profiles-map)))
 
 (defn read
   "Read project map out of file, which defaults to project.clj."

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -409,19 +409,30 @@
        {:plugins '[[lein-foo "1.2.3" :hooks false :middleware false]]}
        '() '()))
 
-;; (deftest test-add-profiles
-;;   (let [expected-result {:dependencies [] :profiles {:a1 {:src-paths ["a1/"]}
-;;                                                      :a2 {:src-paths ["a2/"]}}}]
-;;     (is (= expected-result
-;;            (-> {:dependencies []}
-;;                (add-profiles {:a1 {:src-paths ["a1/"]}
-;;                               :a2 {:src-paths ["a2/"]}}))))
-;;     (is (= expected-result
-;;            (-> {:dependencies []}
-;;                (add-profiles {:a1 {:src-paths ["a1/"]}
-;;                               :a2 {:src-paths ["a2/"]}})
-;;                meta
-;;                :without-profiles)))))
+(deftest test-add-profiles
+  (let [expected-result {:dependencies [] :profiles {:a1 {:src-paths ["a1/"]}
+                                                     :a2 {:src-paths ["a2/"]}}}]
+    (is (= expected-result
+           (-> {:dependencies []}
+               (add-profiles {:a1 {:src-paths ["a1/"]}
+                              :a2 {:src-paths ["a2/"]}}))))
+    (is (= expected-result
+           (-> {:dependencies []}
+               (add-profiles {:a1 {:src-paths ["a1/"]}
+                              :a2 {:src-paths ["a2/"]}})
+               meta
+               :without-profiles)))
+    (is (nil?
+         (-> {:dependencies []}
+             (add-profiles {:a1 {:src-paths ["a1/"]}
+                            :a2 {:src-paths ["a2/"]}})
+             :src-paths)))
+    (is (= ["a1"]
+           (-> {:dependencies []}
+               (add-profiles {:a1 {:src-paths ["a1/"]}
+                              :a2 {:src-paths ["a2/"]}})
+               (merge-profiles [:a1])
+               :src-paths)))))
 
 (deftest test-merge-anon-profiles
   (is (= {:A 1, :C 3}


### PR DESCRIPTION
I believe the :profiles metadata was introduced after this function was
written, so this update makes its comment -- "available to merge by
name" -- true again.
