### PR TITLE
Don't trigger implicit-aot-warning on regex match

### DIFF
--- a/src/leiningen/compile.clj
+++ b/src/leiningen/compile.clj
@@ -7,7 +7,7 @@
   (:refer-clojure :exclude [compile])
   (:import (java.io PushbackReader File)))
 
-(defn- regex? [str-or-re]
+(defn regex? [str-or-re]
   (instance? java.util.regex.Pattern str-or-re))
 
 (defn- matching-nses [re-or-sym namespaces]

--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -248,7 +248,8 @@
                (not= :all (:aot project))
                (not= [:all] (:aot project))
                (not (some #{(:main project)} (:aot project)))
-               (not (some #(re-matches % (:main project)) (filter compile/regex? (:aot project)))))
+               (not (some #(re-matches % (str (:main project)))
+                          (filter compile/regex? (:aot project)))))
       (force implicit-aot-warning))))
 
 ;; TODO: remove for 3.0

--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -246,7 +246,8 @@
     (when (and (:main project) (not (:skip-aot (meta (:main project))))
                (not= :all (:aot project))
                (not= [:all] (:aot project))
-               (not (some #{(:main project)} (:aot project))))
+               (not (some #{(:main project)} (:aot project)))
+               (not (some #(re-matches % (:main project)) (filter regex? (:aot project)))))
       (force implicit-aot-warning))))
 
 ;; TODO: remove for 3.0

--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -2,6 +2,7 @@
   "Package up all the project's files into a jar file."
   (:require [leiningen.pom :as pom]
             [leiningen.clean :as clean]
+            [leiningen.compile :as compile]
             [leiningen.core.classpath :as classpath]
             [leiningen.core.project :as project]
             [leiningen.core.eval :as eval]
@@ -247,7 +248,7 @@
                (not= :all (:aot project))
                (not= [:all] (:aot project))
                (not (some #{(:main project)} (:aot project)))
-               (not (some #(re-matches % (:main project)) (filter regex? (:aot project)))))
+               (not (some #(re-matches % (:main project)) (filter compile/regex? (:aot project)))))
       (force implicit-aot-warning))))
 
 ;; TODO: remove for 3.0


### PR DESCRIPTION
Prevent the implicit-aot-warning from triggering if `:aot` contains a regex matching the main namespace, e.g. if `project.clj` contains something like:
```clojure
:main project.core
:aot [#".*"]
```
I'm not sure if this is the best way to fix this, and I haven't actually tried it out, so consider this more of a bug report than the actual fix.