### PR TITLE
make placement of :signing key clearer

### DIFF
--- a/doc/GPG.md
+++ b/doc/GPG.md
@@ -199,10 +199,9 @@ or by the uid.
 To set a key globally, add it to your user profile in
 `~/.lein/profiles.clj`:
 
-    {:user 
-      ...
-      :signing {:gpg-key "2ADFB13E"}} ;; using the key id
-    
+    {:user {...
+            :signing {:gpg-key "2ADFB13E"}}} ;; using the key id
+
 To set a key for a particular project, add it to the project
 definition:
 


### PR DESCRIPTION
This PR improves the GPG documentation to make the placement of the `:signing` key clearer.
Note the additional missing `}` and more intuitive indention.
