### PR TITLE
Tolerate keywords for version string - fixes #2212

### DIFF
--- a/leiningen-core/test/leiningen/core/test/classpath.clj
+++ b/leiningen-core/test/leiningen/core/test/classpath.clj
@@ -106,3 +106,50 @@
                  ["sonatype" {:url "https://oss.sonatype.org/"}]
                  ["internal" {:url "https://sekrit.info/repo"
                               :username :gpg :password :gpg}]])))))
+
+(deftest test-normalize-dep-vectors
+  (testing "dep vectors with string version"
+    (is (= ['foo/bar "1.0.0"]
+           (normalize-dep-vector ['foo/bar "1.0.0"])))
+    (is (= ['foo/bar "1.0.0" :classifier "test"]
+           (normalize-dep-vector ['foo/bar "1.0.0" :classifier "test"])))
+    (is (= ['foo/bar "1.0.0" :classifier "test" :exclusions ['foo/baz]]
+           (normalize-dep-vector ['foo/bar "1.0.0" :classifier "test" :exclusions ['foo/baz]]))))
+  (testing "dep vectors with keyword version (e.g., for use with lein-modules"
+    (is (= ['foo/bar :version]
+           (normalize-dep-vector ['foo/bar :version])))
+    (is (= ['foo/bar :version :classifier "test"]
+           (normalize-dep-vector ['foo/bar :version :classifier "test"])))
+    (is (= ['foo/bar :version :classifier "test" :exclusions ['foo/baz]]
+           (normalize-dep-vector ['foo/bar :version :classifier "test" :exclusions ['foo/baz]]))))
+  (testing "dep vectors with explicit nils for versions (managed dependencies)"
+    (is (= ['foo/bar nil]
+           (normalize-dep-vector ['foo/bar nil])))
+    (is (= ['foo/bar nil :classifier "test"]
+           (normalize-dep-vector ['foo/bar nil :classifier "test"])))
+    (is (= ['foo/bar nil :classifier "test" :exclusions ['foo/baz]]
+           (normalize-dep-vector ['foo/bar nil :classifier "test" :exclusions ['foo/baz]]))))
+  (testing "dep vectors with implicit nils for versions (managed dependencies)"
+    (is (= ['foo/bar nil]
+           (normalize-dep-vector ['foo/bar])))
+    (is (= ['foo/bar nil :classifier "test"]
+           (normalize-dep-vector ['foo/bar :classifier "test"])))
+    (is (= ['foo/bar nil :classifier "test" :exclusions ['foo/baz]]
+           (normalize-dep-vector ['foo/bar :classifier "test" :exclusions ['foo/baz]]))))
+  (testing "error if dep isn't valid"
+    (is (thrown-with-msg?
+          IllegalArgumentException #"Invalid dependency: artifact id must be a symbol"
+          (normalize-dep-vector [:keyword-id])))
+    (is (thrown-with-msg?
+          IllegalArgumentException #"Invalid dependency: artifact id must be a symbol"
+          (normalize-dep-vector ["string id"])))
+    (is (thrown-with-msg?
+          IllegalArgumentException #"Invalid dependency: options must be keyword->value pairs"
+          (normalize-dep-vector ['foo/bar "1.2.0" :classifier])))
+    (is (thrown-with-msg?
+          IllegalArgumentException #"Invalid dependency: options must be keyword->value pairs"
+          (normalize-dep-vector ['foo/bar :version :classifier "foo" :extra-keyword])))
+    (is (thrown-with-msg?
+          IllegalArgumentException #"Invalid dependency: options must be keyword->value pairs"
+          (normalize-dep-vector ['foo/bar :version "notakeyword" "foo"])))))
+


### PR DESCRIPTION
This commit modifies the logic for normalizing the dependency
vectors.  The previous implementation would not tolerate a keyword
for the `version` identifier in the second position in the tuple.
This caused problems with the lein-module plugin, which allows
keywords to be used as the version identifier.

This implementation takes a different approach, and only assumes
that the vector must end with keyword/value option pairs (if any
options are specified).  It extracts those first, and then tolerates
any remaining value to be interpreted as the version identifier
(including keywords).

This commit also adds some more strict checking of the contents
of the dependency vectors; specifically, it will throw an exception
if the options at the end of the vector are not keyword/value pairs,
or if the artifact id in the first position in the dependency tuple
is not a symbol.