### PR TITLE
Feature/honor sh return codes

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -185,6 +185,21 @@
             (.resurrect System/in))
           exit-value)))))
 
+(defn sh-with-exit-code
+  "Applies SH to CMD and on a non-0 exit code, throws an Exception
+  using FAILURE-MESSAGE. A period is appended to FAILURE-MESSAGE.
+  Returns the exit code on success.
+
+  FAILURE-MESSAGE must satisfy `string?`.
+  (first CMD) must satisfy `string?`."
+  [failure-message & cmd]
+  {:pre [(string? failure-message)
+         (string? (first cmd))]}
+  (let [exit-code (apply sh cmd)]
+    (when-not (= 0 exit-code)
+      (throw (Exception. (format "%s. %s exit code: %d" failure-message (first cmd) exit-code))))
+    exit-code))
+
 (defn- agent-arg [coords file]
   (let [{:keys [options bootclasspath]} (apply hash-map coords)]
     (concat [(str "-javaagent:" file (and options (str "=" options)))]

--- a/leiningen-core/test/leiningen/core/test/eval.clj
+++ b/leiningen-core/test/leiningen/core/test/eval.clj
@@ -60,3 +60,11 @@
                                    "/2.18.0/newrelic-agent-2.18.0.jar"))))
     (is (re-find #"bootclasspath.*newrelic.*jar" newrelic-bootcp))
     (is (re-find #"-javaagent:.*nodisassemble-0.1.2.jar=hello" nodisassemble))))
+
+(deftest test-sh-with-exit-code-successful-command
+  (with-redefs [sh (constantly 0)]
+    (is (= 0 (sh-with-exit-code "Shouldn't see me." "ls")))))
+
+(deftest test-sh-with-exit-code-failed-command
+  (with-redefs [sh (constantly 1)]
+    (is (thrown-with-msg? Exception #"Should see me. ls exit code: 1" (sh-with-exit-code "Should see me" "ls")))))

--- a/src/leiningen/vcs.clj
+++ b/src/leiningen/vcs.clj
@@ -52,24 +52,24 @@
 
 (defmethod push :git [project & args]
   (binding [eval/*dir* (:root project)]
-    (apply eval/sh "git" "push" args)
-    (apply eval/sh "git" "push" "--tags" args)))
+    (apply eval/sh-with-exit-code "Couldn't push to the remote" "git" "push" args)
+    (apply eval/sh-with-exit-code "Couldn't push tags to the remote" "git" "push" "--tags" args)))
 
 (defmethod commit :git [project]
   (binding [eval/*dir* (:root project)]
-    (eval/sh "git" "commit" "-a" "-m" (str "Version " (:version project)))))
+    (eval/sh-with-exit-code "Couldn't commit" "git" "commit" "-a" "-m" (str "Version " (:version project)))))
 
 (defmethod tag :git [{:keys [root version]} & [prefix]]
   (binding [eval/*dir* root]
     (let [tag (if prefix
                 (str prefix version)
                 version)]
-      (eval/sh "git" "tag" "-s" tag "-m" (str "Release " version)))))
+      (eval/sh-with-exit-code "Couldn't tag" "git" "tag" "-s" tag "-m" (str "Release " version)))))
 
 (defmethod assert-committed :git [project]
   (binding [eval/*dir* (:root project)]
     (when (re-find #"Changes (not staged for commit|to be committed)"
-                   (with-out-str (eval/sh "git" "status")))
+                   (with-out-str (eval/sh-with-exit-code "Couldn't get status" "git" "status")))
        (main/abort "Uncommitted changes in" (:root project) "directory."))))
 
 


### PR DESCRIPTION
Still have some functional tests to do but this seems reasonable. I'm not super thrilled about the name `sh-with-exit-code` but I couldn't think of a better one off the top of my head.

Closes #1968 

Let me know if I'm not on the right track, otherwise I'll let you know when I'm done functionally testing it.

- [x] Add unit tests
- [x] Run a successful release
- [x] Run a failed release (gpg tag failure specifically)