### PR TITLE
fixes #1719

### DIFF
--- a/src/leiningen/deploy.clj
+++ b/src/leiningen/deploy.clj
@@ -48,8 +48,13 @@
                "to avoid prompts.")
       (print "Username: ") (flush)
       (let [username (read-line)
-            password (.readPassword (System/console) "%s"
-                                    (into-array ["Password: "]))]
+            console (System/console)
+            password (if console
+                       (.readPassword console "%s"  (into-array ["Password: "]))
+                       (do
+                         (print "Password(visible): ")
+                         (flush)
+                         (read-line)))]
         [id (assoc settings :username username :password password)]))))
 
 ;; repo names must not contain path delimiters because they're used by


### PR DESCRIPTION
This change fixes the problem, that in some environments System/console() might return null, so reading the password for deploying fails.
This is specially the case under cygwin.
The javadoc of System.console() mentions specifically, that it might return null in certain environments.
