### PR TITLE
lein run: don't catch app errors as require errors

### DIFF
--- a/src/leiningen/run.clj
+++ b/src/leiningen/run.clj
@@ -49,7 +49,7 @@
                                     (normalize-main given))))
                 (let [v# (resolve '~(normalize-main given))]
                   (if (ifn? v#)
-                    [:done (v# ~@args)]
+                    [:var v#]
                     [:not-found]))
                 (catch FileNotFoundException e#
                   [:threw e#]))
@@ -57,11 +57,11 @@
            ;; If we didn't succeed above, check if a class exists for
            ;; the given name
            class#
-           (when-not (= :done ns-flag#)
+           (when-not (= :var ns-flag#)
              (try (Class/forName ~(name given))
                   (catch ClassNotFoundException _#)))]
        (cond
-        (= :done ns-flag#) data#
+        (= :var ns-flag#) (data# ~@args)
 
         ;; If the class exists, run its main method.
         class#

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -44,6 +44,8 @@
 
 (def java-main-project (read-test-project "java-main"))
 
+(def file-not-found-thrower-project (read-test-project "file-not-found-thrower"))
+
 (defn abort-msg
   "Catches main/abort thrown by calling f on its args and returns its error
   message."

--- a/test_projects/file-not-found-thrower/.gitignore
+++ b/test_projects/file-not-found-thrower/.gitignore
@@ -1,0 +1,9 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port

--- a/test_projects/file-not-found-thrower/project.clj
+++ b/test_projects/file-not-found-thrower/project.clj
@@ -1,0 +1,6 @@
+(defproject file-not-found-thrower "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.5.1"]])

--- a/test_projects/file-not-found-thrower/src/file_not_found_thrower/core.clj
+++ b/test_projects/file-not-found-thrower/src/file_not_found_thrower/core.clj
@@ -1,0 +1,6 @@
+(ns file-not-found-thrower.core)
+
+(defn -main
+  "I don't do a whole lot."
+  []
+  (slurp "haha this file does NOT EXIST"))


### PR DESCRIPTION
closes #1469

`lein run` currently has some special error handling around
FileNotFoundException which helps it decide what exactly it should
do. Unfortunately if the actual running of the given main function
itself throws a FileNotFoundException this is currently caught by
Leiningen and assumed to be a require error.

The simple solution is to run the main method outside of that error
handling block.

Regression test provided.
