### PR TITLE
#2128 Respect :scm :dir in leiningen.vcs/uses-vcs. 

### DIFF
--- a/src/leiningen/vcs.clj
+++ b/src/leiningen/vcs.clj
@@ -10,7 +10,9 @@
 (def supported-systems (atom [:git]))
 
 (defn uses-vcs [project vcs]
-  (let [vcs-dir (io/file (:root project) (str "." (name vcs)))]
+  (let [vcs-dir (io/file (:root project)
+                         (get-in project [:scm :dir] "")
+                         (str "." (name vcs)))]
     (and (.exists vcs-dir) vcs)))
 
 (defn which-vcs [project & _]


### PR DESCRIPTION
Hello!  I have a fix for #2128.  Be forewarned:  I am a total clojure (and Leiningen and GitHub pull request) babby!

I made a test lein app with the git root a directory above, and was able to reproduce the problem with `lein release`.  With my changes, things seemed to be working:

```
~/clojure $ mkdir test
~/clojure $ cd test/
~/clojure/test $ git init
Initialized empty Git repository in /home/ian/clojure/test/.git/
~/clojure/test $ lein new app foobar
Generating a project called foobar based on the 'app' template.
~/clojure/test $ cd foobar/
~/clojure/test/foobar $ ls
CHANGELOG.md  LICENSE  README.md  doc  project.clj  resources  src  test

[add :scm {:dir ".."} to project.clj]

~/clojure/test/foobar $ lein release
Unknown VCS detected for 'vcs assert-committed'
~/clojure/test/foobar $ ~/clojure/leiningen/bin/lein release
Recalculating Leiningen's classpath.
On branch master

Initial commit

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	./

nothing added to commit but untracked files present (use "git add" to track)
On branch master

Initial commit

Untracked files:
	./

nothing added to commit but untracked files present
java.lang.Exception: Couldn't commit. git exit code: 1
 at leiningen.core.eval$sh_with_exit_code.invokeStatic (eval.clj:220)
. . . 
```

How does this look?  Thanks!