### PR TITLE
Don't check certificate with wget in lein.bat

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -151,7 +151,7 @@ if NOT ERRORLEVEL 1 (
 call wget --help >nul 2>&1
 if NOT ERRORLEVEL 1 (
     set LAST_HTTP_CLIENT=wget
-    call wget -O %1 %2
+    call wget --no-check-certificate -O %1 %2
     goto EOF
 )
 call curl --help >nul 2>&1


### PR DESCRIPTION
This is a potential installation blocker for new users on Windows. I
don't know how widespread the issue actually is because it may only be
in regard to older leiningen versions updating on Windows.