### PR TITLE
Update to pomegranate 0.3.1

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -7,7 +7,7 @@
                  [bultitude "0.2.8"]
                  [classlojure "0.6.6"]
                  [robert/hooke "1.3.0"]
-                 [com.cemerick/pomegranate "0.3.0"]
+                 [com.cemerick/pomegranate "0.3.1"]
                  [org.apache.maven.wagon/wagon-http "2.10"]
                  [com.hypirion/io "0.3.1"]
                  [pedantic "0.2.0"]]


### PR DESCRIPTION
Pomegranate 0.3.1 was just released, and includes some changes necessary for #2067.  This commit updates lein to the new version of pomegranate.