### PR TITLE
Prefer :all over other meta while merging profile.

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -472,6 +472,8 @@
 
         (= (class left) (class right)) right
 
+        (or (= :all left) (= :all right)) :all
+
         :else
         (do (println left "and" right "have a type mismatch merging profiles.")
             right)))


### PR DESCRIPTION
If project.clj looks like

``` clojure
...
:aot [mynamespace]
:profiles {:myprofile {:aot :all}}
```

`lein with-profiles +myprofile <task>` will warn _[mynamespace] and :all have a type mismatch merging profiles_ and will pick one which is merged last. IMO :all should be prefered over collection of namespaces.
