### PR TITLE
don't parse broken scm params from non-github URLs

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -74,7 +74,7 @@
   "Parses a GitHub URL returning a [username repo] pair."
   [url]
   (if url
-    (rest
+    (next
      (or (re-matches #"(?:[A-Za-z_]{2,}@)?github.com:([^/]+)/([^/]+).git" url)
          (re-matches #"[^:]+://(?:[A-Za-z_]{2,}@)?github.com/([^/]+)/([^/]+).git" url)))))
 


### PR DESCRIPTION
return nil instead of the empty list from parse-github-url. Otherwise
we end up with broken connection and developerConnection params in pom
files when not using github, like in:

  &lt;scm&gt;
    &lt;connection&gt;scm:git:git://github.com//.git&lt;/connection&gt;
    &lt;developerConnection&gt;scm:git:ssh://git@github.com//.git&lt;/developerConnection&gt;
    &lt;tag&gt;03299434f4af53bde0fd4f4000174ae7a7ee0818
&lt;/tag&gt;
    &lt;url&gt;https://github.com//&lt;/url&gt;
  &lt;/scm&gt;

With this change, the scm section for non-github URLs looks like:

  &lt;scm&gt;
    &lt;tag&gt;03299434f4af53bde0fd4f4000174ae7a7ee0818
&lt;/tag&gt;
    &lt;url/&gt;
  &lt;/scm&gt;

