### PR TITLE
Fix for issue #2082

### DIFF
--- a/src/leiningen/compile.clj
+++ b/src/leiningen/compile.clj
@@ -162,7 +162,7 @@ Code that should run on startup belongs in a -main defn."
                          (throw t#)))))
            project (update-in project [:prep-tasks]
                               (partial remove #{"compile"}))]
-       (try (binding [*print-dup* true]
+       (try (binding [eval/*eval-print-dup* true]
               (eval/eval-in-project project form))
             (catch Exception e
               (main/abort "Compilation failed:" (.getMessage e)))


### PR DESCRIPTION
This PR introduces, as requested on issue #2082, an option to specify whether *print-dup* should be enabled for the forms passed to eval-in-project.
