### PR TITLE
run travis tests with oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ jdk:
   - openjdk6
   - openjdk7
   - oraclejdk7
+  - oraclejdk8
 matrix:
   allow_failures:
     - oraclejdk7
+    - oraclejdk8


### PR DESCRIPTION
for now, allow failure, since we're allowing failure for oraclejdk7

I see no indication that travis provides openjdk8, but I may be wrong
