### PR TITLE
`lein vcs TASK` gives non-stack trace message when unable to detect VCS.

### DIFF
--- a/src/leiningen/vcs.clj
+++ b/src/leiningen/vcs.clj
@@ -38,11 +38,11 @@
 
 (defmethod push :none [project & [args]] (unknown-vcs "push"))
 
-(defmethod commit :none [project & [args]] (unknown-vcs "commit"))
+(defmethod commit :none [project] (unknown-vcs "commit"))
 
-(defmethod tag :none [project & [args]] (unknown-vcs "tag"))
+(defmethod tag :none [project] (unknown-vcs "tag"))
 
-(defmethod assert-committed :none [project & [args]] (unknown-vcs "assert-committed"))
+(defmethod assert-committed :none [project] (unknown-vcs "assert-committed"))
 
 ;;; Git
 


### PR DESCRIPTION
Played around with the new `lein release` functionality and thought that the error messages when `lein vcs TASK` can't detect a VCS could be a bit more descriptive instead of resulting in a stack trace. This commit provides a message indicating it could not detect the vcs and describes what task failed.
