### PR TITLE
remove clean targets for all profiles

### DIFF
--- a/src/leiningen/uberjar.clj
+++ b/src/leiningen/uberjar.clj
@@ -129,13 +129,13 @@ be deactivated."
      (let [project (project/merge-profiles project [:uberjar])
            project (update-in project [:jar-inclusions]
                               concat (:uberjar-inclusions project))
-           standalone-filename (jar/get-jar-filename project :standalone)
            [_ jar] (try (first (jar/jar project main))
                         (catch Exception e
                           (when main/*debug*
                             (.printStackTrace e))
                           (main/abort "Uberjar aborting because jar failed:"
-                                      (.getMessage e))))]
+                                      (.getMessage e))))
+           standalone-filename (jar/get-jar-filename project :standalone)]
        (with-open [out (-> standalone-filename
                            (FileOutputStream.)
                            (ZipOutputStream.))]


### PR DESCRIPTION
Fixes issue #1721 

For `lein clean`, in addition to deleting all of the clean targets for the project, generate profile-specific clean targets for all known profiles and (attempt to) delete all of them as well.

(all tests pass)
