### PR TITLE
Refactor main/drop-partial-args

### DIFF
--- a/leiningen-core/src/leiningen/core/main.clj
+++ b/leiningen-core/src/leiningen/core/main.clj
@@ -240,13 +240,11 @@
                   " is a Clojure namespace, but not a Leiningen task.")))
   (throw (ex-info "Task not found" {:exit-code 1 :suppress-msg true})))
 
-;; TODO: got to be a cleaner way to do this, right?
 (defn- drop-partial-args [pargs]
   #(for [[f & r] %
-         :let [non-varargs (if (pos? (inc (.indexOf (or r []) '&)))
-                             (min (count pargs) (.indexOf r '&))
-                             (count pargs))]]
-     (cons f (drop non-varargs r))))
+         :let [[fixed-args rest-args] (split-with (partial not= '&) r)
+               new-fixed-args (drop (count pargs) fixed-args)]]
+     (cons f (concat new-fixed-args rest-args))))
 
 (defn- splice-into-args
   "Alias vectors may include :project/key entries.

--- a/leiningen-core/test/leiningen/core/test/main.clj
+++ b/leiningen-core/test/leiningen/core/test/main.clj
@@ -79,6 +79,18 @@
   (is (matching-arity? (resolve-task "one-or-two") ["clojure" "2"]))
   (is (not (matching-arity? (resolve-task "one-or-two") ["clojure" "2" "3"]))))
 
+(deftest partial-tasks
+  (are [task args] (matching-arity? (resolve-task task) args)
+       ["one-or-two" "clojure"] ["2"]
+       ["one-or-two" "clojure" "2"] []
+       ["fixed-and-var-args" "one"] ["two"]
+       ["fixed-and-var-args" "one" "two"] []
+       ["fixed-and-var-args" "one" "two"] ["more"])
+  (are [task args] (not (matching-arity? (resolve-task task) args))
+       ["one-or-two" "clojure"] ["2" "3"]
+       ["one-or-two" "clojure" "2"] ["3"]
+       ["fixed-and-var-args" "one"] []))
+
 (deftest test-version-satisfies
   (is (version-satisfies? "1.5.0" "1.4.2"))
   (is (not (version-satisfies? "1.4.2" "1.5.0")))

--- a/leiningen-core/test/leiningen/fixed_and_var_args.clj
+++ b/leiningen-core/test/leiningen/fixed_and_var_args.clj
@@ -1,0 +1,4 @@
+(ns leiningen.fixed-and-var-args "Dummy task for tests.")
+
+(defn fixed-and-var-args [project one two & rest]
+  (println "a dummy task for tests"))


### PR DESCRIPTION
The refactoring was prompted by the `TODO`.  I believe it's a little better now.  This function is private and so is not tested directly.  I did add some tests which exercise partial application of task arguments with `resolve-task`, as well add a dummy project which has both fixed and `&` arguments, since there didn't seem to be one.

This is my first dip into the Leiningen codebase and I'm pretty new to Clojure as well, so please let me know if any of the terminology is off or whatever else.