### PR TITLE
Remove println from leiningen.core.utils/git-file-contents

### DIFF
--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -124,7 +124,6 @@
   printed."
   [git-dir ref-path]
   (let [ref (io/file git-dir ref-path)]
-    (println (.toString ref))
     (if (.canRead ref)
       (.trim (slurp ref))
       (do


### PR DESCRIPTION
`leiningen-core/src/leiningen/core/utils.clj` has an unnecessary `println` in `git-file-contents` which can make builds quite noisy (at least on systems where `git` is not on the `PATH` or unavailable).
