### PR TITLE
Modify .lein-failures. Help retest individual tests.

### DIFF
--- a/src/leiningen/retest.clj
+++ b/src/leiningen/retest.clj
@@ -10,6 +10,6 @@
     (apply test/test project
            (concat (if (.exists (java.io.File. ".lein-failures"))
                      (->> (slurp ".lein-failures")
-                          read-string sort (map name)))
+                          read-string keys sort))
                    selectors))
     (main/abort "Cannot retest when :monkeypatch-clojure-test is disabled.")))


### PR DESCRIPTION
Sometimes it is preferable and time-saving to retest :only failed tests,
instead of retesting the entire namespace.

To enable this, we can write a map to .lein-failures like this:
{"failed-ns-1" ["failed-test-1" "failed-test-2"]
 "failed-ns-2" ["failed-test-1"]
 ... ... ...}

But we do NOT change the API or behaviour of `lein-retest`.

We only modify it to read namespace names from a map instead of a set.

We now have the option to write a custom plugin or wrapper that retests
only failed tests.