### PR TITLE
Fix jar task for :classifiers

### DIFF
--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -320,7 +320,7 @@ Create a $PROJECT-$VERSION-$CLASSIFIER.jar file for each entry in the project's
 :classifiers. Returns a map of :classifier/:extension coordinates to files."
   [{:keys [classifiers] :as project} provided-profiles]
   (into {}
-        (map #(apply classifier-jar project %) provided-profiles classifiers)))
+        (map #(apply classifier-jar project provided-profiles %) classifiers)))
 
 (defn jar
   "Package up all the project's files into a jar file.

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -54,6 +54,8 @@
 
 (def jvm-opts-project (read-test-project "jvm-opts"))
 
+(def with-classifiers-project (read-test-project "with-classifiers"))
+
 (defn abort-msg
   "Catches main/abort thrown by calling f on its args and returns its error
   message."

--- a/test/leiningen/test/jar.clj
+++ b/test/leiningen/test/jar.clj
@@ -76,6 +76,17 @@
   (with-out-str
     (is (jar helper/sample-no-aot-project))))
 
+(deftest test-classifier-jar-succeeds
+  (is (= 1 (count (:classifiers helper/with-classifiers-project)))
+      "test project has a classifier")
+  (is (= 1 (count (classifier-jars helper/with-classifiers-project nil)))
+      "test project produces a classifier jar")
+  (with-out-str
+    (is (jar helper/with-classifiers-project)
+        "jar runs correctly")
+    (is (= 2 (count (jar helper/with-classifiers-project)))
+        "jar produces two jar files")))
+
 (deftest ^:online test-no-deps-jar
   (let [[coord jar-file] (first
                           (jar (dissoc helper/sample-project

--- a/test_projects/with-classifiers/project.clj
+++ b/test_projects/with-classifiers/project.clj
@@ -1,0 +1,3 @@
+(defproject with-classifiers "0.1.0-SNAPSHOT"
+  :classifiers {:tests {:source-paths ^:replace ["test"]
+                        :resource-paths ^:replace []}})


### PR DESCRIPTION
The classified jar files were not being generated due to incorrect arguments
in code.
