### PR TITLE
Upgrade clojure-complete from 0.2.3 to 0.2.4

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -486,7 +486,7 @@
                 ;; bump deps in leiningen's own project.clj with these
                 :dependencies '[^:displace [org.clojure/tools.nrepl "0.2.12"
                                             :exclusions [org.clojure/clojure]]
-                                ^:displace [clojure-complete "0.2.3"
+                                ^:displace [clojure-complete "0.2.4"
                                             :exclusions [org.clojure/clojure]]]
                 :checkout-deps-shares [:source-paths
                                        :test-paths

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -43,7 +43,7 @@
                                [stencil/stencil "0.2.0"]
                                [org.clojure/tools.nrepl "0.2.12"
                                 :exclusions [[org.clojure/clojure]]]
-                               [clojure-complete/clojure-complete "0.2.3"
+                               [clojure-complete/clojure-complete "0.2.4"
                                 :exclusions [[org.clojure/clojure]]]],
                :twelve 12 ; testing unquote
 

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                  [reply "0.3.7" :exclusions [ring/ring-core
                                              org.thnetos/cd-client]]
                  [org.clojure/tools.nrepl "0.2.12"]
-                 [clojure-complete "0.2.3"]
+                 [clojure-complete "0.2.4"]
                  ;; bump versions of various common transitive deps
                  [slingshot "0.10.3"]
                  [cheshire "5.5.0"]


### PR DESCRIPTION
0.2.4 contains type hints to eliminate reflection warnings. The diff between 0.2.3 and 0.2.4 is https://github.com/ninjudd/clojure-complete/compare/0.2.3...0.2.4. It doesn't look like there's anything too objectionable in there.