### PR TITLE
How to opt out from "Main-Class: clojure.main"

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -190,7 +190,9 @@
   ;; metadata to the namespace symbol. ^:skip-aot will not disable AOT
   ;; compilation of :main when :aot is :all or contains the main class. It's
   ;; best to be explicit with the :aot key rather than relying on
-  ;; auto-compilation of :main.
+  ;; auto-compilation of :main. Setting :main to nil is useful when a
+  ;; project contains several main functions. nil will produce a jar
+  ;; with manifest.mf that lacks `Main-Class' property.
   :main my.service.runner
   ;; Support project-specific task aliases. These are interpreted in
   ;; the same way as command-line arguments to the lein command. If


### PR DESCRIPTION
This little change documents how to opt out from `Main-Class` property generated by Leiningen/

Related to #1627.
