### PR TITLE
Update CHNAGELOG.md templates

### DIFF
--- a/resources/leiningen/new/app/CHANGELOG.md
+++ b/resources/leiningen/new/app/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased][unreleased]
+## [Unreleased]
 ### Changed
 - Add a new arity to `make-widget-async` to provide a different widget shape.
 
@@ -20,5 +20,5 @@ All notable changes to this project will be documented in this file. This change
 - Files from the new template.
 - Widget maker public API - `make-widget-sync`.
 
-[unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
+[Unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
 [0.1.1]: https://github.com/your-name/{{name}}/compare/0.1.0...0.1.1

--- a/resources/leiningen/new/default/CHANGELOG.md
+++ b/resources/leiningen/new/default/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased][unreleased]
+## [Unreleased]
 ### Changed
 - Add a new arity to `make-widget-async` to provide a different widget shape.
 
@@ -20,5 +20,5 @@ All notable changes to this project will be documented in this file. This change
 - Files from the new template.
 - Widget maker public API - `make-widget-sync`.
 
-[unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
+[Unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
 [0.1.1]: https://github.com/your-name/{{name}}/compare/0.1.0...0.1.1

--- a/resources/leiningen/new/plugin/CHANGELOG.md
+++ b/resources/leiningen/new/plugin/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased][unreleased]
+## [Unreleased]
 ### Changed
 - Add a new arity to `make-widget-async` to provide a different widget shape.
 
@@ -20,5 +20,5 @@ All notable changes to this project will be documented in this file. This change
 - Files from the new template.
 - Widget maker public API - `make-widget-sync`.
 
-[unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
+[Unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
 [0.1.1]: https://github.com/your-name/{{name}}/compare/0.1.0...0.1.1

--- a/resources/leiningen/new/template/CHANGELOG.md
+++ b/resources/leiningen/new/template/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased][unreleased]
+## [Unreleased]
 ### Changed
 - Add a new arity to `make-widget-async` to provide a different widget shape.
 
@@ -20,5 +20,5 @@ All notable changes to this project will be documented in this file. This change
 - Files from the new template.
 - Widget maker public API - `make-widget-sync`.
 
-[unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
+[Unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
 [0.1.1]: https://github.com/your-name/{{name}}/compare/0.1.0...0.1.1


### PR DESCRIPTION
https://github.com/olivierlacan/keep-a-changelog/pull/72 shortens linkage to `Unreleased` link, so I update these CHNAGELOG.md templates in order to follow it.