### PR TITLE
Parse GitHub usernames with - in them

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -75,8 +75,8 @@
   [url]
   (if url
     (next
-     (or (re-matches #"(?:[A-Za-z_]{2,}@)?github.com:([^/]+)/([^/]+).git" url)
-         (re-matches #"[^:]+://(?:[A-Za-z_]{2,}@)?github.com/([^/]+)/([^/]+).git" url)))))
+     (or (re-matches #"(?:[A-Za-z-]{2,}@)?github.com:([^/]+)/([^/]+).git" url)
+         (re-matches #"[^:]+://(?:[A-Za-z-]{2,}@)?github.com/([^/]+)/([^/]+).git" url)))))
 
 (defn- github-urls [url]
   (if-let [[user repo] (parse-github-url url)]


### PR DESCRIPTION
GitHub usernames only allow alphanumeric characters and single hypens. This commit fixes the regex to allow dashes, and remove _ as _ aren't valid in Github usernames.

<img width="496" alt="screenshot of safari technology preview 29-07-16 10-14-14 am" src="https://cloud.githubusercontent.com/assets/811954/17231431/f101ace4-5575-11e6-8134-f83b186a3c82.png">
