### PR TITLE
Print compile error stacktraces as they occur

### DIFF
--- a/src/leiningen/compile.clj
+++ b/src/leiningen/compile.clj
@@ -127,7 +127,11 @@ Code that should run on startup belongs in a -main defn."
        (let [form `(doseq [namespace# '~namespaces]
                      (binding [*out* *err*]
                        (println "Compiling" namespace#))
-                     (clojure.core/compile namespace#))
+                     (try
+                       (clojure.core/compile namespace#)
+                       (catch Throwable t#
+                         (.printStackTrace t#)
+                         (throw t#))))
              project (update-in project [:prep-tasks]
                                 (partial remove #{"compile"}))]
          (try (eval/eval-in-project project form)


### PR DESCRIPTION
While attempting to compile a main .clj file to a class, to create an uberjar with "lein uberjar", I ran into a mysterious compilation error that only printed "Compilation failed: Subprocess failed" with no further information. (The program works fine from the REPL.) 

I modified Leiningen to print a stack trace when compile errors occur, which gave me the information I needed to debug the problem. I submit the attached modification in case anyone else finds this useful.
