### PR TITLE
Add regression test for #1555

### DIFF
--- a/leiningen-core/test/leiningen/core/test/mirrors.clj
+++ b/leiningen-core/test/leiningen/core/test/mirrors.clj
@@ -1,0 +1,20 @@
+(ns leiningen.core.test.mirrors
+  (:require [clojure.test :refer :all]
+            [cemerick.pomegranate :as pom]
+            [leiningen.core.project :refer [init-project]]))
+
+;; Regression test for Issue #1555
+(deftest ^:online mirrors-work-ok-with-plugins
+  ;; turn off add-classpath so we don't actually mutate the classpath;
+  ;; we're still hitting the internet, and there's probably something
+  ;; in pomegranate we could redef to prevent that, but I haven't
+  ;; figured out what it is exactly.
+  (with-redefs [pom/add-classpath (constantly nil)]
+    (is (init-project
+         ;; we need to use a sequence of pairs rather than a map to
+         ;; reproduce the bug; IRL maps got converted to seqs somehow or
+         ;; another anyhow, but apparently not by init-project.
+         {:mirrors [["central" {:name "foo"
+                                :url "http://repo1.maven.org/maven2/"}]]
+          ;; Have to have a plugin to reproduce
+          :plugins '[[lein-pprint "1.1.1"]]}))))


### PR DESCRIPTION
Requesting a review on this testing technique -- calling `init-project` is going to actually mutate the classpath of the jvm running the tests, correct? If so, that seems at least hypothetically bad. The full test suite still passes.

Is there a strategic function we can redef to keep this from happening? Or another way of testing #1555?
