### PR TITLE
Add support for reader conditional files (cljc) (#1827)

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -358,7 +358,7 @@ middleware.
 
 ## Clojure Version
 
-Leiningen 2.4.0 and on uses Clojure 1.6.0. If you need to use a
+Leiningen 2.5.2 and on uses Clojure 1.7.0. If you need to use a
 different version of Clojure from within a Leiningen plugin, you can
 use `eval-in-project` with a dummy project argument:
 

--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -3,7 +3,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Library for core functionality of Leiningen."
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [bultitude "0.2.6"]
                  [classlojure "0.6.6"]
                  [robert/hooke "1.3.0"]

--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -4,7 +4,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Library for core functionality of Leiningen."
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [bultitude "0.2.6"]
+                 [bultitude "0.2.8"]
                  [classlojure "0.6.6"]
                  [robert/hooke "1.3.0"]
                  [com.cemerick/pomegranate "0.3.0"]

--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -64,7 +64,7 @@
               (subs 1)
               (str suffix)
               io/resource))
-        [".clj" (str clojure.lang.RT/LOADER_SUFFIX ".class")]))
+        [".clj" ".cljc" (str clojure.lang.RT/LOADER_SUFFIX ".class")]))
 
 (defn error [& args]
   (binding [*out* *err*] ;; TODO: use main/warn for this in 3.0

--- a/project.clj
+++ b/project.clj
@@ -6,10 +6,10 @@
   :url "https://github.com/technomancy/leiningen"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[leiningen-core "2.5.1"]
+  :dependencies [[leiningen-core "2.5.2-SNAPSHOT"]
                  [org.clojure/data.xml "0.0.3"]
                  [commons-io "2.4"]
-                 [bultitude "0.2.6"]
+                 [bultitude "0.2.8"]
                  [stencil "0.3.5" :exclusions [org.clojure/core.cache]]
                  [org.apache.maven.indexer/indexer-core "4.1.3"
                   :exclusions [org.apache.maven/maven-model

--- a/resources/leiningen/new/app/project.clj
+++ b/resources/leiningen/new/app/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]]
   :main ^:skip-aot {{namespace}}
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/resources/leiningen/new/default/project.clj
+++ b/resources/leiningen/new/default/project.clj
@@ -3,4 +3,4 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]])

--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -231,7 +231,8 @@
 
 (defn- compile-main? [{:keys [main source-paths] :as project}]
   (and main (not (:skip-aot (meta main)))
-       (some #(.exists (io/file % (b/path-for main))) source-paths)))
+       (some #(or (.exists (io/file % (b/path-for main "clj")))
+                  (.exists (io/file % (b/path-for main "cljc")))) source-paths)))
 
 (def ^:private implicit-aot-warning
   (delay

--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -134,7 +134,7 @@
             vars))])
 
 (defn- convert-to-ns [possible-file]
-  (if (and (.endsWith possible-file ".clj") (.exists (io/file possible-file)))
+  (if (and (re-matches #".*\.cljc?" possible-file) (.exists (io/file possible-file)))
     (str (second (b/ns-form-for-file possible-file)))
     possible-file))
 

--- a/test/leiningen/test/compile.clj
+++ b/test/leiningen/test/compile.clj
@@ -6,6 +6,7 @@
         [leiningen.compile]
         [leiningen.test.helper :only [sample-project delete-file-recursively
                                       sample-failing-project
+                                      sample-reader-cond-project
                                       tricky-name-project
                                       more-gen-classes-project
                                       with-system-err-str]])
@@ -38,6 +39,13 @@
                      "classes" "more_gen_classes" "baz.class")))
   (is (not (.exists (file "test_projects" "more-gen-classes" "target"
                           "classes" "more_gen_classes" "foo.class")))))
+
+(deftest test-compile-cljc
+  (compile sample-reader-cond-project)
+  (is (.exists (file "test_projects" "sample-reader-cond" "target"
+                     "classes" "nom" "nom" "clj__init.class")))
+  (is (.exists (file "test_projects" "sample-reader-cond" "target"
+                     "classes" "nom" "nom" "cljc__init.class"))))
 
 (def eip-check (atom false))
 

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -36,6 +36,8 @@
 
 (def sample-profile-meta-project (read-test-project "sample-profile-meta"))
 
+(def sample-reader-cond-project (read-test-project "sample-reader-cond"))
+
 (def tricky-name-project (read-test-project "tricky-name"))
 
 (def native-project (read-test-project "native"))

--- a/test/leiningen/test/test.clj
+++ b/test/leiningen/test/test.clj
@@ -87,7 +87,7 @@
   (let [project (project/merge-profiles sample-failing-project
                                         [{:aot ^:replace []
                                           :dependencies ^:replace
-                                          [['org.clojure/clojure "1.6.0"]]}])]
+                                          [['org.clojure/clojure "1.7.0"]]}])]
     (binding [main/*exit-process?* false]
       (is (= "EOF while reading" (try (test project) false
                                       (catch Exception e

--- a/test/leiningen/test/test.clj
+++ b/test/leiningen/test/test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.test :refer :all]
             [leiningen.test :refer :all]
             [leiningen.test.helper :refer [tmp-dir sample-no-aot-project
+                                           sample-reader-cond-project
                                            sample-failing-project
                                            with-system-err-str]]
             [clojure.java.io :as io]
@@ -67,6 +68,10 @@
 (deftest test-namespace-argument
   (test sample-no-aot-project "selectors")
   (is (= (ran?) #{:regular :not-custom :int2 :fixture})))
+
+(deftest test-reader-conditional-tests
+  (test sample-reader-cond-project)
+  (is (= (ran?) #{:clj-test :cljc-test})))
 
 (deftest test-invalid-namespace-argument
   (is (.contains

--- a/test/leiningen/test/update_in.clj
+++ b/test/leiningen/test/update_in.clj
@@ -15,9 +15,9 @@
               ":repl-options:port" "inc" "--" "repl" ":headless"]
              ["repl" (prj-map {:repl-options {:port 2}}) ":headless"]
 
-             [(prj-map {:dependencies [['clojure.core "1.6.0"]]})
+             [(prj-map {:dependencies [['clojure.core "1.7.0"]]})
               ":dependencies" "conj" "[slamhound \"1.1.3\"]" "--" "repl"]
-             ["repl" (prj-map {:dependencies [['clojure.core "1.6.0"]
+             ["repl" (prj-map {:dependencies [['clojure.core "1.7.0"]
                                              ['slamhound "1.1.3"]]})]]
             (partition 2))]
     (let [[in-prj key-path f & args] in-args

--- a/test_projects/bad-require/project.clj
+++ b/test_projects/bad-require/project.clj
@@ -3,5 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]]
   :main bad-require.core)

--- a/test_projects/file-not-found-thrower/project.clj
+++ b/test_projects/file-not-found-thrower/project.clj
@@ -3,4 +3,4 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]])

--- a/test_projects/java-main/project.clj
+++ b/test_projects/java-main/project.clj
@@ -1,4 +1,4 @@
 (defproject java-main "0.1.0-SNAPSHOT"
   :java-source-paths ["src/java"]
-  :dependencies [[org.clojure/clojure "1.6.0"]] ;; lein run errors if not there.
+  :dependencies [[org.clojure/clojure "1.7.0"]] ;; lein run errors if not there.
   :main my.java.Main)

--- a/test_projects/jvm-opts/project.clj
+++ b/test_projects/jvm-opts/project.clj
@@ -5,6 +5,6 @@
 
 (defproject custom/args "0.0.1-SNAPSHOT"
   :description "A test project"
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]]
   :profiles {:no-op {}
              :ascii {:jvm-opts ["-Dfile.encoding=ASCII"]}})

--- a/test_projects/more-gen-classes/project.clj
+++ b/test_projects/more-gen-classes/project.clj
@@ -3,4 +3,4 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]])

--- a/test_projects/sample-reader-cond/project.clj
+++ b/test_projects/sample-reader-cond/project.clj
@@ -1,0 +1,10 @@
+;; This project is used for leiningen's test suite, so don't change
+;; any of these values without updating the relevant tests. If you
+;; just want a basic project to work from, generate a new one with
+;; "lein new".
+
+(defproject nomnomnom "0.5.0-SNAPSHOT"
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [janino "2.5.15"]]
+  :aot :all
+  :uberjar-exclusions [#"DUMMY"])

--- a/test_projects/sample-reader-cond/src/nom/nom/clj.clj
+++ b/test_projects/sample-reader-cond/src/nom/nom/clj.clj
@@ -1,0 +1,1 @@
+(ns nom.nom.clj)

--- a/test_projects/sample-reader-cond/src/nom/nom/cljc.cljc
+++ b/test_projects/sample-reader-cond/src/nom/nom/cljc.cljc
@@ -1,0 +1,1 @@
+(ns nom.nom.cljc)

--- a/test_projects/sample-reader-cond/test/clj_test.clj
+++ b/test_projects/sample-reader-cond/test/clj_test.clj
@@ -1,0 +1,7 @@
+(ns clj-test
+  (:use [clojure.test]
+        [selectors :only [record-ran]]))
+
+(deftest clojure-test
+  (record-ran :clj-test)
+  (is true))

--- a/test_projects/sample-reader-cond/test/cljc_test.cljc
+++ b/test_projects/sample-reader-cond/test/cljc_test.cljc
@@ -1,0 +1,8 @@
+(ns cljc-test
+  (:use #?(:clj  [clojure.test]
+           :cljs [cljs.test])
+        [selectors :only [record-ran]]))
+
+(deftest conditional-test
+  (record-ran :cljc-test)
+  (is true))

--- a/test_projects/sample-reader-cond/test/selectors.clj
+++ b/test_projects/sample-reader-cond/test/selectors.clj
@@ -1,0 +1,10 @@
+(ns selectors
+  (:use [clojure.test]
+        [clojure.java.io]))
+
+(defn record-ran [t]
+  (let [file-name (format "%s/lein-test-ran"
+                          (System/getProperty "java.io.tmpdir"))]
+    (with-open [w (writer file-name :append true)]
+      (.write w (str t "\n")))))
+

--- a/test_projects/uberjar-merging/project.clj
+++ b/test_projects/uberjar-merging/project.clj
@@ -4,7 +4,7 @@
 ;; "lein new".
 
 (defproject nomnomnom "0.5.0-SNAPSHOT"
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [janino "2.5.15"]
                  [org.platypope/method-fn "0.1.0"]]
   :uberjar-exclusions [#"DUMMY"]


### PR DESCRIPTION
Clojure 1.7.0 will add support for reader conditionals:

http://dev.clojure.org/display/design/Reader+Conditionals

This patch adds reader conditional support to leiningen, in particular for
compilation (including aot and stale files) and testing.

Before this patch can be merged, [Raynes/bultitude](https://github.com/Raynes/bultitude) needs to release support for resolving namespaces in cljc file, and modify `path-for` in some way as it will no longer be possible to do a 1-to-1 mapping between a namespace and its source file. I've created a merge request for this purpose: https://github.com/Raynes/bultitude/pull/28

Please let me know if there's anything I can do to help get this change accepted. I'm very eager to have this support added as our commercial project requires aot, so we can't use reader conditionals until this is feature is added.