### PR TITLE
Bump the nREPL dep to 0.2.12

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                                jakarta-regexp]]
                  [reply "0.3.7" :exclusions [ring/ring-core
                                              org.thnetos/cd-client]]
-                 [org.clojure/tools.nrepl "0.2.10"]
+                 [org.clojure/tools.nrepl "0.2.12"]
                  [clojure-complete "0.2.3"]
                  ;; bump versions of various common transitive deps
                  [slingshot "0.10.3"]


### PR DESCRIPTION
nREPL 0.2.11 added an extremely important source-tracking feature, which is leveraged by CIDER (and probably some other tools). 0.2.12 fixed a critical bug introduced in 0.2.11.