### PR TITLE
Don't preset JAVA_CMD. Refs #2009

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -222,12 +222,7 @@ else # Not running from a checkout
     fi
 fi
 
-if [ -z "$JAVA_CMD" ]
-then
-    JAVA_CMD=$(which java)
-fi
-
-if [ ! -x "$JAVA_CMD" ]
+if [ ! -x "$JAVA_CMD" ] && ! type -f java >/dev/null
 then
     >&2 echo "Leiningen coundn't find 'java' executable, which is required."
     >&2 echo "Please either set JAVA_CMD or put java (>=1.6) in your \$PATH ($PATH)."
@@ -235,7 +230,7 @@ then
 fi
 
 export JAVA_CMD
-export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-$JAVA_CMD}"
+export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-java}"
 
 if [[ -z "${DRIP_INIT+x}" && "$(basename "$LEIN_JAVA_CMD")" == *drip* ]]; then
     export DRIP_INIT="$(printf -- '-e\n(require (quote leiningen.repl))')"


### PR DESCRIPTION
Because on Cygwin JAVA_CMD will be set to an UNIX path. This will result
in a "File not found" exception when the native Leiningen JAVA process
will execute JAVA_CMD.

Also use shell builtin "type" fs external "which" 