### PR TITLE
Fix for retaining :uberjar-name from profiles.

### DIFF
--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -276,8 +276,7 @@ propagated to the compilation phase and not stripped out."
   (get-classified-jar-filename project (when uberjar? :standalone)))
 
 (defn get-jar-filename [project & [uberjar?]]
-  (get-jar-filename* (assoc (preprocess-project project)
-                       :uberjar-name (:uberjar-name project)) uberjar?))
+  (get-jar-filename* (preprocess-project project) uberjar?))
 
 (defn build-jar
   "Build a jar for the given project and jar-file."

--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -276,7 +276,8 @@ propagated to the compilation phase and not stripped out."
   (get-classified-jar-filename project (when uberjar? :standalone)))
 
 (defn get-jar-filename [project & [uberjar?]]
-  (get-jar-filename* (preprocess-project project) uberjar?))
+  (get-jar-filename* (assoc (preprocess-project project)
+                       :uberjar-name (:uberjar-name project)) uberjar?))
 
 (defn build-jar
   "Build a jar for the given project and jar-file."


### PR DESCRIPTION
Hello Friendly Leiningenites,

This is a fix for the bug where :uberjar-name isn't maintained from profiles. Tests pass and :uberjar-name is maintained when set inside a profile (albeit true that :uberjar-name is explicitly retained).

The gist of changes in this pull request: reusing some of the profiles code from jar.clj inside uberjar.clj, and re-associng uberjar-name after "preprocess-project" is called during jar-filename extraction. The idea is that uberjar-name wasn't being used from profiles inside uberjar.clj, and it was being removed during preprocess-project as well.

Cheers,
Kyle
