### PR TITLE
allow setting no-auth in settings

### DIFF
--- a/src/leiningen/deploy.clj
+++ b/src/leiningen/deploy.clj
@@ -32,6 +32,7 @@
 (defn add-auth-interactively [[id settings]]
   (if (or (and (:username settings) (some settings [:password :passphrase
                                                     :private-key-file]))
+          (:no-auth settings)
           (re-find #"(file|scp|scpexe)://" (:url settings)))
     [id settings]
     (do


### PR DESCRIPTION
Some wagons can find their own authentication. For example, the S3 wagon can
use IAM roles if it's running on an EC2 instance. For these wagons, all we need
to do is get out of the way.