### PR TITLE
Create source, resource and test paths for eval prep

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -57,9 +57,13 @@
   "Before we can run eval-in-project we need to prep the project by running
   javac, compile, and any other tasks the project specifies."
   [project]
-  ;; This must exist before the project is launched.
+  ;; These must exist before the project is launched.
   (when (:root project)
-    (.mkdirs (io/file (:compile-path project "/tmp"))))
+    (.mkdirs (io/file (:compile-path project "/tmp")))
+    (doseq [path (concat (:source-paths project)
+                         (:test-paths project)
+                         (:resource-paths project))]
+      (.mkdirs (io/file path))))
   (write-pom-properties project)
   (classpath/resolve-dependencies :dependencies project)
   (run-prep-tasks project)


### PR DESCRIPTION
If a directory on the classpath does not exist when the JVM is started, it's ignored even if it is subsequently created. This can be a pain when dealing with resources generated on the fly, such as Javascript generated from a Clojurescript source. Currently the only solution is to close and restart the REPL when that happens.

This pull request ensures that source, resource and test paths exist as part of the prep work for eval-in-project, thereby fixing this issue. I've added a test that fails without these changes.