### PR TITLE
Updated help text for `test`

### DIFF
--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -170,8 +170,7 @@ specify a subset of your test suite to run:
 Write the selectors in project.clj:
 
     :test-selectors {:default (complement :integration)
-                     :integration :integration
-                     :all (constantly true)}
+                     :integration :integration}
 
 Arguments to this task will be considered test selectors if they are keywords,
 otherwise arguments must be test namespaces or files to run. With no

--- a/test_projects/sample/project.clj
+++ b/test_projects/sample/project.clj
@@ -22,8 +22,7 @@
                                                  (:name p) "]")})}]
   :test-selectors {:integration :integration
                    :default (complement :integration)
-                   :random (fn [_] (> (rand) ~(float 1/2)))
-                   :all (constantly true)}
+                   :random (fn [_] (> (rand) ~(float 1/2)))}
   :repositories {"other" "http://example.com/repo"}
   :deploy-repositories {"snapshots" ~(format "file://%s/lein-repo"
                                              (System/getProperty "java.io.tmpdir"))})


### PR DESCRIPTION
This is a fix for issue #1708. I just removed the references to `:all (constantly true)` in the help text and in sample/project.clj.
