### PR TITLE
Escape variable so script does not break on space in username

### DIFF
--- a/bin/lein-pkg
+++ b/bin/lein-pkg
@@ -6,9 +6,7 @@
 
 export LEIN_VERSION="2.5.2-SNAPSHOT"
 
-export USR=`whoami`
-
-if [ "$USR" = "root" ] && [ "$LEIN_ROOT" = "" ]; then
+if [ "`whoami`" = "root" ] && [ "$LEIN_ROOT" = "" ]; then
     echo "WARNING: You're currently running as root; probably by accident."
     echo "Press control-C to abort or Enter to continue as root."
     echo "Set LEIN_ROOT to disable this warning."

--- a/bin/lein-pkg
+++ b/bin/lein-pkg
@@ -6,7 +6,9 @@
 
 export LEIN_VERSION="2.5.2-SNAPSHOT"
 
-if [ `whoami` = "root" ] && [ "$LEIN_ROOT" = "" ]; then
+export USR=`whoami`
+
+if [ "$USR" = "root" ] && [ "$LEIN_ROOT" = "" ]; then
     echo "WARNING: You're currently running as root; probably by accident."
     echo "Press control-C to abort or Enter to continue as root."
     echo "Set LEIN_ROOT to disable this warning."


### PR DESCRIPTION
Running `lein` on OSX Yosemite 10.10.3 breaks with error `/usr/local/bin/lein: line 9: [: too many arguments`. Separating the `whoami` command in a variable and escaping this solves the problem.