### PR TITLE
fix #1581 - do not try to create an existing directory

### DIFF
--- a/src/leiningen/new/templates.clj
+++ b/src/leiningen/new/templates.clj
@@ -165,7 +165,7 @@
   (let [dir (or *dir*
                 (-> (System/getProperty "leiningen.original.pwd")
                     (io/file name) (.getPath)))]
-    (if (or (.isDirectory (io/files dir)) (.mkdir (io/file dir)) *force?*)
+    (if (or (= "." dir) (.mkdir (io/file dir)) *force?*)
       (doseq [path paths]
         (if (string? path)
           (.mkdirs (template-path dir path data))


### PR DESCRIPTION
Treat existence of parent directory as a condition to create template content.
