### PR TITLE
Add option to not sign tags when running "vcs" "tag"

### DIFF
--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -297,6 +297,13 @@ libraries using Leiningen. Applications will have different requirements
 that are varied enough that Leiningen doesn't attempt to support them
 out of the box.
 
+### Tagging
+
+By default `["vcs" "tag"]` will create a GPG signed tag with your project version
+number. You can add a tag prefix by passing the prefix after `"tag"`,
+for example: `["vcs" "tag" "v"]`. You can disable tag signing by passing `--no-sign`,
+for example: `["vcs" "tag" "v" "--no-sign"]` or `["vcs" "tag" "--no-sign"]`.
+
 ## Deploying to Maven Central
 
 Deploying your libraries and other artifacts to [Maven

--- a/test/leiningen/test/vcs.clj
+++ b/test/leiningen/test/vcs.clj
@@ -1,0 +1,15 @@
+(ns leiningen.test.vcs
+  (:require [clojure.test :refer :all]
+            [leiningen.vcs :as vcs]))
+
+(deftest parsed-args
+  (testing "VCS tag argument parsing"
+    (are [args parsed-args] (= (vcs/parse-tag-args args) parsed-args)
+      [] {:sign? true}
+      ["v"] {:prefix "v" :sign? true}
+      ["v" "--sign"] {:prefix "v" :sign? true}
+      ["--sign"] {:sign? true}
+      ["--no-sign"] {:sign? false}
+      ["--no-sign" "v"] {:prefix "v" :sign? false}
+      ["-s"] {:sign? true}
+      ["v" "r"] {:prefix "r" :sign? true})))


### PR DESCRIPTION
- Add vcs tag commandline argument parser
- Update documentation to show new options

This is my first non-doc contribution to Leiningen, so let me know if any of my code style is wrong. I'd also welcome any improvements on the docs for tag arguments, I felt my changes were a bit awkward.

Fixes #1873, fixes #1799

- [ ] Need to notify https://github.com/nberger/lein-tag-no-sign about this change.