### PR TITLE
Move read-checkouts to project module and make it public

### DIFF
--- a/leiningen-core/dev-resources/checkouts/lib1/project.clj
+++ b/leiningen-core/dev-resources/checkouts/lib1/project.clj
@@ -1,0 +1,2 @@
+(defproject checkout-lib1 "0.0.1"
+  :description "Test some checkouts.")

--- a/leiningen-core/dev-resources/checkouts/lib2/project.clj
+++ b/leiningen-core/dev-resources/checkouts/lib2/project.clj
@@ -1,0 +1,2 @@
+(defproject checkout-lib2 "0.0.1"
+  :description "Test some checkouts.")

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -415,6 +415,10 @@
 (deftest test-middleware
   (is (= 7 (:seven (init-project (read (.getFile (io/resource "p2.clj"))))))))
 
+(deftest test-checkouts
+  (let [project (read (.getFile (io/resource "p1.clj")))]
+    (is (= #{"checkout-lib1" "checkout-lib2"} (set (map :name (read-checkouts project)))))))
+
 (deftest test-activate-middleware
   (let [errors (atom [])]
     (with-redefs [utils/error (fn [& args] (swap! errors conj args))]


### PR DESCRIPTION
It's needed for plugins which behaviour depends on checkouts. e.g. cljs-build auto should track changes in checkouts too.

I tried to solve circular dependency between classpath and project modules but without success. If you give me some advice then I could do this in scope of this task to remove this circular dependency.