### PR TITLE
Warn on checkout/dep mismatch

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -979,6 +979,12 @@ Also initializes the project; see read-raw for a version that skips init."
 
 (alter-var-root #'read-dependency-project memoize)
 
+(defn- warn-checkout-version-mismatch [base-project checkout-project]
+  (let [checkout-ver (:version checkout-project)
+        project-dep-ver (last (first (filter #(= (first %) (:name checkout-project)) (:dependencies project))))]
+    (when (not= checkout-ver project-dep-ver)
+      (warn "Warning: using" (:name checkout-project) "version" (checkout-ver) "from" :path-goes-here ", not the released version."))))
+
 (defn read-checkouts
   "Returns a list of project maps for this project's checkout
   dependencies."
@@ -987,4 +993,5 @@ Also initializes the project; see read-raw for a version that skips init."
         :let [project-file (io/file dep "project.clj")
               checkout-project (read-dependency-project project-file)]
         :when checkout-project]
+	(warn-checkout-version-mismatch project checkout-project)
     checkout-project))


### PR DESCRIPTION
@hyPiRion : this is the basic skeleton of what I think it's going to look like, but I'm curious

1. if there's a canonical way to get the filesystem path of a project (see :path-goes-here in my diff)
2. what a good automated test strategy for a warning would be
3. if you have any other comments.

Thanks for offering your help with this, and sorry for the delay in getting to it.