### PR TITLE
Flush output of exception error messages

### DIFF
--- a/leiningen-core/src/leiningen/core/main.clj
+++ b/leiningen-core/src/leiningen/core/main.clj
@@ -339,5 +339,6 @@ Get the latest version of Leiningen at http://leiningen.org or by executing
         (stacktrace/print-cause-trace e)
         (when-not (:suppress-msg (ex-data e))
           (println (.getMessage e))))
+      (flush)
       (exit (:exit-code (ex-data e) 1))))
   (exit 0))


### PR DESCRIPTION
When running on OS X, an exception thrown in a plugin was resulting in no
output from lein.  Adding the flush ensures the output occurs before the
process exits.
