### PR TITLE
Upgrade `wagon-http` to version 2.6

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -8,7 +8,7 @@
                  [classlojure "0.6.6"]
                  [robert/hooke "1.3.0"]
                  [com.cemerick/pomegranate "0.3.0"]
-                 [org.apache.maven.wagon/wagon-http "2.6"]
+                 [org.apache.maven.wagon/wagon-http "2.7"]
                  [com.hypirion/io "0.3.1"]
                  [pedantic "0.2.0"]]
   :scm {:dir ".."}


### PR DESCRIPTION
There is a bug in Apache Maven Wagon v2.4 that manifests when I attempt
to run `lein` on a machine behind our firewall; I get the following
error multiple times, then the build fails:

```
Oct 03, 2014 8:24:02 PM org.apache.http.impl.client.DefaultHttpClient tryConnect
INFO: I/O exception (java.net.SocketException) caught when connecting to {s}->https://clojars.org: Connection reset
```

There seems to be something wrong with the way Wagon 2.4 uses
HttpClient (likely because Wagon 2.4 uses a much older verion of
HttpClient as well as a now-deprecated mechanism for creating the
HttpClient instance.)

Simply upgrading to version 2.6 and rebuilding Leiningen
solves the problem.
