### PR TITLE
provide ability to supply a custom rendering function

### DIFF
--- a/src/leiningen/new/templates.clj
+++ b/src/leiningen/new/templates.clj
@@ -124,14 +124,15 @@
   "Create a renderer function that looks for mustache templates in the
   right place given the name of your template. If no data is passed, the
   file is simply slurped and the content returned unchanged."
-  [name]
-  (fn [template & [data]]
+  [name & [render-fn]]
+  (let [render (or render-fn render-text)]
+    (fn [template & [data]]
     (let [path (string/join "/" ["leiningen" "new" (sanitize name) template])]
       (if-let [resource (io/resource path)]
         (if data
-          (render-text (slurp-resource resource) data)
+          (render (slurp-resource resource) data)
           (io/reader resource))
-        (main/abort (format "Template resource '%s' not found." path))))))
+        (main/abort (format "Template resource '%s' not found." path)))))))
 
 ;; Our file-generating function, `->files` is very simple. We'd like
 ;; to keep it that way. Sometimes you need your file paths to be

--- a/src/leiningen/new/templates.clj
+++ b/src/leiningen/new/templates.clj
@@ -123,7 +123,11 @@
 (defn renderer
   "Create a renderer function that looks for mustache templates in the
   right place given the name of your template. If no data is passed, the
-  file is simply slurped and the content returned unchanged."
+  file is simply slurped and the content returned unchanged.
+  
+  render-fn - Optional rendering function that will be used in place of the
+              default renderer. This allows rendering templates that contain
+              tags that conflic with the Stencil renderer such as {{..}}."
   [name & [render-fn]]
   (let [render (or render-fn render-text)]
     (fn [template & [data]]


### PR DESCRIPTION
Leiningen uses Stencil to render its templates, and that can be limiting in many situation. For example, I need to render Selmer templates that use `{{...}}` syntax and that conflicts with Stencil. I'm currently forced to use `with-redefs` to override the renderer as seen [here](https://github.com/yogthos/luminus-template/blob/b5753e158a0b8e1426ef7b87a0e3768bb698a264/src/leiningen/new/luminus.clj#L62). It would be nice to have the ability to supply a custom rendering function instead.