### PR TITLE
Expand profiles before [un]merging them, re #1421

### DIFF
--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -490,6 +490,15 @@
                             :c {:C 3}}})
                (merge-profiles [:a :b :c {:D 4}])
                (unmerge-profiles [:b {:D 4}])
+               (dissoc :profiles))))
+    (is (= expected
+           (-> (make-project
+                {:profiles {:a {:A 1}
+                            :b {:B 2}
+                            :c {:C 3}
+                            :foo [:b]}})
+               (merge-profiles [:a :b :c])
+               (unmerge-profiles [:foo])
                (dissoc :profiles))))))
 
 (deftest test-dedupe-deps


### PR DESCRIPTION
This mainly addresses the fact that the following two commands generate
different output:
  $ lein pom
  $ lein with-profile default pom
I believe the problem also affects uberjar, since both tasks unmerge
:default prior to doing their thing.

Version 2.3.4 generates the same output for the above two commands,
because it doesn't expand profiles in the with-profile task, as master
does. So this change attempts to only deal with fully-expanded profiles
when [un]merging them.
