### PR TITLE
Fix checking for SNAPSHOT deps with managed deps - fixes #2205

### DIFF
--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -74,6 +74,8 @@
 
 (def managed-deps-project (read-test-project "managed-deps"))
 
+(def managed-deps-snapshot-project (read-test-project "managed-deps-snapshot"))
+
 (defn abort-msg
   "Catches main/abort thrown by calling f on its args and returns its error
   message."

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -5,7 +5,7 @@
         [leiningen.core.user :as user]
         [leiningen.test.helper
          :only [sample-project sample-profile-meta-project
-                managed-deps-project]
+                managed-deps-project managed-deps-snapshot-project]
          :as lthelper])
   (:require [clojure.data.xml :as xml]
             [leiningen.core.project :as project]
@@ -355,31 +355,33 @@
     (is (not (snapshot? nil)))))
 
 (deftest test-managed-dependencies
-  (let [xml (xml/parse-str
-             (make-pom managed-deps-project))]
-    (testing "normal dependencies are written to pom properly"
-      (is (= ["org.clojure" "rome" "ring" "ring" "commons-codec" "commons-math"
-              "org.clojure" "org.clojure"]
-             (map #(first-in % [:dependency :groupId])
-                  (deep-content xml [:project :dependencies]))))
-      (is (= ["clojure" "rome" "ring" "ring-codec" "commons-codec" "commons-math"
-              "tools.emitter.jvm" "tools.namespace"]
-             (map #(first-in % [:dependency :artifactId])
-                  (deep-content xml [:project :dependencies]))))
-      (is (= [nil nil nil nil "1.6" nil "0.1.0-beta5" "0.3.0-alpha3"]
-             (map #(first-in % [:dependency :version])
-                  (deep-content xml [:project :dependencies])))))
-    (testing "managed dependencies are written to pom properly"
-      (is (= ["org.clojure" "rome" "ring" "ring" "commons-math" "ring" "org.clojure"]
-             (map #(first-in % [:dependency :groupId])
-                  (deep-content xml [:project :dependencyManagement :dependencies]))))
-      (is (= ["clojure" "rome" "ring" "ring-codec" "commons-math" "ring-defaults"
-              "tools.reader"]
-             (map #(first-in % [:dependency :artifactId])
-                  (deep-content xml [:project :dependencyManagement :dependencies]))))
-      (is (= ["1.3.0" "0.9" "1.0.0" "1.0.1" "1.2" "0.2.1" "1.0.0-beta3"]
-             (map #(first-in % [:dependency :version])
-                  (deep-content xml [:project :dependencyManagement :dependencies]))))
-      (is (= [nil nil nil nil "sources" nil nil]
-             (map #(first-in % [:dependency :classifier])
-                  (deep-content xml [:project :dependencyManagement :dependencies])))))))
+  (doseq [proj [managed-deps-snapshot-project
+                managed-deps-project]]
+    (let [xml (xml/parse-str
+               (make-pom proj))]
+      (testing "normal dependencies are written to pom properly"
+        (is (= ["org.clojure" "rome" "ring" "ring" "commons-codec" "commons-math"
+                "org.clojure" "org.clojure"]
+               (map #(first-in % [:dependency :groupId])
+                    (deep-content xml [:project :dependencies]))))
+        (is (= ["clojure" "rome" "ring" "ring-codec" "commons-codec" "commons-math"
+                "tools.emitter.jvm" "tools.namespace"]
+               (map #(first-in % [:dependency :artifactId])
+                    (deep-content xml [:project :dependencies]))))
+        (is (= [nil nil nil nil "1.6" nil "0.1.0-beta5" "0.3.0-alpha3"]
+               (map #(first-in % [:dependency :version])
+                    (deep-content xml [:project :dependencies])))))
+      (testing "managed dependencies are written to pom properly"
+        (is (= ["org.clojure" "rome" "ring" "ring" "commons-math" "ring" "org.clojure"]
+               (map #(first-in % [:dependency :groupId])
+                    (deep-content xml [:project :dependencyManagement :dependencies]))))
+        (is (= ["clojure" "rome" "ring" "ring-codec" "commons-math" "ring-defaults"
+                "tools.reader"]
+               (map #(first-in % [:dependency :artifactId])
+                    (deep-content xml [:project :dependencyManagement :dependencies]))))
+        (is (= ["1.3.0" "0.9" "1.0.0" "1.0.1" "1.2" "0.2.1" "1.0.0-beta3"]
+               (map #(first-in % [:dependency :version])
+                    (deep-content xml [:project :dependencyManagement :dependencies]))))
+        (is (= [nil nil nil nil "sources" nil nil]
+               (map #(first-in % [:dependency :classifier])
+                    (deep-content xml [:project :dependencyManagement :dependencies]))))))))

--- a/test/leiningen/test/uberjar.clj
+++ b/test/leiningen/test/uberjar.clj
@@ -7,7 +7,8 @@
             [leiningen.test.helper :refer [sample-no-aot-project
                                            uberjar-merging-project
                                            provided-project
-                                           managed-deps-project]])
+                                           managed-deps-project
+                                           managed-deps-snapshot-project]])
   (:import (java.io File FileOutputStream)
            (java.util.zip ZipFile)))
 
@@ -67,8 +68,13 @@
     (is (= 0 (:exit (sh "java" bootclasspath "-jar" filename))))))
 
 (deftest test-uberjar-managed-dependencies
-  (uberjar managed-deps-project)
-  (let [filename (str "test_projects/managed-deps/target/"
-                      "mgmt-0.99.0-SNAPSHOT-standalone.jar")
-        uberjar-file (File. filename)]
-    (is (= true (.exists uberjar-file)))))
+  (doseq [[proj jarfile] [[managed-deps-snapshot-project
+                           (str "test_projects/managed-deps-snapshot/target/"
+                                "mgmt-0.99.0-SNAPSHOT-standalone.jar")]
+                          [managed-deps-project
+                           (str "test_projects/managed-deps/target/"
+                                "mgmt-0.99.0-standalone.jar")]]]
+    (uberjar proj)
+    (let [uberjar-file (File. jarfile)]
+      (is (= true (.exists uberjar-file))
+          (format "File '%s' does not exist!" uberjar-file)))))

--- a/test_projects/managed-deps-snapshot/project.clj
+++ b/test_projects/managed-deps-snapshot/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.3.0")
 
-(defproject mgmt "0.99.0"
+(defproject mgmt "0.99.0-SNAPSHOT"
   :description "A test project"
 
   :managed-dependencies [[~(symbol "org.clojure" "clojure") ~clj-version]


### PR DESCRIPTION
This commit fixes #2205: when using managed dependencies in
a project, if the project itself was a non-SNAPSHOT version,
then when `lein install` and similar tasks were executed,
lein would check to make sure that none of the dependencies
were a SNAPSHOT version.  lein was checking that directly against
the `:dependencies` vector, which would cause an NPE if a dependency
didn't specify a version number (because it was inheriting it from
the `:managed-dependencies` section).

This commit fixes the bug by calling the code that merges the
`:dependencies` and `:managed-dependencies` vectors together prior
to performing the SNAPSHOT check.