### PR TITLE
Make the file-not-found test less strict

### DIFF
--- a/test/leiningen/test/run.clj
+++ b/test/leiningen/test/run.clj
@@ -82,4 +82,4 @@
     ;; the inappropriate error message "Can't find
     ;; 'file-not-found-thrower.core' as .class or .clj for lein run:
     ;; please check the spelling." is not
-    (is (.startsWith s "Exception in thread \"main\" java.io.FileNotFoundException"))))
+    (is (.contains s "Exception in thread \"main\" java.io.FileNotFoundException"))))


### PR DESCRIPTION
The JVM sometimes prepends stuff to the err output (like if you have the JAVA_TOOL_OPTIONS set) and this makes this particular test fail.
This adds a bit of convenience and this doesn't invalidate the test AFAIK.
