### PR TITLE
Clarify .lein-classpath usage with plugin deps

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -34,7 +34,8 @@ cumbersome. Once you've installed the plugin once, you can avoid this
 annoyance by creating a `.lein-classpath` file in your test project
 containing the path to the `src` directory of your plugin. If your plugin
 depends on another library that you are also working on then that needs
-to be added as another line to `.lein-classpath`.
+to be added to `.lein-classpath` with the classpath separator, either
+`:` for unix, or `;` for Windows.
 
 When emitting output, please use `leiningen.core.main/info`,
 `leiningen.core.main/warn`, and `leiningen.core.main/debug` rather than


### PR DESCRIPTION
Explain that plugin dependencies need to be added to .lein-classpath if they are being edited.
