### PR TITLE
Modify tiered-jvm-opts for :base profile

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -468,7 +468,8 @@
 (def tiered-jvm-opts
   (if (.contains (or (System/getenv "LEIN_JVM_OPTS") "") "Tiered")
     ["-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1"
-     "-XX:-OmitStackTraceInFastThrow"] []))
+     "-XX:-OmitStackTraceInFastThrow"]
+    ["-XX:-OmitStackTraceInFastThrow"]))
 
 
 (def default-profiles


### PR DESCRIPTION
Fix for #2035 to always prevent "trace missing" messages by default when exceptions occur.