### PR TITLE
Gpg piping fix

### DIFF
--- a/leiningen-core/src/leiningen/core/user.clj
+++ b/leiningen-core/src/leiningen/core/user.clj
@@ -139,7 +139,8 @@
            (println "Could not decrypt credentials from" (str file))
            (println err)
            (println "See `lein help gpg` for how to install gpg."))
-         (read-string out)))))
+         (binding [*read-eval* false]
+           (read-string out))))))
 
 (def credentials (memoize credentials-fn))
 


### PR DESCRIPTION
This fixes #2062 as discussed in the issue.

Also, I `*read-eval*` is now bound to false when reading (untrusted) `credendials.clj.gpg`.