### PR TITLE
Fix Issue 1422 - add help text to repl and uberjar tasks documenting imp...

### DIFF
--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -247,8 +247,7 @@ Subcommands:
   and the port from LEIN_REPL_PORT, :repl-options, or .nrepl-port in
   the project root, in that order.
   
-Note: the default profiles (`:dev`, `:provided`, `:user`, `:system`, and `:base`) 
-profiles are activated for this task.  Type 'lein help profiles' for more information."
+Note: the :repl profile is implicitly activated for this task, and cannot be deactivated."
 
   ([project] (repl project ":start"))
   ([project subcommand & opts]

--- a/src/leiningen/uberjar.clj
+++ b/src/leiningen/uberjar.clj
@@ -124,8 +124,7 @@ With an argument, the uberjar will be built with an alternate main.
 The namespace you choose as main should have :gen-class in its ns form
 as well as defining a -main function.
   
-Note: the default profiles (`:dev`, `:provided`, `:user`, `:system`, and `:base`) 
-profiles are activated for this task.  Type 'lein help profiles' for more information."
+Note: The :uberjar profile is implicitly activated for this task, and cannot be deactivated."
 
   ([project main]
      (let [standalone-filename (jar/get-jar-filename project :standalone)


### PR DESCRIPTION
...licit profile application

Added the following text to both `repl` and `uberjar` docstrings:

```
Note: the default profiles (`:dev`, `:provided`, `:user`, `:system`, and `:base`) 
profiles are activated for this task.  Type 'lein help profiles' for more information.
```
