### PR TITLE
Fix #2145: extra whitespace added to JVM_OPTS

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -110,18 +110,9 @@
 (defn- d-property [[k v]]
   (format "-D%s=%s" (as-str k) v))
 
-;; TODO: this would still screw up with something like this:
-;; export JAVA_OPTS="-Dmain.greeting=\"hello -main\" -Xmx512m"
-(defn- join-broken-arg [args x]
-  (if (= \- (first x))
-    (conj args x)
-    (conj (vec (butlast args))
-          (str (last args) " " x))))
-
 (defn ^:internal get-jvm-opts-from-env [env-opts]
   (and (seq env-opts)
-       (reduce join-broken-arg []
-               (.split (string/trim env-opts) " "))))
+       (re-seq #"(?:[^\s\"']+|\"[^\"]*\"|'[^']*')+" (string/trim env-opts))))
 
 (defn- get-jvm-args
   "Calculate command-line arguments for launching java subprocess."

--- a/leiningen-core/test/leiningen/core/test/eval.clj
+++ b/leiningen-core/test/leiningen/core/test/eval.clj
@@ -46,7 +46,14 @@
 (deftest test-jvm-opts
   (is (= ["-Dhello=\"guten tag\"" "-XX:+HeapDumpOnOutOfMemoryError"]
          (get-jvm-opts-from-env (str "-Dhello=\"guten tag\" "
-                                     "-XX:+HeapDumpOnOutOfMemoryError")))))
+                                     "-XX:+HeapDumpOnOutOfMemoryError"))))
+  (is (= ["-Dfoo=bar" "-Dbar=baz"]
+         (get-jvm-opts-from-env (str "    -Dfoo=bar"
+                                     "    -Dbar=baz"))))
+  (is (= ["-Dfoo='ba\"r'" "-Dbar=\"ba\"'z'" "arg"]
+         (get-jvm-opts-from-env (str "    -Dfoo='ba\"r'"
+                                     "    -Dbar=\"ba\"'z'"
+                                     "    arg")))))
 
 (deftest test-file-encoding-in-jvm-args
   (is (contains?


### PR DESCRIPTION
Instead of using String.split then recombining arguments to repair broken
quoted arguments, this parser now finds entire arguments using regex matching.
This is more robust, handling extra whitespace (and non-space whitespace)
correctly, while also correctly matching quotations in argument strings and
preserving internal spaces.