### PR TITLE
Updated error message for newbies

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -51,6 +51,10 @@ function add_path {
 
 function download_failed_message {
     echo "Failed to download $1"
+    echo ''
+    echo "If this is your first experience with Leiningen, make sure you have"
+    echo "checked out the 'stable' branch and not the 'master' branch."
+    echo ''
     echo "It's possible your HTTP client's certificate store does not have the"
     echo "correct certificate authority needed. This is often caused by an"
     echo "out-of-date version of libssl. Either upgrade it or set HTTP_CLIENT"


### PR DESCRIPTION
When you clone a git repo, it gives you the master branch by default.  Not everyone knows to switch to the 'stable' branch, and the error message when you just clone, cd bin, and .lein is misleading.  Tried to hint how to fix this issue because it's really easy if you only know to do it.
