### PR TITLE
Ignore .nrepl-port wherever it is in the source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,15 @@
 *~
 .lein*
 /.classpath
-.nrepl-port
+/.nrepl-port
 /.project
 /.settings
 /hs_err_pid*.log
 /lein.man
 /leiningen-core/.lein-plugins/checksum
+/leiningen-core/.nrepl-port
 /leiningen-core/dev-resources/target
+/lein-pprint/.nrepl-port
 /logs
 /scratch.clj
 /target


### PR DESCRIPTION
If you start an nrepl in the leiningen-core sub-directory, you end up with a .nrepl-port in there so I think it makes sense to ignore that too. I don't see a problem with just ignoring it globally but if you think that would be a problem I'd be happy to update this PR accordingly.
