### PR TITLE
javac supports relative source paths as arguments

### DIFF
--- a/doc/MIXED_PROJECTS.md
+++ b/doc/MIXED_PROJECTS.md
@@ -113,7 +113,6 @@ the default profile:
 ```
 
 This profile can then be compiled using: `lein with-profile precomp compile`
-n
 Once this is done, the default profile can be used in a separate
 invocation of `lein` to perform the `javac` and `compile` steps.
 
@@ -162,6 +161,34 @@ $ lein with-profile precomp compile
 The project is now ready to complete compilation normally. For
 instance, invoking `lein test` or `lein uberjar` will cause `javac`
 and `compile` to run first.
+
+Java and Clojure compilation can be interleaved as many times as necessary.
+This can be accomplished with explicit `compile` and `javac` steps in
+`:prep-tasks`. Each `compile` step will take the namespace(s) to AOT compile
+before any other tasks will be run, and each `javac` step will take the
+directories (relative to the project root) to compile before any other
+tasks will be run. For example,
+
+```clojure
+(defproject example/complicated-compile "0.0.1"
+  :description
+  "Really complicated project where Java depends on Clojure depends on Java..."
+  :min-lein-version "2.6.2"
+  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :source-paths ["src/clojure"]
+  :java-source-paths ["src/java"]
+  :prep-tasks [["compile" "complicated-compile.clojure.firststeps"]
+               ["javac" "src/java/complicated_compile/java/secondsteps"]
+               ["compile" "complicated-compile.clojure.thirdsteps"]
+               ["javac" "src/java/complicated_compile/java/fourthsteps"]
+               ;; ...
+               "javac"
+               "compile"])
+```
+
+Note that this example clobbers the `:prep-tasks` defaults. In these
+scenarios, you'll need to concatenate `"javac"` and `"compile"` to the
+end of your `:prep-tasks` manually.
 
 ## Other Languages
 

--- a/test/leiningen/test/alternating_language_compilation.clj
+++ b/test/leiningen/test/alternating_language_compilation.clj
@@ -1,0 +1,29 @@
+;; SPOILER ALERT: This file contains the answer to Project Euler #65,
+;; Convergents of e (https://projecteuler.net/problem=65). If you intend
+;; to solve this problem on your own, don't look too deeply into expected-output.
+(ns leiningen.test.alternating-language-compilation
+  "Tests compilation of Java that depends on Clojure that depends on Java..."
+  (:require [clojure.string :as string]
+            [leiningen.clean :refer [clean]]
+            [leiningen.run :refer [run]]
+            [leiningen.test.helper
+             :refer [alternating-language-compilation-project
+                     with-system-out-str]])
+  (:import java.io.File)
+  (:use clojure.test))
+
+(def ^:private expected-output
+  (string/join (System/getProperty "line.separator")
+               [(str "The 100th expansion of e is "
+                     "6963524437876961749120273824619538346438023188214475670667"
+                     "/2561737478789858711161539537921323010415623148113041714756")
+                "The sum of the digits of the numerator is 272"
+                ""]))
+
+(def ^:private target-proj alternating-language-compilation-project)
+
+(deftest test-alternating-language-compilation
+  (testing "Compilation can alternate between Java and Clojure and Java and..."
+    (do (clean target-proj)
+        (let [output-from-run (with-system-out-str (run target-proj))]
+          (is (= output-from-run expected-output))))))

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -63,6 +63,9 @@
 
 (def with-classifiers-project (read-test-project "with-classifiers"))
 
+(def alternating-language-compilation-project
+  (read-test-project "alternating-language-compilation"))
+
 (defn abort-msg
   "Catches main/abort thrown by calling f on its args and returns its error
   message."

--- a/test/leiningen/test/javac.clj
+++ b/test/leiningen/test/javac.clj
@@ -1,7 +1,12 @@
 (ns leiningen.test.javac
+  (:require [clojure.string :as string])
+  (:import [java.io BufferedReader StringReader])
   (:use [clojure.test]
         [clojure.java.io :only [file]]
-        [leiningen.javac :only [javac normalize-javac-options]]
+        [leiningen.javac :only [javac
+                                normalize-javac-options
+                                uncommented-lines-from-reader
+                                extract-package-from-line-seq]]
         [leiningen.test.helper :only [delete-file-recursively
                                       #_dev-deps-project]]))
 
@@ -33,3 +38,160 @@
                      "dev_deps_only" "Junk.class")))
   (is (.exists (file "test_projects/dev-deps-only/classes"
                      "dev_deps_only" "Junk2.class"))))
+
+(defn- inject-newlines [& args]
+  (string/join (System/getProperty "line.separator") args))
+
+(def ^:private comment-stripping-data
+  [[(inject-newlines
+     "This isn't Java,"
+     "But it does share comment semantics.")
+    (inject-newlines
+     "This isn't Java,"
+     "But it does share comment semantics.")]
+   [(inject-newlines
+     "See? Here's a // trailing comment,"
+     "A line after it,"
+     "And a // trailing comment again.")
+    (inject-newlines
+     "See? Here's a "
+     "A line after it,"
+     "And a ")]
+   [(inject-newlines
+     "/* But block comments */"
+     "also work.")
+    (inject-newlines
+     ""
+     "also work.")]
+   [(inject-newlines
+     "/* Even"
+     "across"
+     "line */"
+     "delimiters")
+    (inject-newlines
+     ""
+     ""
+     ""
+     "delimiters")]
+   [(inject-newlines
+     "Even /* when started"
+     "in the middle */"
+     "of a line")
+    (inject-newlines
+     "Even "
+     ""
+     "of a line")]
+   [(inject-newlines
+     "Even /* when stopping"
+     "in the */ middle of"
+     "a line too")
+    (inject-newlines
+     "Even "
+     " middle of"
+     "a line too")]
+   [(inject-newlines
+     "However, a // line comment /*"
+     "supersedes a /* block comment */")
+    (inject-newlines
+     "However, a "
+     "supersedes a ")]
+   [(inject-newlines
+     "But, /* you */ can /*"
+     "string */ a /* few */ of /*"
+     "these */ along // together")
+    (inject-newlines
+     "But,  can "
+     " a  of "
+     " along ")]])
+
+(deftest test-javac-comment-stripping
+  (testing "comments are stripped in lexed-lines-from-reader"
+    (loop [test-cases comment-stripping-data]
+      (if (empty? test-cases)
+        true ;; we passed
+        (let [[given expected] (first test-cases)
+              given-as-reader  (-> given (StringReader.) (BufferedReader.))
+              given-as-seq     (uncommented-lines-from-reader given-as-reader)
+              lexed-as-str     (apply inject-newlines given-as-seq)]
+          (if (is (= lexed-as-str expected))
+            (recur (rest test-cases))
+            false)))))) ;; we failed
+
+(def ^:private package-extraction-data
+  [[(inject-newlines
+     "import java.util.UUID;"
+     "import java.util.Set;"
+     ""
+     "public class Main {"
+     "    public static void main(String[] args) {"
+     "        System.out.println(\"Hello, World!\");"
+     "    }"
+     "}")
+    nil]
+   [(inject-newlines
+     "package my.java.Main;"
+     ""
+     "public class Main {"
+     "    public static void main(String[] args) {"
+     "        System.out.println(\"Hello, World!\");"
+     "    }"
+     "}")
+    "my.java.Main"]
+   [(inject-newlines
+     ""
+     "    "
+     "package my.java.Main;      "
+     "public class Main {"
+     "    public static void main(String[] args) {"
+     "        System.out.println(\"Hello, World!\");"
+     "    }"
+     "}")
+    "my.java.Main"]
+   [(inject-newlines
+     "package"
+     "my.java.Main"
+     ";"
+     "public class Main {"
+     "    public static void main(String[] args) {"
+     "        System.out.println(\"Hello, World!\");"
+     "    }"
+     "}")
+    "my.java.Main"]
+   [(inject-newlines
+     "package      my.java.Main;;;;;"
+     "public class Main {"
+     "    public static void main(String[] args) {"
+     "        System.out.println(\"Hello, World!\");"
+     "    }"
+     "}")
+    "my.java.Main"]
+   [(inject-newlines
+     "   package   my.java.Main;  "
+     "public class Main {"
+     "    public static void main(String[] args) {"
+     "        System.out.println(\"Hello, World!\");"
+     "    }"
+     "}")
+    "my.java.Main"]
+   [(inject-newlines
+     "package"
+     ""
+     "")
+    nil]])
+
+(deftest test-package-extraction
+  (loop [test-data-queue  package-extraction-data
+         test-data-offset 0]
+    (if (empty? test-data-queue)
+      true ;; assume we succeeded
+      (let [[test-data expected] (first test-data-queue)
+            test-data-seq        (-> test-data
+                                     (StringReader.)
+                                     (BufferedReader.)
+                                     (uncommented-lines-from-reader))]
+        (if-not (is (= (extract-package-from-line-seq test-data-seq) expected))
+          (binding [*out* *err*]
+            (println "test-package-extraction failure at offset"
+                     test-data-offset)
+            false)
+          (recur (rest test-data-queue) (inc test-data-offset)))))))

--- a/test_projects/alternating-language-compilation/.gitignore
+++ b/test_projects/alternating-language-compilation/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/test_projects/alternating-language-compilation/LICENSE
+++ b/test_projects/alternating-language-compilation/LICENSE
@@ -1,0 +1,214 @@
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and
+documentation distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+i) changes to the Program, and
+
+ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from
+a Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license
+agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+distribute and sublicense the Contribution of such Contributor, if any, and
+such derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under
+Licensed Patents to make, use, sell, offer to sell, import and otherwise
+transfer the Contribution of such Contributor, if any, in source code and
+object code form.  This patent license shall apply to the combination of the
+Contribution and the Program if, at the time the Contribution is added by the
+Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any
+other combinations which include the Contribution. No hardware per se is
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses
+to its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other
+intellectual property rights of any other entity. Each Contributor disclaims
+any liability to Recipient for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a condition to
+exercising the rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual property rights
+needed, if any. For example, if a third party patent license is required to
+allow Recipient to distribute the Program, it is Recipient's responsibility
+to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient
+copyright rights in its Contribution, if any, to grant the copyright license
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+i) effectively disclaims on behalf of all Contributors all warranties and
+conditions, express and implied, including warranties or conditions of title
+and non-infringement, and implied warranties or conditions of merchantability
+and fitness for a particular purpose;
+
+ii) effectively excludes on behalf of all Contributors all liability for
+damages, including direct, indirect, special, incidental and consequential
+damages, such as lost profits;
+
+iii) states that any provisions which differ from this Agreement are offered
+by that Contributor alone and not by any other party; and
+
+iv) states that source code for the Program is available from such
+Contributor, and informs licensees how to obtain it in a reasonable manner on
+or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a
+manner which does not create potential liability for other Contributors.
+Therefore, if a Contributor includes the Program in a commercial product
+offering, such Contributor ("Commercial Contributor") hereby agrees to defend
+and indemnify every other Contributor ("Indemnified Contributor") against any
+losses, damages and costs (collectively "Losses") arising from claims,
+lawsuits and other legal actions brought by a third party against the
+Indemnified Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program in
+a commercial product offering.  The obligations in this section do not apply
+to any claims or Losses relating to any actual or alleged intellectual
+property infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor tocontrol, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim
+at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON
+AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all risks
+associated with its exercise of rights under this Agreement , including but
+not limited to the risks and costs of program errors, compliance with
+applicable laws, damage to or loss of data, programs or equipment, and
+unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and
+does not cure such failure in a reasonable period of time after becoming
+aware of such noncompliance. If all Recipient's rights under this Agreement
+terminate, Recipient agrees to cease use and distribution of the Program as
+soon as reasonably practicable. However, Recipient's obligations under this
+Agreement and any licenses granted by Recipient relating to the Program shall
+continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of
+the Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel or otherwise. All
+rights in the Program not expressly granted under this Agreement are
+reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/test_projects/alternating-language-compilation/project.clj
+++ b/test_projects/alternating-language-compilation/project.clj
@@ -1,0 +1,16 @@
+(defproject alternating-language-compilation "0.1.0-SNAPSHOT"
+  :description "Demonstrate compilation of Java that depends on Clojure that depends on Java..."
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :java-source-paths ["src/java"]
+  :source-paths      ["src/clojure"]
+  ;; Direct Linking allows us to call into Clojure code from Java
+  ;; without having to trigger var initialization in the runtime.
+  ;; In this particular test case, we need it.
+  :jvm-opts          ["-Dclojure.compiler.direct-linking=true"]
+  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :prep-tasks [["javac" "src/java/leiningen/test/alc"]
+               ["compile" "leiningen.test.alc.naturalexpander"]
+               "javac"
+               "compile"]
+  :main leiningen.test.euler65.Euler65)

--- a/test_projects/alternating-language-compilation/src/clojure/leiningen/test/alc/naturalexpander.clj
+++ b/test_projects/alternating-language-compilation/src/clojure/leiningen/test/alc/naturalexpander.clj
@@ -1,0 +1,35 @@
+;; SPOILER ALERT: This file implements a solution to Project Euler #65,
+;; Convergence of e. (https://projecteuler.net/problem=65) If you intend
+;; to solve this problem on your own, don't pay too much attention to
+;; what the code is doing.
+
+(ns leiningen.test.alc.naturalexpander
+  "Expands a repeated fraction representing the natural number, \"e\"."
+  (:import leiningen.test.alc.WrappedOnesIterator
+           clojure.lang.Ratio))
+
+(definterface INaturalExpander
+  (^java.math.BigInteger getNumerator [])
+  (^java.math.BigInteger getDenominator [])
+  (expandBy [fractions]))
+
+;; WrappedOnesIterator isn't thread-safe, so we need to make a new one
+;; every time as a workaround
+(defn natural-fraction-schedule []
+  (cons 2
+        (iterator-seq
+         (WrappedOnesIterator. (.iterator (map #(* % 2) (drop 1 (range))))))))
+
+(deftype NaturalExpander [^:unsynchronized-mutable return-value]
+  INaturalExpander
+  (^java.math.BigInteger getNumerator [self] (numerator return-value))
+  (^java.math.BigInteger getDenominator [self] (denominator return-value))
+  (expandBy [self fractions]
+    (let [fraction-sched (reverse (take fractions (natural-fraction-schedule)))]
+      (if (< (count fraction-sched) 2)
+        (set! return-value (Ratio. (first fraction-sched) 1))
+        (loop [previous (first fraction-sched)
+               pending  (rest fraction-sched)]
+          (if (empty? pending)
+            (set! return-value previous)
+            (recur (+ (/ 1 previous) (first pending)) (rest pending))))))))

--- a/test_projects/alternating-language-compilation/src/java/leiningen/test/alc/WrappedOnesIterator.java
+++ b/test_projects/alternating-language-compilation/src/java/leiningen/test/alc/WrappedOnesIterator.java
@@ -1,0 +1,44 @@
+package leiningen.test.alc;
+
+import java.util.Iterator;
+
+/**
+ * Does what it says on the tin: Takes an iterator of Long,
+ * and wraps it with ones, i.e. there is a one before and
+ * after every element returned by the wrapped iterator.
+ */
+public class WrappedOnesIterator implements Iterator<Long> {
+    private Iterator<Long> origIterator;
+    private int modThreeCounter = 0;
+
+    /**
+     * @param orig Original iterator to wrap
+     */
+    public WrappedOnesIterator(Iterator<Long> orig) {
+        origIterator = orig;
+    }
+
+    public boolean hasNext() {
+        return modThreeCounter == 2 || origIterator.hasNext();
+    }
+
+    public Long next() {
+        Long ret = 0L;
+        if (modThreeCounter == 1) {
+            ret = origIterator.next();
+        } else {
+            ret = 1L;
+        }
+        modThreeCounter += 1;
+        modThreeCounter %= 3;
+        return ret;
+    }
+
+    /**
+     * Unsupported on this Iterator.
+     * @throws UnsupportedOperationException
+     */
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/test_projects/alternating-language-compilation/src/java/leiningen/test/euler65/Euler65.java
+++ b/test_projects/alternating-language-compilation/src/java/leiningen/test/euler65/Euler65.java
@@ -1,0 +1,34 @@
+/* 
+ * SPOILER ALERT!
+ * This file implements a solution to Project Euler problem #65,
+ * Convergents of e (https://projecteuler.net/problem=65). If you
+ * intend to solve this problem on your own, don't pay too much
+ * attention to what the code is doing.
+ *
+ * Also, this is incredibly contrived, but only to test javac
+ * functionality. Don't take this as a best practice.
+ */
+
+package leiningen.test.euler65;
+
+import leiningen.test.alc.naturalexpander.NaturalExpander;
+import java.math.BigInteger;
+
+public class Euler65 {
+    public static NaturalExpander expander = new NaturalExpander(null);
+
+    public static void main(String[] args) {
+        expander.expandBy(100);
+        BigInteger numerator = expander.getNumerator();
+        System.out.println(String.format("The 100th expansion of e is %s/%s",
+                                         numerator,
+                                         expander.getDenominator()));
+        int sumOfDigits = 0;
+        while (numerator.compareTo(BigInteger.ZERO) == 1) {
+            sumOfDigits += numerator.mod(BigInteger.TEN).longValue();
+            numerator = numerator.divide(BigInteger.TEN);
+        }
+        System.out.println("The sum of the digits of the numerator is " +
+                           sumOfDigits);
+    }
+}


### PR DESCRIPTION
As specified in MIXED_PROJECTS.md, this is done with the intent to
support multi-stage source interleaving between Clojure and Java.

Also changed in this patchset:
- @-arguments passed to javac are now expanded
- compilation of Java sources can be avoided even when not stored
  in a directory format mirroring the package format
