### PR TITLE
(#2043) `release` task: support SNAPSHOTs on qualifiers

### DIFF
--- a/test/leiningen/test/release.clj
+++ b/test/leiningen/test/release.clj
@@ -12,55 +12,151 @@
    {:major 1
     :minor 0
     :patch 0
-    :qualifier nil}
+    :qualifier nil
+    :snapshot nil}
    {:major "2.0.0-SNAPSHOT"
     :minor "1.1.0-SNAPSHOT"
-    :patch "1.0.1-SNAPSHOT"}]
+    :patch "1.0.1-SNAPSHOT"
+    :release "1.0.0"
+    :alpha "1.0.0-alpha1-SNAPSHOT"
+    :beta "1.0.0-beta1-SNAPSHOT"
+    :rc "1.0.0-RC1-SNAPSHOT"
+    :qualifier "1.0.0-1-SNAPSHOT"}]
 
    ["1.2.3"
    {:major 1
     :minor 2
     :patch 3
-    :qualifier nil}
+    :qualifier nil
+    :snapshot nil}
    {:major "2.0.0-SNAPSHOT"
     :minor "1.3.0-SNAPSHOT"
-    :patch "1.2.4-SNAPSHOT"}]
+    :patch "1.2.4-SNAPSHOT"
+    :release "1.2.3"
+    :alpha "1.2.3-alpha1-SNAPSHOT"
+    :beta "1.2.3-beta1-SNAPSHOT"
+    :rc "1.2.3-RC1-SNAPSHOT"
+    :qualifier "1.2.3-1-SNAPSHOT"}]
 
    ["1.2.3-herp"
    {:major 1
     :minor 2
     :patch 3
-    :qualifier "herp"}
+    :qualifier "herp"
+    :snapshot nil}
    {:major "2.0.0-SNAPSHOT"
     :minor "1.3.0-SNAPSHOT"
     :patch "1.2.4-SNAPSHOT"
-    :release "1.2.3"}]
+    :release "1.2.3"
+    :alpha "1.2.3-alpha1-SNAPSHOT"
+    :beta "1.2.3-beta1-SNAPSHOT"
+    :rc "1.2.3-RC1-SNAPSHOT"
+    :qualifier "1.2.3-herp1-SNAPSHOT"}]
 
    ["1.0.0-SNAPSHOT"
    {:major 1
     :minor 0
     :patch 0
-    :qualifier "SNAPSHOT"}
+    :qualifier nil
+    :snapshot "SNAPSHOT"}
    {:major "2.0.0-SNAPSHOT"
     :minor "1.1.0-SNAPSHOT"
     :patch "1.0.1-SNAPSHOT"
     :release "1.0.0"
-    :alpha "1.0.0-alpha1"
-    :beta "1.0.0-beta1"
-    :rc "1.0.0-RC1"}]
+    :alpha "1.0.0-alpha1-SNAPSHOT"
+    :beta "1.0.0-beta1-SNAPSHOT"
+    :rc "1.0.0-RC1-SNAPSHOT"
+    :qualifier "1.0.0-1-SNAPSHOT"}]
 
    ["1.0.0-alpha1"
    {:major 1
     :minor 0
     :patch 0
-    :qualifier "alpha1"}
+    :qualifier "alpha1"
+    :snapshot nil}
    {:major "2.0.0-SNAPSHOT"
     :minor "1.1.0-SNAPSHOT"
     :patch "1.0.1-SNAPSHOT"
     :release "1.0.0"
-    :alpha "1.0.0-alpha2"
-    :beta "1.0.0-beta1"
-    :rc "1.0.0-RC1"}]])
+    :alpha "1.0.0-alpha2-SNAPSHOT"
+    :beta "1.0.0-beta1-SNAPSHOT"
+    :rc "1.0.0-RC1-SNAPSHOT"
+    :qualifier "1.0.0-alpha2-SNAPSHOT"}]
+
+   ["1.0.0-alpha1-SNAPSHOT"
+    {:major 1
+     :minor 0
+     :patch 0
+     :qualifier "alpha1"
+     :snapshot "SNAPSHOT"}
+    {:major "2.0.0-SNAPSHOT"
+     :minor "1.1.0-SNAPSHOT"
+     :patch "1.0.1-SNAPSHOT"
+     :release "1.0.0-alpha1"
+     :alpha "1.0.0-alpha2-SNAPSHOT"
+     :beta "1.0.0-beta1-SNAPSHOT"
+     :rc "1.0.0-RC1-SNAPSHOT"
+     :qualifier "1.0.0-alpha2-SNAPSHOT"}]
+
+   ["1.0.0-beta1"
+    {:major 1
+     :minor 0
+     :patch 0
+     :qualifier "beta1"
+     :snapshot nil}
+    {:major "2.0.0-SNAPSHOT"
+     :minor "1.1.0-SNAPSHOT"
+     :patch "1.0.1-SNAPSHOT"
+     :release "1.0.0"
+     :alpha "1.0.0-alpha1-SNAPSHOT"
+     :beta "1.0.0-beta2-SNAPSHOT"
+     :rc "1.0.0-RC1-SNAPSHOT"
+     :qualifier "1.0.0-beta2-SNAPSHOT"}]
+
+   ["1.0.0-RC2-SNAPSHOT"
+    {:major 1
+     :minor 0
+     :patch 0
+     :qualifier "RC2"
+     :snapshot "SNAPSHOT"}
+    {:major "2.0.0-SNAPSHOT"
+     :minor "1.1.0-SNAPSHOT"
+     :patch "1.0.1-SNAPSHOT"
+     :release "1.0.0-RC2"
+     :alpha "1.0.0-alpha1-SNAPSHOT"
+     :beta "1.0.0-beta1-SNAPSHOT"
+     :rc "1.0.0-RC3-SNAPSHOT"
+     :qualifier "1.0.0-RC3-SNAPSHOT"}]
+
+   ["1.2.3-herp2"
+    {:major 1
+     :minor 2
+     :patch 3
+     :qualifier "herp2"
+     :snapshot nil}
+    {:major "2.0.0-SNAPSHOT"
+     :minor "1.3.0-SNAPSHOT"
+     :patch "1.2.4-SNAPSHOT"
+     :release "1.2.3"
+     :alpha "1.2.3-alpha1-SNAPSHOT"
+     :beta "1.2.3-beta1-SNAPSHOT"
+     :rc "1.2.3-RC1-SNAPSHOT"
+     :qualifier "1.2.3-herp3-SNAPSHOT"}]
+
+   ["1.2.3-25"
+    {:major 1
+     :minor 2
+     :patch 3
+     :qualifier "25"
+     :snapshot nil}
+    {:major "2.0.0-SNAPSHOT"
+     :minor "1.3.0-SNAPSHOT"
+     :patch "1.2.4-SNAPSHOT"
+     :release "1.2.3"
+     :alpha "1.2.3-alpha1-SNAPSHOT"
+     :beta "1.2.3-beta1-SNAPSHOT"
+     :rc "1.2.3-RC1-SNAPSHOT"
+     :qualifier "1.2.3-26-SNAPSHOT"}]])
 
 (deftest test-string->semantic-version
   (testing "Testing semantic version string parsing"
@@ -88,6 +184,7 @@
 (deftest version-map->string-valid
   (doseq [[string parsed bumps] valid-semver-version-values]
     (is (= string (version-map->string parsed)))
-    (doseq [[level string] bumps]
-      (is (= (merge {:qualifier nil} (bump-version-map parsed level))
-             (parse-semantic-version string))))))
+    (doseq [[level expected-bumped-string] bumps]
+      (let [bumped (bump-version-map parsed level)]
+        (is (= bumped (parse-semantic-version expected-bumped-string)))
+        (is (= expected-bumped-string (version-map->string bumped)))))))


### PR DESCRIPTION
Prior to this commit, the `lein release` task was not
really usable for releases that had qualifiers such
as `-alpha1`, `-beta2`, or `-RC1`.

The reason for this is that the code for parsing the
semver could not handle a qualifier like `-alpha1`
AND a `-SNAPSHOT` qualifier at the same time.

The default `:release-tasks` include a `bump-version`
at the `:release` level, and then the release, and
then a `bump-version` at the `:patch` level.  If
you had a version that started out as `1.0.0-alpha1` *or*
`1.0.0-alpha1-SNAPSHOT`, then the `:release` bump
would always set the version to `1.0.0`.  Then the
actual release would occur, and then the `:patch` bump
would take you to `1.0.1-SNAPSHOT`.

With this commit, `qualifier` and `snapshot` are
separated into two separate fields in the version map.
This allows us to modify the `bump-version` behavior
so that it works as one would expect with a qualifier
like `alpha`:

```clj
(is (= (bump-version "1.0.0-alpha1-SNAPSHOT" :release)
       "1.0.0-alpha1"))
(is (= (bump-version "1.0.0-alpha1")
       "1.0.0-alpha2-SNAPSHOT"))
```

This allows the default `:release-tasks` setup to be
used with qualifiers like alpha/beta.

The commit also adds a new `level` that can be passed
to the `change` task: `:qualifier`.  If this level
is passed, then the qualifier will be incremented
instead of the major/minor/patch.  It is a superset
of the existing alpha/beta/RC behavior but works with
arbitrary qualifier strings.