### PR TITLE
Fix for issue 1607

### DIFF
--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -79,6 +79,15 @@
   (m (first (drop-while #(nil? (re-find (re-pattern %) k))
                         (keys m)))))
 
+(defn- get-with-pattern-fallback
+  "Gets a value from map m, but if it doesn't exist, fallback
+   to use get-by-pattern."
+  [m k]
+  (let [exact-match (m k)]
+    (if (nil? exact-match)
+      (get-by-pattern m k)
+      exact-match)))
+
 (def ^:private native-names
   {"Mac OS X" :macosx "Windows" :windows "Linux" :linux
    "FreeBSD" :freebsd "OpenBSD" :openbsd
@@ -88,12 +97,12 @@
 (defn get-os
   "Returns a keyword naming the host OS."
   []
-  (get-by-pattern native-names (System/getProperty "os.name")))
+  (get-with-pattern-fallback native-names (System/getProperty "os.name")))
 
 (defn get-arch
   "Returns a keyword naming the host architecture"
   []
-  (get-by-pattern native-names (System/getProperty "os.arch")))
+  (get-with-pattern-fallback native-names (System/getProperty "os.arch")))
 
 (defn platform-nullsink
   "Returns a file destination that will discard output."


### PR DESCRIPTION
Instead of always using a regex to try to match the native-names keys
when doing a get-os or get-arch call, use a get-with-pattern-fallback
function to first try the exact match and only if that fails, use
get-by-pattern.  This prevents matching "x86_64" with "x86" when
"x86_64" is the better match.

This fixed the issues I've been having with odd native lib failures on Mac OS X (see https://github.com/overtone/shadertone/issues/25 but I've been seeing other, similar random failures for a little while now).

I ran bin/lein test
Ran 166 tests containing 582 assertions.
0 failures, 0 errors.

This is my first pull request, so if I'm doing something wrong or if the code has issues, just let me know.
