### PR TITLE
Whitelist :uberjar-name and :jar-name to allow propagation to uberjar

### DIFF
--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -222,7 +222,7 @@
 (def whitelist-keys
   "Project keys which don't affect the production of the jar should be
 propagated to the compilation phase and not stripped out."
-  [:offline? :local-repo :certificates :warn-on-reflection :mirrors])
+  [:offline? :local-repo :certificates :warn-on-reflection :mirrors :uberjar-name :jar-name])
 
 (defn- retain-whitelisted-keys
   "Retains the whitelisted keys from the original map in the new one."


### PR DESCRIPTION
This fixes bug #1718 by allowing :uberjar-name and :jar-name to
propagate into the project, thus allowing uberjar to correctly retrieve
the :uberjar-name from build profiles