### PR TITLE
Add LEIN_NO_USER_PROFILES to avoid user profiles

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -179,7 +179,7 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
         ORIG_PWD="$PWD"
         cd "$LEIN_DIR"
 
-        $0 classpath .lein-classpath
+        LEIN_NO_USER_PROFILES=1 $0 classpath .lein-classpath
         sum "$LEIN_DIR/project.clj" "$LEIN_DIR/leiningen-core/project.clj" > \
             .lein-project-checksum
         cd "$ORIG_PWD"

--- a/leiningen-core/src/leiningen/core/user.clj
+++ b/leiningen-core/src/leiningen/core/user.clj
@@ -80,9 +80,10 @@
                         (-> a meta :origin) "and in" (-> b meta :origin)))
              (throw (ex-info "Multiple profiles defined in ~/.lein"
                              {:exit-code 1})))]
-       (merge-with error-fn
-                   (load-profiles (leiningen-home))
-                   (into {} (profiles-d-profiles)))))))
+       (if (not (System/getenv "LEIN_NO_USER_PROFILES"))
+         (merge-with error-fn
+                     (load-profiles (leiningen-home))
+                     (into {} (profiles-d-profiles))))))))
 
 (defn gpg-program
   "Lookup the gpg program to use, defaulting to 'gpg'"


### PR DESCRIPTION
When set, this environment var will prevent user level profiles from
loading.

The var is set when calculating .lein-classpath for running from a
checkout, to prevent user level plugins getting baked into lein's
classpath.
