### PR TITLE
Fully qualify clojure-complete dep to fix #1480

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -429,7 +429,7 @@
                                             {:displace true})}
                 :dependencies '[[org.clojure/tools.nrepl "0.2.3"
                                  :exclusions [org.clojure/clojure]]
-                                [clojure-complete "0.2.3"
+                                [clojure-complete/clojure-complete "0.2.3"
                                  :exclusions [org.clojure/clojure]]]
                 :checkout-deps-shares [:source-paths
                                        :test-paths


### PR DESCRIPTION
Here's one way to fix #1480 and I believe it's sufficient since the read-profiles initialization that fixed #1407 seems to ensure that any redundant non-group-qualified deps merged from multiple profiles won't result in redundant entries in the deps list, which seems to be the situation causing the NPE in exclusion-for-range. I had a hard time coming up with a test for this, btw, but it's easy enough to reproduce. Just create a new app and add a dep on clojure-complete to project.clj. You'll see two of them in the output of 'lein pprint :dependencies' and the NPE from 'lein deps :tree'
