### PR TITLE
Fix issue 1444 - Leiningen errors if profiles.clj is blank.  Push try-ca...

### DIFF
--- a/leiningen-core/src/leiningen/core/user.clj
+++ b/leiningen-core/src/leiningen/core/user.clj
@@ -64,14 +64,10 @@
   "Load profiles.clj from dir if present. Tags all profiles with its origin."
   (memoize
    (fn [dir]
-     (try
        (if-let [contents (utils/read-file (io/file dir "profiles.clj"))]
          (utils/map-vals contents with-meta
-                         {:origin (str (io/file dir "profiles.clj"))}))
-       (catch Exception e
-         (binding [*out* *err*]
-           (println "Error reading profiles.clj from" dir)
-           (println (.getMessage e))))))))
+                         {:origin (str (io/file dir "profiles.clj"))})))))
+
 
 (def profiles
   "Load profiles.clj from your Leiningen home and profiles.d if present."

--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -26,7 +26,15 @@
   "Read the contents of file if it exists."
   [file]
   (if (.exists file)
-    (read-string (slurp file))))
+    (try (read-string (slurp file))
+        (catch Exception e
+         (binding [*out* *err*]
+           (println "Error reading" 
+                   (.getName file)
+                   "from"
+                   (.getParent file)))
+         (throw e)))))
+
 
 (defn symlink?
   "Checks if a File is a symbolic link or points to another file."


### PR DESCRIPTION
...tch from user/load-profiles to utils/read-file, print helpful error message from utils/read-file, and bubble exception up.

Tested this with both a blank ~/.lein/profiles.clj and proj-dir/profiles.clj.  Error message and stack trace given in both cases.
