### PR TITLE
Fix for issue #2091

### DIFF
--- a/src/leiningen/run.clj
+++ b/src/leiningen/run.clj
@@ -124,7 +124,9 @@
   "Loads the project namespaces as well as all its dependencies and then calls
   ns/f, passing it the args."
   [project given prep-type args]
-  (let [prepped-args (map #(prep-arg prep-type %) args)]
+  ;; must convert lazy-seq to list(issue #2091)
+  ;; eval can't handle well a form that contains an evaluated empty lazy-seq
+  (let [prepped-args (apply list (map #(prep-arg prep-type %) args))]
     (try (eval/eval-in-project project (run-form given prepped-args))
          (catch clojure.lang.ExceptionInfo e
            (main/exit (:exit-code (ex-data e) 1))))))


### PR DESCRIPTION
This PR fix issue #2091
`lein run` would crash when evaluating in `:leiningen` instead of `:subprocess`.
This would happen anytime that the `eval` function was called with the `run-form` as the form and no arg was passed.
As shown here https://groups.google.com/forum/#!topic/clojure/7xa7Yg0-htc
`eval` can't handle well a form that contains an evaluated empty lazy-seq, throwing an `java.lang.UnsupportedOperationException`. 
Because of this the form was not being evaluating, not showing an informative error message for the user.
