### PR TITLE
Ensure that there are not multiple source files for a namespace

### DIFF
--- a/src/leiningen/compile.clj
+++ b/src/leiningen/compile.clj
@@ -35,9 +35,10 @@
   [project]
   (for [namespace (compilable-namespaces project)
         :let [rel-source (b/path-for namespace)
-              source (first (for [source-path (:source-paths project)
-                                  :let [file (io/file source-path rel-source)]]
-                              file))]
+              source (first (sort-by (fn [f] (not (.exists f)))
+                                     (for [source-path (:source-paths project)
+                                           :let [file (io/file source-path rel-source)]]
+                                       file)))]
         :when source
         :let [rel-compiled (.replaceFirst rel-source "\\.clj$" "__init.class")
               compiled (io/file (:compile-path project) rel-compiled)]

--- a/test/leiningen/test/compile.clj
+++ b/test/leiningen/test/compile.clj
@@ -84,7 +84,6 @@
 ;; (deftest test-compile-java-main
 ;;   (compile dev-deps-project))
 
-
 (deftest bad-aot-test
   (is (re-find #"does\.not\.exist|does\/not\/exist"
                (with-out-str


### PR DESCRIPTION
An update of pull request #1572 which mistakenly threw an exception when no source files were found for a namespace. I've left in a log message stating that no file could be found.
