### PR TITLE
Get lein partially working under Java 9

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -4,10 +4,11 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Library for core functionality of Leiningen."
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [bultitude "0.2.8"]
+                 [bultitude "0.2.8" :exclusions [org.tcrawley/dynapath]]
                  [classlojure "0.6.6"]
                  [robert/hooke "1.3.0"]
-                 [com.cemerick/pomegranate "0.3.1"]
+                 [com.cemerick/pomegranate "0.3.1" :exclusions [org.tcrawley/dynapath]]
+                 [org.tcrawley/dynapath "0.2.4"]
                  [org.apache.maven.wagon/wagon-http "2.10"]
                  [com.hypirion/io "0.3.1"]
                  [pedantic "0.2.0"]]

--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -3,7 +3,6 @@
   (:require [classlojure.core :as cl]
             [clojure.java.io :as io]
             [clojure.string :as string]
-            [cemerick.pomegranate :as pomegranate]
             [cemerick.pomegranate.aether :as aether]
             [leiningen.core.project :as project]
             [leiningen.core.main :as main]
@@ -340,8 +339,7 @@
     (System/setProperty "clojure.debug" "true"))
   ;; :dependencies are loaded the same way as plugins in eval-in-leiningen
   (project/load-plugins project :dependencies)
-  (doseq [path (classpath/get-classpath project)]
-    (pomegranate/add-classpath path))
+  (project/init-lein-classpath project)
   (doseq [opt (get-jvm-args project)
           :when (.startsWith opt "-D")
           :let [[_ k v] (re-find #"^-D(.*?)=(.*)$" opt)]]

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -878,10 +878,11 @@
                   (remove (set profiles) included-profiles)
                   (concat excluded-profiles profiles))))
 
-(defn- init-lein-classpath
+(defn init-lein-classpath
   "Adds dependencies to Leiningen's classpath if required."
   [project]
   (when (= :leiningen (:eval-in project))
+    (ensure-dynamic-classloader)
     (doseq [path (classpath/get-classpath project)]
       (pomegranate/add-classpath path))))
 


### PR DESCRIPTION
This includes three changes:

* Exclude the dynapath that comes in from bultitude and pomegranate, and
  depend directly on a newer version that operates properly under Java 9
* Ensure we have a modifiable classloader before asking pomegranate to
  modify it. Before Java 9, the AppClassLoader was a URLClassLoader, and
  therefore modifiable. This is no longer the case with Java 9.
* Remove duplicated classpath init code from `eval-in :leiningen`, and
  replace it with a call to `project/init-lein-classpath`. This required
  making the latter function public.

These changes allow some lein functionality to work under Java 9 - there
is a Java 9 issue with data.xml that needs to be fixed before lein's
tests can all pass (http://dev.clojure.org/jira/browse/DXML-32).

Once bultitude and pomegranate are updated to use the newer dynapath, 
the exclusions here can be removed.

This resolves the primary issue in #2149.

Doing this as a PR to get a second set of eyes on it to make sure I'm not inadvertently breaking something.