### PR TITLE
Platform independent SHA

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -23,11 +23,10 @@ else
   cygwin=false
 fi
 
-if command -v shasum >/dev/null 2>&1; then
-    SUM="shasum"
-elif command -v sha1sum >/dev/null 2>&1; then
-    SUM="sha1sum"
-fi
+function command_not_found {
+    >&2 echo "Leiningen coundn't find $1 in your \$PATH ($PATH), which is required."
+    exit 1
+}
 
 function make_native_path {
     # ensure we have native paths
@@ -311,6 +310,15 @@ else
 
     if [ "$LEIN_FAST_TRAMPOLINE" != "" ] && [ -r project.clj ]; then
         INPUTS="$@ $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj")"
+
+        if command -v shasum >/dev/null 2>&1; then
+            SUM="shasum"
+        elif command -v sha1sum >/dev/null 2>&1; then
+            SUM="sha1sum"
+        else
+            command_not_found "sha1sum or shasum"
+        fi
+
         export INPUT_CHECKSUM=$(echo $INPUTS | $SUM | cut -f 1 -d " ")
         # Just don't change :target-path in project.clj, mkay?
         TRAMPOLINE_FILE="target/trampolines/$INPUT_CHECKSUM"

--- a/bin/lein
+++ b/bin/lein
@@ -23,6 +23,12 @@ else
   cygwin=false
 fi
 
+if hash shasum >/dev/null 2>&1; then
+    SUM="shasum -"
+elif hash sha1sum >/dev/null 2>&1; then
+    SUM="sha1sum"
+fi
+
 function make_native_path {
     # ensure we have native paths
     if $cygwin && [[ "$1"  == /* ]]; then
@@ -305,7 +311,7 @@ else
 
     if [ "$LEIN_FAST_TRAMPOLINE" != "" ] && [ -r project.clj ]; then
         INPUTS="$@ $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj")"
-        export INPUT_CHECKSUM=$(echo $INPUTS | shasum - | cut -f 1 -d " ")
+        export INPUT_CHECKSUM=$(echo $INPUTS | $SUM | cut -f 1 -d " ")
         # Just don't change :target-path in project.clj, mkay?
         TRAMPOLINE_FILE="target/trampolines/$INPUT_CHECKSUM"
     else

--- a/bin/lein
+++ b/bin/lein
@@ -23,9 +23,9 @@ else
   cygwin=false
 fi
 
-if hash shasum >/dev/null 2>&1; then
-    SUM="shasum -"
-elif hash sha1sum >/dev/null 2>&1; then
+if command -v shasum >/dev/null 2>&1; then
+    SUM="shasum"
+elif command -v sha1sum >/dev/null 2>&1; then
     SUM="sha1sum"
 fi
 


### PR DESCRIPTION
This addresses the problem in #687. Not all systems have `shasum`, some have `sha1sum` instead. Feel free to suggest other solutions, this was the first that came to my mind.

(`$SUM` was already used before in the history of leiningen, so I just revived that variable name)