### PR TITLE
Avoid setting SCRIPT to empty string

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -113,6 +113,9 @@ LEIN_JAR="$LEIN_HOME/self-installs/leiningen-$LEIN_VERSION-standalone.jar"
 # normalize $0 on certain BSDs
 if [ "$(dirname "$0")" = "." ]; then
     SCRIPT="$(which $(basename "$0"))"
+    if [ -z "$SCRIPT" ]; then
+        SCRIPT="$0"
+    fi
 else
     SCRIPT="$0"
 fi


### PR DESCRIPTION
On Ubuntu 12, if `$0` is `./lein`, then `SCRIPT="$(which $(basename "$0"))"` ends up blank. That causes an error message later: "You do not have permission to upgrade the installation in". But it is not really a permission issue, just a blank value for SCRIPT.
