### PR TITLE
Avoid lein jar on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ on your `PATH` and running `lein self-install` should still work for
 most users. If you have [Cygwin](http://www.cygwin.com/) you should be
 able to use the shell script above rather than the batch file.
 
+N.B.: Avoid using a LEIN_JAR environment variable. If you have one instance of Leiningen on your PATH as well as a LEIN_JAR pointing to a different instance, there is a known problem where `lein -v` and `lein update` will refer to the first instance, while usage of Leiningen, such as `lein new foobar`, will refer to the latter.
+
 ## Basic Usage
 
 The

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ on your `PATH` and running `lein self-install` should still work for
 most users. If you have [Cygwin](http://www.cygwin.com/) you should be
 able to use the shell script above rather than the batch file.
 
-N.B.: Avoid using a LEIN_JAR environment variable. If you have one instance of Leiningen on your PATH as well as a LEIN_JAR pointing to a different instance, there is a known problem where `lein -v` and `lein update` will refer to the first instance, while usage of Leiningen, such as `lein new foobar`, will refer to the latter.
+N.B.: Avoid using a LEIN_JAR environment variable.
+If you have one instance of Leiningen on your PATH as well as a LEIN_JAR
+pointing to a different instance, there is a known problem where `lein -v` and
+`lein update` will refer to the first instance, while usage of Leiningen, such
+as `lein new foobar`, will refer to the latter.
 
 ## Basic Usage
 

--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -19,7 +19,9 @@ call :FIND_DIR_CONTAINING_UPWARDS project.clj
 if "%DIR_CONTAINING%" neq "" cd "%DIR_CONTAINING%"
 
 :: LEIN_JAR and LEIN_HOME variables can be set manually.
-:: Only set LEIN_JAR manually if you know what you are doing. Having LEIN_JAR pointing to one version of Leiningen as well as having a different version in PATH has been known to cause problems.
+:: Only set LEIN_JAR manually if you know what you are doing.
+:: Having LEIN_JAR pointing to one version of Leiningen as well as
+:: having a different version in PATH has been known to cause problems.
 
 if "x%LEIN_HOME%" == "x" (
     set LEIN_HOME=!USERPROFILE!\.lein

--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -19,6 +19,7 @@ call :FIND_DIR_CONTAINING_UPWARDS project.clj
 if "%DIR_CONTAINING%" neq "" cd "%DIR_CONTAINING%"
 
 :: LEIN_JAR and LEIN_HOME variables can be set manually.
+:: Only set LEIN_JAR manually if you know what you are doing. Having LEIN_JAR pointing to one version of Leiningen as well as having a different version in PATH has been known to cause problems.
 
 if "x%LEIN_HOME%" == "x" (
     set LEIN_HOME=!USERPROFILE!\.lein


### PR DESCRIPTION
This is a simple documentation improvement, adding a comment to README.md and one to /bin/lein.bat . The comments concern the usage of the environment variable LEIN_JAR on windows leading to surprising results in certain setups, as described in https://github.com/technomancy/leiningen/issues/2084