### PR TITLE
Add typehint to `class` param passed to Reflector/invokeStaticMethod

### DIFF
--- a/src/leiningen/run.clj
+++ b/src/leiningen/run.clj
@@ -56,7 +56,7 @@
 
            ;; If we didn't succeed above, check if a class exists for
            ;; the given name
-           class#
+           ^Class class#
            (when-not (= :var ns-flag#)
              (try (Class/forName ~(name given))
                   (catch ClassNotFoundException _#)))]


### PR DESCRIPTION
Eliminates reflection warnings like:

```
Reflection warning, /tmp/form-init6919407174722938138.clj:1:991 - call to static method invokeStaticMethod on clojure.lang.Reflector can't be resolved
```
when using `lein run` and friends.