### PR TITLE
Allow check for root user to process correctly on Solaris.

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -83,7 +83,19 @@ function self_install {
   fi
 }
 
-if [ "$(id -u)" -eq 0 ] && [ "$LEIN_ROOT" = "" ]; then
+function check_root {
+  local -i user_id
+  # Thank you for the complexity, Solaris
+  if [ `uname` = "SunOS" -a -x /usr/xpg4/bin/id ]; then
+    user_id=$(/usr/xpg4/bin/id -u 2>/dev/null || echo 0)
+  else
+    user_id=$(id -u 2>/dev/null || echo 0)
+  fi
+  [ $user_id -eq 0 -a "$LEIN_ROOT" = "" ] && return 0
+  return 1
+}
+
+if check_root; then
     echo "WARNING: You're currently running as root; probably by accident."
     echo "Press control-C to abort or Enter to continue as root."
     echo "Set LEIN_ROOT to disable this warning."


### PR DESCRIPTION
On Solaris, the standard `id` command, `/usr/bin/id`, does not allow for the `-u` flag.  `/usr/xpg4/bin/id -u` must be used instead.