### PR TITLE
Don't require port for drawbridge URLs

### DIFF
--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -83,12 +83,14 @@
   (let [opt (str (first opts))]
     (if-let [sx (string-from-file opt)]
       (connect-string project [sx])
-      (as-> (s/split opt #":") x
-            (remove s/blank? x)
-            (-> (drop-last (count x) [(repl-host project) (client-repl-port project)])
-                (concat x))
-            (s/join ":" x)
-            (ensure-port x)))))
+      (if (is-uri? opt)
+        opt
+        (as-> (s/split opt #":") x
+              (remove s/blank? x)
+              (-> (drop-last (count x) [(repl-host project) (client-repl-port project)])
+                  (concat x))
+              (s/join ":" x)
+              (ensure-port x))))))
 
 (defn options-for-reply [project & {:keys [attach port]}]
   (as-> (:repl-options project) opts

--- a/test/leiningen/test/repl.clj
+++ b/test/leiningen/test/repl.clj
@@ -84,8 +84,12 @@
        ""                         "repl-host:5"
        "7"                        "repl-host:7"
        "myhost:9"                 "myhost:9"
+       "http://localhost"         "http://localhost"
+       "http://localhost/ham"     "http://localhost/ham"
        "http://localhost:20"      "http://localhost:20"
        "http://localhost:20/ham"  "http://localhost:20/ham"
+       "https://localhost"        "https://localhost"
+       "https://localhost/ham"    "https://localhost/ham"
        "https://localhost:20"     "https://localhost:20"
        "https://localhost:20/ham" "https://localhost:20/ham")
   (with-redefs [repl-host (constantly "repl-host")
@@ -96,8 +100,6 @@
          (is (re-find
               #"Port is required"
               (lthelper/abort-msg connect-string proj in)))
-         ["https://localhost/ham"] {:root "/tmp"}
-         ["http://localhost/ham"]  {:root "/tmp"}
          ["foo1234"]               {:root "/tmp"}
          []                        {:root "/tmp"}
          []                        lthelper/with-resources-project)


### PR DESCRIPTION
REPL-y does not seem to require it, and I'm unaware of any other reason to mandate it.