### PR TITLE
Fix an issue when deploying project to Clojars.

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -75,8 +75,8 @@
   [url]
   (if url
     (rest
-     (or (re-matches #"(?:git@)?github.com:([^/]+)/([^/]+).git" url)
-         (re-matches #"[^:]+://(?:git@)?github.com/([^/]+)/([^/]+).git" url)))))
+     (or (re-matches #"(?:[A-Za-z_]{2,}@)?github.com:([^/]+)/([^/]+).git" url)
+         (re-matches #"[^:]+://(?:[A-Za-z_]{2,}@)?github.com/([^/]+)/([^/]+).git" url)))))
 
 (defn- github-urls [url]
   (if-let [[user repo] (parse-github-url url)]


### PR DESCRIPTION
In some setup, people are adding their GitHub usernames in the URL of the repo such that they don't have to provide their usernames when commiting to GitHub, just their password.

This was an issue with Leiningen since it was ignored and the POM file's <scm> section was not properly generated which leaded to a missing GitHub link on their Clojars project page.

The change in the regex of parse-github-url follows two rules of the GitHub username creation:

  (1) alpha-numeric and underscores only
  (2) minimum two characters

This fix will now match GitHub URLs like:

```
https://fgiasson@github.com/structureddynamics/clj-turtle
```

The only thing I am not sure about is the reason why only the `git` user was handled.
