### PR TITLE
Honor whitelist settings when javac called via jar - fixes #2089

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -837,6 +837,16 @@
                           :excluded-profiles exclude-profiles
                           :profile-inherited-meta include-profiles-meta}))))
 
+(def whitelist-keys
+  "Project keys which don't affect the production of the jar (sans its name)
+  should be propagated to the compilation phase and not stripped out."
+  [:offline? :local-repo :certificates :warn-on-reflection :mirrors :uberjar-name :jar-name])
+
+(defn retain-whitelisted-keys
+  "Retains the whitelisted keys from the original map in the new one."
+  [new original]
+  (merge new (select-keys original whitelist-keys)))
+
 ;; # High-level profile operations
 
 (defn set-profiles

--- a/src/leiningen/javac.clj
+++ b/src/leiningen/javac.clj
@@ -98,6 +98,14 @@
        (abort# "Java compiler not found; Be sure to use java from a JDK\n"
                "rather than a JRE by modifying PATH or setting JAVA_CMD."))))
 
+(defn javac-project-for-subprocess
+  "Merge profiles to create project appropriate for javac subprocess.  This
+  function is mostly extracted to simplify testing, to validate that settings
+  like `:local-repo` and `:mirrors` are respected."
+  [project subprocess-profile]
+  (-> (project/merge-profiles project [subprocess-profile])
+      (project/retain-whitelisted-keys project)))
+
 ;; We can't really control what is printed here. We're just going to
 ;; allow `.run` to attach in, out, and err to the standard streams. This
 ;; should have the effect of compile errors being printed. javac doesn't
@@ -117,7 +125,7 @@
       (try
         (binding [eval/*pump-in* false]
           (eval/eval-in
-           (project/merge-profiles project [subprocess-profile])
+           (javac-project-for-subprocess project subprocess-profile)
            form))
         (catch Exception e
           (if-let [exit-code (:exit-code (ex-data e))]

--- a/src/leiningen/uberjar.clj
+++ b/src/leiningen/uberjar.clj
@@ -168,7 +168,7 @@ be deactivated."
        (with-open [out (-> standalone-filename
                            (FileOutputStream.)
                            (ZipOutputStream.))]
-         (let [whitelisted (select-keys project jar/whitelist-keys)
+         (let [whitelisted (select-keys project project/whitelist-keys)
                project (-> (project/unmerge-profiles project [:default])
                            (merge whitelisted))
                deps (->> (classpath/resolve-dependencies :dependencies project)

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -15,12 +15,15 @@
   (io/file local-repo
            (if (string? n) n (or (namespace n) (name n))) (name n) v))
 
-(defn- read-test-project [name]
-  (with-redefs [user/profiles (constantly {})]
+(defn read-test-project-with-user-profiles [name user-profiles]
+  (with-redefs [user/profiles (constantly user-profiles)]
     (let [project (project/read (format "test_projects/%s/project.clj" name))]
       (project/init-project
        (project/project-with-profiles-meta
-         project (merge @project/default-profiles (:profiles project)))))))
+        project (merge @project/default-profiles (:profiles project)))))))
+
+(defn read-test-project [name]
+  (read-test-project-with-user-profiles name {}))
 
 (def with-resources-project (read-test-project "with-resources"))
 


### PR DESCRIPTION
This commit refactors a few things from the `jar` and
`javac` tasks in order to ensure that the "whitelisted"
settings from the user profile (`:local-repo`, `:mirrors`,
etc.) are honored when the `jar` task launches `javac`.

It also adds a test to validate the new behavior.