### PR TITLE
Add group-name to templates.clj

### DIFF
--- a/src/leiningen/new/templates.clj
+++ b/src/leiningen/new/templates.clj
@@ -87,6 +87,17 @@
       (string/replace "/" ".")
       (string/replace "_" "-")))
 
+(defn group-name
+  "Returns group name from (a possibly unqualified) name:
+
+  my.long.group/myproj => my.long.group
+  mygroup/myproj       => mygroup
+  myproj               => nil"
+  [s]
+  (let [grpseq (butlast (string/split (sanitize-ns s) #"\."))]
+    (if (seq grpseq)
+      (->> grpseq (interpose ".") (apply str)))))
+
 (defn year
   "Get the current year. Useful for setting copyright years and such."
   [] (+ (.getYear (java.util.Date.)) 1900))


### PR DESCRIPTION
When creating templates I've found myself using group name quite often when I have files supporting core.  I've added group-name to templates.clj to make this accessible to everyone.  Here is a sample usage

``` clojure
(defn myapp
  "Generate a Clojure application"
  [name]
  (let [render (renderer "myapp")
        sanitized (sanitize-ns name)
        project (project-name name)
        group (group-name sanitized)
        corens (multi-segment sanitized)
        configns (str (or group project) ".config")
        handlerns (str (or group project) ".handler")
        data {:raw-name name
              :name project
              :corens corens
              :corepath (name-to-path corens)
              :configns configns
              :configpath (name-to-path configns)
              :handlerns handlerns
              :handlerpath (name-to-path handlerns)
              :year (year)}]
    (main/info "Generating Clojure application project.")
    (->files data
             [".gitignore" (render "gitignore")]
             ["LICENSE" (render "LICENSE")]
             ["README.md" (render "README.md" data)]
             ["project.clj" (render "project.clj" data)]
             ["src/{{corepath}}.clj" (render "core.clj" data)]
             ["src/{{configpath}}.clj" (render "config.clj" data)]
             ["src/{{handlerpath}}.clj" (render "handler.clj" data)])))
```
