### PR TITLE
Extract version parsing function out of parse-semantic-version.

### DIFF
--- a/src/leiningen/release.clj
+++ b/src/leiningen/release.clj
@@ -6,8 +6,8 @@
 
 (def ^:dynamic *level* :patch)
 
-(defn parse-semantic-version [version-string]
-  "Create map representing the given version string. Raise exception if the
+(defn string->semantic-version [version-string]
+  "Create map representing the given version string. Returns nil if the
   string does not follow guidelines setforth by Semantic Versioning 2.0.0,
   http://semver.org/"
   ;; <MajorVersion>.<MinorVersion>.<PatchVersion>[-<BuildNumber | Qualifier >]
@@ -17,8 +17,14 @@
                          (zipmap [:major :minor :patch]))
         qualifier (last (re-matches #".*-(.+)?" version-string))]
     (if-not (empty? version-map)
-      (merge version-map {:qualifier qualifier})
-      (main/abort "Unrecognized version string:" version-string))))
+      (merge version-map {:qualifier qualifier}))))
+
+(defn parse-semantic-version [version-string]
+  "Create map representing the given version string. Aborts with exit code 1
+  if the string does not follow guidelines setforth by Semantic Versioning 2.0.0,
+  http://semver.org/"
+  (or (string->semantic-version version-string)
+      (main/abort "Unrecognized version string:" version-string)))
 
 (defn version-map->string
   "Given a version-map, return a string representing the version."

--- a/test/leiningen/test/release.clj
+++ b/test/leiningen/test/release.clj
@@ -62,6 +62,16 @@
     :beta "1.0.0-beta1"
     :rc "1.0.0-RC1"}]])
 
+(deftest test-string->semantic-version
+  (testing "Testing semantic version string parsing"
+    (doseq [[args expected] valid-semver-version-values]
+      (testing (format "with valid version strings: %s" args)
+        (is (= (string->semantic-version args) expected))))
+
+    (testing "with invalid version strings."
+      (doseq [[semver-test-data] invalid-semver-version-values]
+        (is (nil? (string->semantic-version semver-test-data)))))))
+
 (deftest test-parse-semver-version
   (testing "Testing semantic version string parsing"
     (doseq [[args expected] valid-semver-version-values]


### PR DESCRIPTION
I've noticed that `leiningen.release/parse-semantic-version` aborts in case it fails to parse the arg string. (The doc string claims to throw an exception instead, btw). It is a pity the code would have to be duplicated in a plugin code or wrapped into something like this if one was to eschew abortion:

``` clojure
(binding [leiningen.core.main/*exit-process?* false *err* (java.io.StringWriter.)]
...)
```

I would like to suggest to decouple the abort and parsing of the version-string. I've created a pull request as a sketch. I'm not happy with the naming I came up with (any suggestions?). It might be preferable to change the name of the original `parse-semantic-version` fn to something that reflects that it will abort in case of a failure while the suggested function `string->semantic-version` should rather be named `parse-semantic-version`. However for compatibility reasons I've refrained from renaming it.
