### PR TITLE
allow subprocesses to shutdown gracefully

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -170,7 +170,8 @@
   (let [env (overridden-env *env*)
         proc (.exec (Runtime/getRuntime) (into-array String cmd) env (io/file *dir*))]
     (.addShutdownHook (Runtime/getRuntime)
-                      (Thread. (fn [] (.destroy proc))))
+                      (Thread. (fn [] (let [in (.getOutputStream proc)]
+                                  (.write in 3)))))
     (with-open [out (.getInputStream proc)
                 err (.getErrorStream proc)
                 in (.getOutputStream proc)]


### PR DESCRIPTION
addresses 'lein run messes with shutdown hooks #1854'

solution based on this thread in core-libs-dev mailing list:
http://mail.openjdk.java.net/pipermail/core-libs-dev/2014-March/025525.html

Instead of terminating the subprocess outright with Process.destroy, this
patch opens a outputstream to the subprocess stdin and sends Ctrl-C to end
it.  This allows the subprocess to call its own shutdown hooks.

A with-open is NOT used here because after the process terminates, there's
nothing to close and it throws IOException Stream Closed.