### PR TITLE
Catch and handle fixture errors during tests

### DIFF
--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -41,6 +41,8 @@
 
 (def sample-reader-cond-project (read-test-project "sample-reader-cond"))
 
+(def sample-fixture-error-project (read-test-project "sample-fixture-error"))
+
 (def tricky-name-project (read-test-project "tricky-name"))
 
 (def native-project (read-test-project "native"))

--- a/test/leiningen/test/test.clj
+++ b/test/leiningen/test/test.clj
@@ -5,6 +5,7 @@
             [leiningen.test.helper :refer [tmp-dir sample-no-aot-project
                                            sample-reader-cond-project
                                            sample-failing-project
+                                           sample-fixture-error-project
                                            with-system-err-str]]
             [clojure.java.io :as io]
             [leiningen.core.main :as main]
@@ -97,3 +98,7 @@
       (is (= "EOF while reading" (try (test project) false
                                       (catch Exception e
                                         (.getMessage e))))))))
+
+(deftest test-catch-fixture-errors
+  (test sample-fixture-error-project)
+  (is (= (ran?) #{:test-a :test-c})))

--- a/test_projects/sample-fixture-error/project.clj
+++ b/test_projects/sample-fixture-error/project.clj
@@ -1,0 +1,7 @@
+;; This project is used for leiningen's test suite, so don't change
+;; any of these values without updating the relevant tests. If you
+;; just want a basic project to work from, generate a new one with
+;; "lein new".
+
+(defproject sample-fixture-error "0.1.0-SNAPSHOT"
+  :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/test_projects/sample-fixture-error/test/test_a.clj
+++ b/test_projects/sample-fixture-error/test/test_a.clj
@@ -1,0 +1,13 @@
+(ns test-a
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :refer [writer]]))
+
+(defn record-ran [t]
+  (let [file-name (format "%s/lein-test-ran"
+                          (System/getProperty "java.io.tmpdir"))]
+    (with-open [w (writer file-name :append true)]
+      (.write w (str t "\n")))))
+
+(deftest test-a
+  (record-ran :test-a)
+  (is (= 1 1)))

--- a/test_projects/sample-fixture-error/test/test_b.clj
+++ b/test_projects/sample-fixture-error/test/test_b.clj
@@ -1,0 +1,11 @@
+(ns test-b
+  (:require [clojure.test :refer :all]
+            [test-a :refer [record-ran]]))
+
+(use-fixtures :once
+  (fn [& _]
+    (throw (Exception. "Don't panic. This is an expected exception."))))
+
+(deftest test-b
+  (record-ran :test-b)
+  (is (= 1 1)))

--- a/test_projects/sample-fixture-error/test/test_c.clj
+++ b/test_projects/sample-fixture-error/test/test_c.clj
@@ -1,0 +1,7 @@
+(ns test-c
+  (:require [clojure.test :refer :all]
+            [test-a :refer (record-ran)]))
+
+(deftest test-c
+  (record-ran :test-c)
+  (is (= 1 1)))


### PR DESCRIPTION
Injected a hook in `clojure.test/test-ns` to catch and handle exceptions, which will prevent the test process from dying and allowing testing to continue on other namespaces.