### PR TITLE
Add profile metadata

### DIFF
--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -81,7 +81,7 @@ to change it.
 The profiles listed above are active during development, but they are
 unmerged before the jar and pom files are created, making them
 invisible to code that depends upon your project. The next two
-profiles are different.
+profile is different.
 
 The `:provided` profile is used to specify dependencies that should be
 available during jar creation, but not propagated to other code that
@@ -91,11 +91,31 @@ but are needed during the development of the project. This is often
 used for frameworks like Hadoop that provide their own copies of
 certain libraries.
 
+## Default Profiles
+
+The `:default-profile` specifies the profiles that are active by
+default when running lein tasks.  If not overridden, this is set to
+`:core-default`, which is a composite profile with
+`[:base :system :user :provided :dev]`.
+
 ## Task Specific Profiles
 
 Some tasks automatically merge a profile if specified.  Examples of
 these are the `:test` profile, when running the `test` task, and the
 `:repl` profile, when running the `repl` task.
+
+## Profile Metadata
+
+If you mark your profile with `^:leaky` metadata, then the profile
+will affect the generated pom and jar when active.
+
+If you mark a profile with `^{:pom-scope :test}` metadata, then the
+profile's `:dependencies` will be added with a `test` scope in the
+generated pom and jar when active.
+
+If you mark a profile with `^{:pom-scope :provided}` metadata, then the
+profile's `:dependencies` will be added with a `provided` scope in the
+generated pom and jar when active.
 
 ## Merging
 

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -42,9 +42,11 @@
                                [robert/hooke "1.1.2"]
                                [stencil/stencil "0.2.0"]
                                [org.clojure/tools.nrepl "0.2.5"
-                                :exclusions [[org.clojure/clojure]]]
+                                :exclusions [[org.clojure/clojure]]
+                                :scope "test"]
                                [clojure-complete/clojure-complete "0.2.3"
-                                :exclusions [[org.clojure/clojure]]]],
+                                :exclusions [[org.clojure/clojure]]
+                                :scope "test"]],
                :twelve 12 ; testing unquote
 
                :repositories [["central" {:url "https://repo1.maven.org/maven2/"

--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -245,7 +245,8 @@ propagated to the compilation phase and not stripped out."
       (add-main main)))
 
 (defn- preprocess-project [project & [main]]
-  (process-project project main project/unmerge-profiles [:default]))
+  (process-project project main project/unmerge-profiles
+                   (project/non-leaky-profiles project)))
 
 (defn- get-jar-filename*
   [project uberjar?]
@@ -304,7 +305,8 @@ With an argument, the jar will be built with an alternate main."
        (when (:auto-clean project true)
          (clean/clean project))
        (eval/prep
-        (process-project project main project/merge-profiles [:provided]))
+        (process-project project main project/merge-profiles
+                         (project/pom-scope-profiles project :provided)))
        (let [jar-file (get-jar-filename* project nil)]
          (write-jar project jar-file (filespecs project))
          (main/info "Created" (str jar-file))

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -28,6 +28,8 @@
 
 (def sample-no-aot-project (read-test-project "sample-no-aot"))
 
+(def sample-profile-meta-project (read-test-project "sample-profile-meta"))
+
 (def tricky-name-project (read-test-project "tricky-name"))
 
 (def native-project (read-test-project "native"))

--- a/test_projects/sample-profile-meta/project.clj
+++ b/test_projects/sample-profile-meta/project.clj
@@ -1,0 +1,16 @@
+;; This project is used for leiningen's test suite, so don't change
+;; any of these values without updating the relevant tests. If you
+;; just want a basic project to work from, generate a new one with
+;; "lein new".
+
+(defproject nomnomnom "0.5.0-SNAPSHOT"
+  :dependencies []
+  :profiles {:default [:core-default :my-leaky :my-provided :my-test]
+             :my-leaky ^:leaky {:dependencies
+                                [[org.clojure/tools.macro "0.1.2"]]}
+             :my-test
+             ^{:pom-scope :test} {:dependencies
+                                  [[org.clojure/java.classpath "0.2.2"]]}
+             :my-provided
+             ^{:pom-scope :provided} {:dependencies
+                                      [[org.clojure/tools.namespace "0.2.6"]]}})


### PR DESCRIPTION
This is a first shot at implementing the profile annotation @technomancy
suggested in #leiningen as a replacement for the proposed :downstream
profile.

Adds :leaky and :pom-scope metadata for profiles.  The :dev, :test,
:base and :provided profiles are implemented in terms of these.

Profiles with :leaky metadata affect the pom and jar creation.

Profiles with a :pom-scope metadata of :test or :provided also affect the
dependencies of a pom.

NB: It changes the ordering in the pom task, which I would argue is a
fix rather than a breaking change, as it now uses the order used within
other lein tasks.
