### PR TITLE
Fix aliasing recursion with with-profile

### DIFF
--- a/src/leiningen/with_profile.clj
+++ b/src/leiningen/with_profile.clj
@@ -11,8 +11,7 @@
   (hooke/with-scope
     (let [project (and project (project/set-profiles
                                  (project/project-with-profiles project)
-                                 profiles))
-          task-name (main/lookup-alias task-name project)]
+                                 profiles))]
       (main/apply-task task-name project args))))
 
 (defn profiles-in-group


### PR DESCRIPTION
If an alias uses with-profile, then the alias was not being handled correctly,
causing a stack overflow.

e.g

```
{:user {"plz" ["with-profile" "+plz" "plz"]}
:plz {:plugins [[lein-plz "0.2.1"]]}}

lein plz
```
