### PR TITLE
Update clj-http from 0.6.5 to 0.9.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  ;; bump versions of various common transitive deps
                  [slingshot "0.10.3"]
                  [cheshire "5.0.2"]
-                 [clj-http "0.6.5" :exclusions [crouton]]]
+                 [clj-http "0.9.2" :exclusions [crouton]]]
   ;; checkout-deps don't work with :eval-in :leiningen
   :profiles {:dev {:resource-paths ["leiningen-core/dev-resources"]
                    :test-paths ["leiningen-core/test"]}


### PR DESCRIPTION
Update clj-http to a more recent version that contains fixes that are useful
in leiningen plugins.
