### PR TITLE
when opening a JarFile, report name of file in any errors

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -49,7 +49,9 @@
 (defn extract-native-deps [files native-path native-prefixes]
   (doseq [file files
           :let [native-prefix (get native-prefixes file "native/")
-                jar (JarFile. file)]
+                jar (try (JarFile. file)
+                      (catch Exception e
+                        (throw (Exception. (format "Problem opening jar %s" file) e))))]
           entry (enumeration-seq (.entries jar))
           :when (.startsWith (.getName entry) native-prefix)]
     (let [f (io/file native-path (subs (.getName entry) (count native-prefix)))]


### PR DESCRIPTION
java.util.JarFile. can fail without reporting the name of the file it's
operating on. If you have a jarfile that isn't a valid zip, this can be
confusing.
