### PR TITLE
Fixed character escaping issue

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -115,7 +115,7 @@ rem the paths inside the bootstrap file do not already contain double quotes but
 
     :: Not running from a checkout.
     if not exist "%LEIN_JAR%" goto NO_LEIN_JAR
-    set CLASSPATH=%LEIN_JAR%
+    set CLASSPATH="%LEIN_JAR%"
   
     if exist ".lein-classpath" (
         for /f "tokens=* delims= " %%i in (.lein-classpath) do (


### PR DESCRIPTION
This fixes the issue where, if there would be a space in the classpath, the -cp variable passed to `java` would be incorrect.

This was an issue I hit upon, since there is a space in my windows username, so that I would get an issue such as:

```
Error: Could not find or load main class Mergen\.lein\self-installs\leiningen-2.6.1-standalone.jar
```

where it is obvious that the first part of the path was cut off due to missing quotes.