### PR TITLE
Remove potemkin dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,6 @@
                  [slingshot "0.10.3"]
                  [cheshire "5.5.0"]
                  [clj-http "2.0.0"]
-                 [potemkin "0.4.1"]
                  [net.cgrand/parsley "0.9.3" :exclusions [org.clojure/clojure]]]
   ;; checkout-deps don't work with :eval-in :leiningen
   :profiles {:dev {:resource-paths ["leiningen-core/dev-resources"]


### PR DESCRIPTION
It doesn't seem like Potemkin is being used anywhere in Leiningen, so it could be removed?

There would probably need to be a warning in the upgrade process, as some plugins may have transitive dependencies on Potemkin.