### PR TITLE
Check that exactly one (existing) source file is found per namespace whe...

### DIFF
--- a/test/leiningen/test/compile.clj
+++ b/test/leiningen/test/compile.clj
@@ -86,13 +86,10 @@
 
 
 (deftest bad-aot-test
-  (is (re-find #"does\.not\.exist|does\/not\/exist"
-               (with-out-str
-                 (binding [*err* *out*]
-                   (try
-                     (compile (assoc sample-project
-                                :aot '[does.not.exist]))
-                     (catch clojure.lang.ExceptionInfo _)))))))
+  (is (thrown? java.io.FileNotFoundException (compile (assoc sample-project :aot '[does.not.exist])))))
+
+(deftest multiple-namespace-files
+  (is (thrown? IllegalStateException (compile (assoc sample-project :source-paths ["src/" "src/"] :aot :all)))))
 
 (deftest compilation-specs-tests
   (is (= '[foo bar] (compilation-specs ["foo" "bar"])))


### PR DESCRIPTION
...n compiling

This was preventing me from building incrementally in a project with multiple source paths. If you have e.g. A and B source paths and the file you're modifying is in B, the previous implementation could check the last modified time of a (non-existent) file in A against the last time the namespace was compiled and then think that nothing had changed.

This implementation will also ensure that you don't have duplicate namespace names in multiple different source paths.
