### PR TITLE
Fix file handle leak in pom.properties FAQ

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -144,8 +144,9 @@
   your project):
 
 ```clj
-(doto (java.util.Properties.)
-  (.load (io/reader (io/resource "META-INF/maven/group/artifact/pom.properties"))))
+(with-open [pom-properties-reader (io/reader (io/resource "META-INF/maven/group/artifact/pom.properties"))]
+  (doto (java.util.Properties.)
+    (.load pom-properties-reader)))
 ```
 
 **Q:** How can I read my project map at runtime?  


### PR DESCRIPTION
There was a file handle leak in the code as it was. It would never close the open reader against the jar resource. This will eventually cause JVM to be unable to open new files.

Functional Tests
----------------------

I'm using the code as I wrote it in my own project and there is now no file handle leak.