### PR TITLE
A more efficient alternative fix for #1721

### DIFF
--- a/src/leiningen/clean.clj
+++ b/src/leiningen/clean.clj
@@ -84,7 +84,9 @@
   specifier is detected in the raw :target-path"
   [project]
   (if-let [tp (->> project meta :without-profiles :target-path (re-find #"(.*?)/[^/]*%") second)]
-    (assoc project :target-path (str (io/file (:root project) tp)))
+    (assoc project :target-path (if (.isAbsolute (io/file tp))
+                                  tp
+                                  (str (io/file (:root project) tp))))
     project))
 
 (defn clean

--- a/test/leiningen/test/clean.clj
+++ b/test/leiningen/test/clean.clj
@@ -131,3 +131,12 @@
     (is (= "/a/b/c/foo/bar/dev" (:target-path p)))
     (clean p)
     (assert-cleaned "/a/b/c/foo/bar/dev")))
+
+(deftest absolute-spliced-target-path
+  (let [p (-> (project/make {:root "/a/b/c"
+                             :target-path "/foo/bar/%s"
+                             :clean-targets ^{:protect false} [:target-path]})
+            (project/set-profiles [:dev]))]
+    (is (= "/foo/bar/dev" (:target-path p)))
+    (clean p)
+    (assert-cleaned "/foo/bar/dev")))


### PR DESCRIPTION
I also added a test for cleaning a project with a spliced target path. We can enhance it for more edge cases if warranted. The profile activation to clean one of my projects (with some 30 defined profiles) was really slowing me down.

This approach uses a regex, so now we have two (more) problems. ;)
