### PR TITLE
Include group in dedupe key to fix #1480

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -195,10 +195,9 @@
 
 (defn- dep-key
   "The unique key used to dedupe dependencies."
-  [[id version & opts]]
-  (-> (apply hash-map opts)
-      (select-keys [:classifier :extension])
-      (assoc :id id)))
+  [dep]
+  (-> (dependency-map dep)
+    (select-keys [:group-id :artifact-id :classifier :extension])))
 
 (defn- reduce-dep-step [deps dep]
   (let [k (dep-key dep)]

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -510,6 +510,15 @@
                                [org.clojure/clojure "1.3.0"]]})
              (:dependencies)))))
 
+(deftest test-dedupe-non-group-deps
+  (is (= '[[foo/foo "1.1"]]
+        (-> (make-project
+              {:dependencies empty-dependencies
+               :profiles {:a {:dependencies '[[foo "1.0"]]}
+                          :b {:dependencies '[[foo "1.1"]]}}})
+          (merge-profiles [:a :b])
+          (:dependencies)))))
+
 (deftest test-warn-user-repos
   (if (System/getenv "LEIN_SUPPRESS_USER_LEVEL_REPO_WARNINGS")
     (testing "no output with suppression"

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -250,13 +250,13 @@
              (make-pom (with-profile
                          sample-project
                          :dev {:dependencies '[[rome "0.8"]]})))]
-    (is (= ["org.clojure" "rome" "ring" "org.clojure" "clojure-complete" "rome"]
+    (is (= ["org.clojure" "rome" "ring" "rome" "org.clojure" "clojure-complete"]
            (map #(first-in % [:dependency :groupId])
                 (deep-content xml [:project :dependencies]))))
-    (is (= ["clojure" "rome" "ring" "tools.nrepl" "clojure-complete" "rome"]
+    (is (= ["clojure" "rome" "ring" "rome" "tools.nrepl" "clojure-complete"]
            (map #(first-in % [:dependency :artifactId])
                 (deep-content xml [:project :dependencies]))))
-    (is (= ["1.3.0" "0.9" "1.0.0" "0.2.3" "0.2.3" "0.8"]
+    (is (= ["1.3.0" "0.9" "1.0.0" "0.8" "0.2.3" "0.2.3"]
            (map #(first-in % [:dependency :version])
                 (deep-content xml [:project :dependencies]))))
     (is (= [nil nil nil "test" "test" "test"]


### PR DESCRIPTION
This caused the ordering to change on the pom test, but the result appears semantically equivalent. I'm still not sure it makes sense including different versions of the same dep in different scopes in the same pom, but at least now the behavior of that test is consistent whether rome is fully qualified to rome/rome or not, so that's progress. Regardless, it should fix #1480 without having to fully-qualify clojure-complete in core.project.
