### PR TITLE
Fixes technomancy/leiningen#1702 - lein self-install/upgrade/downgrade is broken in lein.bat (2.5.0)

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -141,21 +141,21 @@ if NOT "x%HTTP_CLIENT%" == "x" (
     %HTTP_CLIENT% %1 %2
     goto EOF
 )
-call wget >nul 2>&1
-if NOT ERRORLEVEL 9009 (
+where /q wget
+if NOT ERRORLEVEL 1 (
     call wget --no-check-certificate -O %1 %2
     goto EOF
 )
-call curl >nul 2>&1
-if NOT ERRORLEVEL 9009 (
+where /q curl
+if NOT ERRORLEVEL 1 (
     rem We set CURL_PROXY to a space character below to pose as a no-op argument
     set CURL_PROXY= 
     if NOT "x%HTTPS_PROXY%" == "x" set CURL_PROXY="-x %HTTPS_PROXY%"
     call curl %CURL_PROXY% --insecure -f -L -o  %1 %2
     goto EOF
 )
-powershell -? >nul 2>&1
-if NOT ERRORLEVEL 9009 (
+where /q powershell
+if NOT ERRORLEVEL 1 (
     powershell -Command "& {param($a,$f) (new-object System.Net.WebClient).DownloadFile($a, $f)}" ""%2"" ""%1""
     goto EOF
 )


### PR DESCRIPTION
This PR is to fix captioned issue.

As mentioned by @nihilismus, call returns 1. But It's better to use "where" to check the existence of the executable, because 'call' may return previous ERRORLEVEL if the called process didn't set the exit code properly.
