### PR TITLE
defproject throws an exception on duplicate keys

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -352,11 +352,17 @@
 
 (defn- argument-list->argument-map
   [args]
-  (let [keys (filter keyword? args)
+  (let [keys (map first (partition 2 args))
         unique-keys (set keys)]
     (if (= (count keys) (count unique-keys))
       (apply hash-map args)
-      (throw (IllegalArgumentException. "Duplicate Key")))))
+      (let [duplicates (->> (frequencies keys)
+                            (remove #(> 2 (val %)))
+                            (map first))]
+        (throw
+         (IllegalArgumentException.
+          (format "Duplicate keys: %s"
+                  (clojure.string/join ", " duplicates))))))))
 
 (defmacro defproject
   "The project.clj file must either def a project map or call this macro.


### PR DESCRIPTION
This will throw an IllegalArgumentException in the event you pass the defproject macro duplicate keys.

I do also realise that some of the keys may not be keywords. I have never seen this before but can take this into account?

I'm very open to ideas of how to test this as I cannot define a map to test with duplicate keys as clojure doesn't allow this. 
