### PR TITLE
use call to run wget and curl

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -141,17 +141,17 @@ if NOT "x%HTTP_CLIENT%" == "x" (
     %HTTP_CLIENT% %1 %2
     goto EOF
 )
-wget >nul 2>&1
+call wget >nul 2>&1
 if NOT ERRORLEVEL 9009 (
-    wget --no-check-certificate -O %1 %2
+    call wget --no-check-certificate -O %1 %2
     goto EOF
 )
-curl >nul 2>&1
+call curl >nul 2>&1
 if NOT ERRORLEVEL 9009 (
     rem We set CURL_PROXY to a space character below to pose as a no-op argument
     set CURL_PROXY= 
     if NOT "x%HTTPS_PROXY%" == "x" set CURL_PROXY="-x %HTTPS_PROXY%"
-    curl %CURL_PROXY% --insecure -f -L -o  %1 %2
+    call curl %CURL_PROXY% --insecure -f -L -o  %1 %2
     goto EOF
 )
 powershell -? >nul 2>&1


### PR DESCRIPTION
When wget and/or curl is wrapped in a .bat or .cmd file as is done by [Chocolatey](http://chocolatey.org) then you have to use call to be able to execute them. If you don't do this then the bat file hangs and when you put echo on you get the error "The system cannot find the batch label specified". Using call to run executables works without issues on at least Windows 7.
