### PR TITLE
seq? -> sequential? to be able to handle vectors in pom/relativize

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -12,7 +12,7 @@
   (let [root (str (:root project) (System/getProperty "file.separator"))]
     (reduce #(update-in %1 [%2]
                         (fn [xs]
-                          (if (seq? xs)
+                          (if (sequential? xs)
                             (vec (for [x xs]
                                    (.replace x root "")))
                             (and xs (.replace xs root "")))))


### PR DESCRIPTION
The current implementation would break if a middleware plugin emitted a vector for any of the keys in L20 .

It wraps the output in a vec, so it's reasonable to assume it could take a vec as well.
