### PR TITLE
Add docs for providing :jvm-opts

### DIFF
--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -1,3 +1,26 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Deploying Libraries](#deploying-libraries)
+  - [Private Repositories](#private-repositories)
+    - [Static HTTP](#static-http)
+    - [SCP](#scp)
+    - [S3](#s3)
+    - [Artifactory/Nexus/Archiva](#artifactorynexusarchiva)
+    - [Other Non-standard Repository Protocols](#other-non-standard-repository-protocols)
+  - [Authentication](#authentication)
+    - [GPG](#gpg)
+    - [Full-disk Encryption](#full-disk-encryption)
+    - [Credentials in the Environment](#credentials-in-the-environment)
+  - [Deployment](#deployment)
+  - [Releasing Simplified](#releasing-simplified)
+    - [Overriding the default `:release-tasks`](#overriding-the-default-release-tasks)
+    - [Tagging](#tagging)
+  - [Deploying to Maven Central](#deploying-to-maven-central)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Deploying Libraries
 
 Getting your library into [Clojars](http://clojars.org) is fairly

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [FAQ](#faq)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # FAQ
 
 **Q:** How do you pronounce Leiningen?  

--- a/doc/GPG.md
+++ b/doc/GPG.md
@@ -1,3 +1,32 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Using GPG](#using-gpg)
+  - [What is it?](#what-is-it)
+  - [Installing GPG](#installing-gpg)
+    - [Linux](#linux)
+        - [Debian based distributions](#debian-based-distributions)
+      - [Fedora based distributions](#fedora-based-distributions)
+    - [Mac](#mac)
+    - [Windows](#windows)
+  - [Creating a keypair](#creating-a-keypair)
+  - [Listing keys](#listing-keys)
+  - [Publishing your public key](#publishing-your-public-key)
+  - [How Leiningen uses GPG](#how-leiningen-uses-gpg)
+    - [Signing a file](#signing-a-file)
+    - [Overriding the gpg defaults](#overriding-the-gpg-defaults)
+  - [Clojars](#clojars)
+  - [Troubleshooting](#troubleshooting)
+    - [Debian based distributions](#debian-based-distributions-1)
+      - [gpg: can't query passphrase in batch mode](#gpg-cant-query-passphrase-in-batch-mode)
+    - [Mac OSX](#mac-osx)
+      - [Unable to get GPG installed via Homebrew and OSX Keychain to work](#unable-to-get-gpg-installed-via-homebrew-and-osx-keychain-to-work)
+      - [GPG doesn't ask for a passphrase](#gpg-doesnt-ask-for-a-passphrase)
+    - [GPG prompts for passphrase but does not work with Leiningen](#gpg-prompts-for-passphrase-but-does-not-work-with-leiningen)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Using GPG
 
 This is an introduction to setting up and using

--- a/doc/MIXED_PROJECTS.md
+++ b/doc/MIXED_PROJECTS.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Polyglot (Clojure, Java) Projects With Leiningen](#polyglot-clojure-java-projects-with-leiningen)
+  - [Source Layout](#source-layout)
+  - [Java Source Compilation](#java-source-compilation)
+  - [Setting Java Compiler Options With Leiningen](#setting-java-compiler-options-with-leiningen)
+  - [Interleaving Compilation Steps](#interleaving-compilation-steps)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Polyglot (Clojure, Java) Projects With Leiningen
 
 Clojure is a hosted language that encourages interoperability with its

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -1,3 +1,31 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Leiningen Plugins](#leiningen-plugins)
+  - [Writing a Plugin](#writing-a-plugin)
+    - [Local development](#local-development)
+    - [Task Arguments](#task-arguments)
+    - [Documentation and subtasks](#documentation-and-subtasks)
+  - [Code Evaluation](#code-evaluation)
+    - [Evaluating In Project Context](#evaluating-in-project-context)
+  - [Other Plugin Contents](#other-plugin-contents)
+    - [Profiles](#profiles)
+    - [Hooks](#hooks)
+    - [Project Middleware](#project-middleware)
+    - [Maven Wagons](#maven-wagons)
+    - [VCS Methods](#vcs-methods)
+  - [Requiring Plugins](#requiring-plugins)
+  - [Clojure Version](#clojure-version)
+  - [Upgrading Existing Plugins](#upgrading-existing-plugins)
+  - [Projects vs Standalone Execution](#projects-vs-standalone-execution)
+  - [Overriding Built-in Tasks](#overriding-built-in-tasks)
+  - [1.x Compatibility](#1x-compatibility)
+    - [Project-specific Tasks](#project-specific-tasks)
+  - [Have Fun](#have-fun)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 [Japanese](ja/PLUGINS_ja.md)
 
 # Leiningen Plugins

--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -1,3 +1,21 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Profiles](#profiles)
+  - [Declaring Profiles](#declaring-profiles)
+  - [Default Profiles](#default-profiles)
+  - [Task Specific Profiles](#task-specific-profiles)
+    - [Replacing Default Repl Dependencies](#replacing-default-repl-dependencies)
+  - [Profile Metadata](#profile-metadata)
+  - [Merging](#merging)
+  - [Activating Profiles](#activating-profiles)
+  - [Composite Profiles](#composite-profiles)
+  - [Dynamic Eval](#dynamic-eval)
+  - [Debugging](#debugging)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Profiles
 
 You can change the configuration of your project by applying various

--- a/doc/TEMPLATES.md
+++ b/doc/TEMPLATES.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Writing Templates](#writing-templates)
+  - [Structure](#structure)
+  - [Templating System](#templating-system)
+      - [A warning about Mustache tag delimiters](#a-warning-about-mustache-tag-delimiters)
+  - [Distributing your Template](#distributing-your-template)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Writing Templates
 
 Suppose you've written a fabulously popular library, used the world

--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -1,33 +1,36 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Tutorial](#tutorial)
-	- [What This Tutorial Covers](#what-this-tutorial-covers)
-	- [Getting Help](#getting-help)
-	- [Leiningen Projects](#leiningen-projects)
-	- [Creating a Project](#creating-a-project)
-		- [Directory Layout](#directory-layout)
-		- [Filename-to-Namespace Mapping Convention](#filename-to-namespace-mapping-convention)
-	- [project.clj](#projectclj)
-	- [Dependencies](#dependencies)
-		- [Overview](#overview)
-		- [Artifact IDs, Groups, and Versions](#artifact-ids-groups-and-versions)
-		- [Snapshot Versions](#snapshot-versions)
-		- [Repositories](#repositories)
-		- [Checkout Dependencies](#checkout-dependencies)
-		- [Search](#search)
-	- [Running Code](#running-code)
-	- [Tests](#tests)
-	- [Profiles](#profiles)
-	- [What to do with it](#what-to-do-with-it)
-		- [Uberjar](#uberjar)
-		- [Framework (Uber)jars](#framework-uberjars)
-		- [Server-side Projects](#server-side-projects)
-		- [Publishing Libraries](#publishing-libraries)
-	- [That's It!](#thats-it!)
+  - [What This Tutorial Covers](#what-this-tutorial-covers)
+  - [Getting Help](#getting-help)
+  - [Leiningen Projects](#leiningen-projects)
+  - [Creating a Project](#creating-a-project)
+    - [Directory Layout](#directory-layout)
+    - [Filename-to-Namespace Mapping Convention](#filename-to-namespace-mapping-convention)
+  - [project.clj](#projectclj)
+  - [Dependencies](#dependencies)
+    - [Overview](#overview)
+    - [Artifact IDs, Groups, and Versions](#artifact-ids-groups-and-versions)
+    - [Snapshot Versions](#snapshot-versions)
+    - [Repositories](#repositories)
+    - [Checkout Dependencies](#checkout-dependencies)
+    - [Search](#search)
+  - [Setting JVM Options](#setting-jvm-options)
+  - [Running Code](#running-code)
+  - [Tests](#tests)
+  - [Profiles](#profiles)
+  - [What to do with it](#what-to-do-with-it)
+    - [Uberjar](#uberjar)
+    - [Framework (Uber)jars](#framework-uberjars)
+    - [Server-side Projects](#server-side-projects)
+    - [Publishing Libraries](#publishing-libraries)
+  - [That's It!](#thats-it)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
 
 # Tutorial
 
@@ -354,6 +357,25 @@ These prefixes allow you to execute more advanced queries such as:
 
 `lein search` also accepts a second, optional parameter for fetching
 successive pages, e.g. `lein search clojure 2`.
+
+## Setting JVM Options
+
+To pass extra arguments to the JVM, set the `:jvm-opts` vector. This will override any default JVM opts set by Leiningen.
+
+```clj
+ :jvm-opts ["-Xmx1g"]
+```
+
+If you want to pass [compiler options](http://clojure.org/reference/compilation#_compiler_options) to the Clojure compiler, you also do this here.
+
+```
+:jvm-opts ["-Dclojure.compiler.disable-locals-clearing=true"
+           "-Dclojure.compiler.elide-meta=[:doc :file :line :added]" 
+           ; notice the array is not quoted like it would be if you passed it directly on the command line.
+           "-Dclojure.compiler.direct-linking=true"]
+```
+
+You can also pass options to Leiningen in the `JVM_OPTS` environment variable. If you want to provide the Leiningen JVM with custom options, set them in `LEIN_JVM_OPTS`.
 
 ## Running Code
 

--- a/doc/ja/PLUGINS_ja.md
+++ b/doc/ja/PLUGINS_ja.md
@@ -1,3 +1,30 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Leiningen プラグイン](#leiningen-%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3)
+  - [プラグインを書く](#%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%82%92%E6%9B%B8%E3%81%8F)
+    - [タスクの引数](#%E3%82%BF%E3%82%B9%E3%82%AF%E3%81%AE%E5%BC%95%E6%95%B0)
+    - [ドキュメンテーション](#%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%83%86%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3)
+  - [コード評価](#%E3%82%B3%E3%83%BC%E3%83%89%E8%A9%95%E4%BE%A1)
+    - [プロジェクトコンテクスト内での評価](#%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AF%E3%82%B9%E3%83%88%E5%86%85%E3%81%A7%E3%81%AE%E8%A9%95%E4%BE%A1)
+  - [他のプラグインコンテンツ](#%E4%BB%96%E3%81%AE%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84)
+    - [プロファイル](#%E3%83%97%E3%83%AD%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB)
+    - [フック](#%E3%83%95%E3%83%83%E3%82%AF)
+    - [プロジェクト ミドルウェア](#%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88-%E3%83%9F%E3%83%89%E3%83%AB%E3%82%A6%E3%82%A7%E3%82%A2)
+    - [Maven Wagon](#maven-wagon)
+    - [VCSメソッド](#vcs%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89)
+  - [プラグインの呼び出し](#%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%AE%E5%91%BC%E3%81%B3%E5%87%BA%E3%81%97)
+  - [Clojureのバージョン](#clojure%E3%81%AE%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3)
+  - [既存のプラグインのアップグレード](#%E6%97%A2%E5%AD%98%E3%81%AE%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%AE%E3%82%A2%E3%83%83%E3%83%97%E3%82%B0%E3%83%AC%E3%83%BC%E3%83%89)
+  - [プロジェクト vs スタンドアロンでの実行](#%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88-vs-%E3%82%B9%E3%82%BF%E3%83%B3%E3%83%89%E3%82%A2%E3%83%AD%E3%83%B3%E3%81%A7%E3%81%AE%E5%AE%9F%E8%A1%8C)
+  - [標準タスクの上書き](#%E6%A8%99%E6%BA%96%E3%82%BF%E3%82%B9%E3%82%AF%E3%81%AE%E4%B8%8A%E6%9B%B8%E3%81%8D)
+  - [1.x互換性](#1x%E4%BA%92%E6%8F%9B%E6%80%A7)
+    - [特定のプロジェクト向けタスク](#%E7%89%B9%E5%AE%9A%E3%81%AE%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E5%90%91%E3%81%91%E3%82%BF%E3%82%B9%E3%82%AF)
+  - [楽しんでください](#%E6%A5%BD%E3%81%97%E3%82%93%E3%81%A7%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 [English](../PLUGINS.md)
 
 # Leiningen プラグイン


### PR DESCRIPTION
I wasn't quite sure where to put this. TUTORIAL seemed reasonable, though I'd be open to other places to, or maybe a new docs section explaining in more detail Leiningen options?