### PR TITLE
Docs to fix gpg: can't query passphrase in batch mode in debian

### DIFF
--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -145,14 +145,15 @@ encrypted it. Due to a bug in `gpg` you currently need to use
 launches, but with `gpg-agent` you only have to enter your passphrase
 periodically; it will keep it cached for a given period.
 
-Remember to uncomment `use-agent` in ~/.gnupg/gpg.conf otherwise you get this error
+Remember to uncomment `use-agent` in `~/.gnupg/gpg.conf` otherwise
+ you get this error
 
 ```
 gpg: can't query passphrase in batch mode
 gpg: decryption failed: secret key not available
 ```
 
-You can test your gpg.conf with
+You can test whether this solution works with
 
 ```
 gpg --quiet --batch --decrypt ~/.lein/credentials.clj.gpg

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -145,6 +145,21 @@ encrypted it. Due to a bug in `gpg` you currently need to use
 launches, but with `gpg-agent` you only have to enter your passphrase
 periodically; it will keep it cached for a given period.
 
+Remember to uncomment `use-agent` in ~/.gnupg/gpg.conf otherwise you get this error
+
+```
+gpg: can't query passphrase in batch mode
+gpg: decryption failed: secret key not available
+```
+
+You can test your gpg.conf with
+
+```
+gpg --quiet --batch --decrypt ~/.lein/credentials.clj.gpg
+```
+
+If the system asked your passphrase then problem solved.
+
 ### Full-disk Encryption
 
 If you use full-disk encryption, it may be safe to store your

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -145,22 +145,6 @@ encrypted it. Due to a bug in `gpg` you currently need to use
 launches, but with `gpg-agent` you only have to enter your passphrase
 periodically; it will keep it cached for a given period.
 
-Remember to uncomment `use-agent` in `~/.gnupg/gpg.conf` otherwise
- you get this error
-
-```
-gpg: can't query passphrase in batch mode
-gpg: decryption failed: secret key not available
-```
-
-You can test whether this solution works with
-
-```
-gpg --quiet --batch --decrypt ~/.lein/credentials.clj.gpg
-```
-
-If the system asked your passphrase then problem solved.
-
 ### Full-disk Encryption
 
 If you use full-disk encryption, it may be safe to store your

--- a/doc/GPG.md
+++ b/doc/GPG.md
@@ -255,14 +255,16 @@ ignored.
 
 #### gpg: can't query passphrase in batch mode
 
+If you get this error message:
+
 ```
 gpg: can't query passphrase in batch mode
 gpg: decryption failed: secret key not available
 ```
 
-Check your ~/.gnupg/gpg.conf and make sure `use-agent` is not commented.
+Check your `~/.gnupg/gpg.conf` and make sure `use-agent` is not commented.
 
-You can test your gpg.conf with
+You can test the new configuration with:
 
 ```
 gpg --quiet --batch --decrypt ~/.lein/credentials.clj.gpg

--- a/doc/GPG.md
+++ b/doc/GPG.md
@@ -251,24 +251,20 @@ ignored.
 
 ## Troubleshooting
 
-### Debian based systems
+### Debian based distributions
 
 #### gpg: can't query passphrase in batch mode
 
-If you get this error message:
+	Could not decrypt credentials from /home/xxx/.lein/credentials.clj.gpg
+	gpg: can't query passphrase in batch mode
+	gpg: decryption failed: secret key not available
 
-```
-gpg: can't query passphrase in batch mode
-gpg: decryption failed: secret key not available
-```
 
-Check your `~/.gnupg/gpg.conf` and make sure `use-agent` is not commented.
+This error happens with gpg 1.4.12. Make sure that you have `use-agent` option explicitly enabled in `~/.gnupg/gpg.conf`. See gpg option list.
 
-You can test the new configuration with:
+You can test whether this solution works with
 
-```
-gpg --quiet --batch --decrypt ~/.lein/credentials.clj.gpg
-```
+	gpg --quiet --batch --decrypt ~/.lein/credentials.clj.gpg
 
 If the system asked your passphrase then problem solved.
 

--- a/doc/GPG.md
+++ b/doc/GPG.md
@@ -251,6 +251,25 @@ ignored.
 
 ## Troubleshooting
 
+### Debian based systems
+
+#### gpg: can't query passphrase in batch mode
+
+```
+gpg: can't query passphrase in batch mode
+gpg: decryption failed: secret key not available
+```
+
+Check your ~/.gnupg/gpg.conf and make sure `use-agent` is not commented.
+
+You can test your gpg.conf with
+
+```
+gpg --quiet --batch --decrypt ~/.lein/credentials.clj.gpg
+```
+
+If the system asked your passphrase then problem solved.
+
 ### Mac OSX
 
 #### Unable to get GPG installed via Homebrew and OSX Keychain to work


### PR DESCRIPTION
I use debian and when I did `lein deploy clojars` I got this error message:
```
gpg: can't query passphrase in batch mode
gpg: decryption failed: secret key not available
```

It turns out, I have to uncomment `use-agent` in `~/.gnupg/gpg.conf`.

I added the description of this problem and the solution in GPG.md and DEPLOY.md
