### PR TITLE
Allow user repositories with uberjar Fixes #2098

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -840,7 +840,7 @@
 (def whitelist-keys
   "Project keys which don't affect the production of the jar (sans its name)
   should be propagated to the compilation phase and not stripped out."
-  [:offline? :local-repo :certificates :warn-on-reflection :mirrors :uberjar-name :jar-name])
+  [:certificates :jar-name :local-repo :mirrors :offline? :repositories :uberjar-name :warn-on-reflection])
 
 (defn retain-whitelisted-keys
   "Retains the whitelisted keys from the original map in the new one."


### PR DESCRIPTION
Allow user defined private repositories when building jars, uberjars and running deploy tasks.

For details see issue at:

https://github.com/technomancy/leiningen/issues/2098