### PR TITLE
PROFILES.md - be really explicit about overriding

### DIFF
--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -88,7 +88,7 @@ vectors even though they behave like maps (because it only makes sense
 to have a single version of a given dependency present at once). The
 replace/displace metadata hints still apply though.
 
-Remember that if a profile with the same name is specified at multiple places, 
+Remember that if a profile with the same name is specified in multiple files, 
 the last one will *replace* the previous ones, no merging. Only profiles of
 different names are merged onto the project map.
 


### PR DESCRIPTION
While "Declaring Profiles" states that "Profiles specified in `profiles.clj` will override
profiles in `project.clj`," some less attentive reader can interpret it so that _keys/values_ from profiles.clj override those from project.clj, not that the profile as whole is replaced. This changes
tries to make it really clear. (Of course feel free to change the wording as you see fit.)
