### PR TITLE
Be explicit about array type.

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -164,7 +164,7 @@
   (when *pump-in*
     (utils/rebind-io!))
   (let [env (overridden-env *env*)
-        proc (.exec (Runtime/getRuntime) (into-array cmd) env (io/file *dir*))]
+        proc (.exec (Runtime/getRuntime) (into-array String cmd) env (io/file *dir*))]
     (.addShutdownHook (Runtime/getRuntime)
                       (Thread. (fn [] (.destroy proc))))
     (with-open [out (io/reader (.getInputStream proc))


### PR DESCRIPTION
I don't think this actually fixes [my problem][1], but into-array's single-argument semantics are evil.

[1]: https://gist.github.com/brandonbloom/d3598b6f2e4ef493ed56