### PR TITLE
Fix check task

### DIFF
--- a/src/leiningen/check.clj
+++ b/src/leiningen/check.clj
@@ -17,7 +17,7 @@
                        (let [ns-file# (-> (str ns#)
                                           (.replace \- \_)
                                           (.replace \. \/))]
-                         (bind [*out* *err*]
+                         (binding [*out* *err*]
                            (println "Compiling namespace" ns#))
                          (try
                            (binding [*warn-on-reflection* true]


### PR DESCRIPTION
Replaces `bind` with `binding`.

I'm not actually convinced that this particular output should be going
to stderr anyway.
