### PR TITLE
Use SimpleDateFormat instead of #inst (flaky)

### DIFF
--- a/test/leiningen/test/keys.clj
+++ b/test/leiningen/test/keys.clj
@@ -1,12 +1,14 @@
 (ns leiningen.test.keys
   (:require [clojure.test :refer :all]))
 
+(def df (java.text.SimpleDateFormat. "yyyy-MM-dd"))
+
 (deftest technomancy-gpg-key
-  (let [month-before-key-expiry #inst "2017-05-14"]
+  (let [month-before-key-expiry (.parse df "2017-05-14")]
     (is (< (System/currentTimeMillis) (.getTime month-before-key-expiry))
         "If this fails, yell at technomancy to generate a new key!")))
 
 (deftest clojars-ssl-cert
-  (let [month-before-cert-expiry #inst "2016-07-12"]
+  (let [month-before-cert-expiry (.parse df "2016-07-12")]
     (is (< (System/currentTimeMillis) (.getTime month-before-cert-expiry))
         "If this fails, yell at _ato to get a new SSL cert.")))


### PR DESCRIPTION
# inst was failing when run as `lein test`, but not if I ran `lein test leiningen.test.keys`. Something's screwy with data-readers.

I have checked that the tests still work if I change the dates to be in the past.
