### PR TITLE
Powershell fixes

### DIFF
--- a/bin/lein.ps1
+++ b/bin/lein.ps1
@@ -44,10 +44,8 @@ function Initialize-Environment
     {
         $proxy = [Net.WebRequest]::DefaultWebProxy.GetProxy('https://github.com/')
         Write-Verbose "Using proxy: $proxy"
-        $Script:PSBoundParameters = @{
-            'Invoke-WebRequest:Proxy' = $proxy
-            'Invoke-WebRequest:ProxyUseDefaultCredentials' = $true
-        }
+        $Script:PSBoundParameters.Add('Invoke-WebRequest:Proxy', $proxy)
+        $Script:PSBoundParameters.Add('Invoke-WebRequest:ProxyUseDefaultCredentials', $true)
     }
 }
 

--- a/bin/lein.ps1
+++ b/bin/lein.ps1
@@ -107,13 +107,9 @@ function Update-Self
         OutFile = "$PSCommandPath.pending"
     } |% {Write-Progress 'Update-Self' $_.Uri -CurrentOperation "Downloading to $PSCommandPath.pending" -PercentComplete 50 ; Invoke-WebRequest @_}
     Write-Progress 'Update-Self' -Completed
-    Install-Self
-    Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {
-        rm "$PSScriptRoot\lein.cmd"
-        mv "$PSScriptRoot\lein.cmd.pending" "$PSScriptRoot\lein.cmd"
-        rm "$PSCommandPath.pending"
-        mv "$PSCommandPath" "$PSCommandPath.pending"
-    }
+    Move-Item "$PSScriptRoot\lein.cmd.pending" "$PSScriptRoot\lein.cmd" -force
+    Move-Item "$PSCommandPath.pending" "$PSCommandPath" -force
+    . "$PSCommandPath" self-install
 }
 
 function Invoke-Java


### PR DESCRIPTION
The first commit fixes an error that was being thrown when using a proxy:
`Cannot convert the "System.Collections.Hashtable" value of type "System.Collections.Hashtable" to type
"System.Management.Automation.PSBoundParametersDictionary".`

The second I'm unable to test but appears more correct than what was there before:
1) The pending and current powershell scripts were reversed in the Update-Self function.
2) The Install-Self function was being called for the current version not the new one.
