### PR TITLE
Bump cheshire dependency.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [clojure-complete "0.2.3"]
                  ;; bump versions of various common transitive deps
                  [slingshot "0.10.3"]
-                 [cheshire "5.0.2"]
+                 [cheshire "5.5.0"]
                  [clj-http "0.9.2" :exclusions [crouton]]]
   ;; checkout-deps don't work with :eval-in :leiningen
   :profiles {:dev {:resource-paths ["leiningen-core/dev-resources"]


### PR DESCRIPTION
The current version pulls in really old versions of jackson which can easily break plugin code.

This doesn't fix #1875, but it might reduce the number of people adversely affected by this dependency.