### PR TITLE
Fixed adding %LEIN_JAR% to %CLASSPATH% (preserving original %CLASSPATH% values)

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -115,7 +115,7 @@ rem the paths inside the bootstrap file do not already contain double quotes but
 
     :: Not running from a checkout.
     if not exist "%LEIN_JAR%" goto NO_LEIN_JAR
-    set CLASSPATH=%LEIN_JAR%
+    set CLASSPATH="%LEIN_JAR%;%CLASSPATH%"
   
     if exist ".lein-classpath" (
         for /f "tokens=* delims= " %%i in (.lein-classpath) do (


### PR DESCRIPTION
Without this lein can't find the JAR in the %USERHOME%/.lein/self-installed directory when %USERHOME% has spaces in it. Note, I add %CLASSPATH% to prevent any previously set values in %CLASSPATH% from getting whacked.