### PR TITLE
Allow keyword dependency versions, fixes #2212

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -538,17 +538,17 @@
   due to the use of `:managed-dependencies`, and to inject a `nil` into the
   vector in the place where the version string should be."
   [dep]
-  (if dep
+  ;; Some plugins may replace a keyword with a version string later on, so
+  ;; assume that even lenght vectors are alright. If not, then they will blow up
+  ;; at a later stage.
+  (if (even? (count dep))
+    dep
     (let [id (first dep)
-          sec (second dep)
-          version (if-not (keyword? sec) sec)
-          opts (if (keyword? sec)
-                 (nthrest dep 1)
-                 (nthrest dep 2))]
+          opts (rest dep)]
       ;; it's important to preserve the metadata, because it is used for
       ;; profile merging, etc.
       (with-meta
-       (into [id version] opts)
+       (into [id nil] opts)
        (meta dep)))))
 
 (defn normalize-dep-vectors

--- a/leiningen-core/test/leiningen/core/test/classpath.clj
+++ b/leiningen-core/test/leiningen/core/test/classpath.clj
@@ -106,3 +106,33 @@
                  ["sonatype" {:url "https://oss.sonatype.org/"}]
                  ["internal" {:url "https://sekrit.info/repo"
                               :username :gpg :password :gpg}]])))))
+
+(deftest test-normalize-dep-vectors
+  (testing "dep vectors with string version"
+    (is (= ['foo/bar "1.0.0"]
+           (normalize-dep-vector ['foo/bar "1.0.0"])))
+    (is (= ['foo/bar "1.0.0" :classifier "test"]
+           (normalize-dep-vector ['foo/bar "1.0.0" :classifier "test"])))
+    (is (= ['foo/bar "1.0.0" :classifier "test" :exclusions ['foo/baz]]
+           (normalize-dep-vector ['foo/bar "1.0.0" :classifier "test" :exclusions ['foo/baz]]))))
+  (testing "dep vectors with keyword version (e.g., for use with lein-modules)"
+    (is (= ['foo/bar :version]
+           (normalize-dep-vector ['foo/bar :version])))
+    (is (= ['foo/bar :version :classifier "test"]
+           (normalize-dep-vector ['foo/bar :version :classifier "test"])))
+    (is (= ['foo/bar :version :classifier "test" :exclusions ['foo/baz]]
+           (normalize-dep-vector ['foo/bar :version :classifier "test" :exclusions ['foo/baz]]))))
+  (testing "dep vectors with explicit nils for versions (managed dependencies)"
+    (is (= ['foo/bar nil]
+           (normalize-dep-vector ['foo/bar nil])))
+    (is (= ['foo/bar nil :classifier "test"]
+           (normalize-dep-vector ['foo/bar nil :classifier "test"])))
+    (is (= ['foo/bar nil :classifier "test" :exclusions ['foo/baz]]
+           (normalize-dep-vector ['foo/bar nil :classifier "test" :exclusions ['foo/baz]]))))
+  (testing "dep vectors with implicit nils for versions (managed dependencies)"
+    (is (= ['foo/bar nil]
+           (normalize-dep-vector ['foo/bar])))
+    (is (= ['foo/bar nil :classifier "test"]
+           (normalize-dep-vector ['foo/bar :classifier "test"])))
+    (is (= ['foo/bar nil :classifier "test" :exclusions ['foo/baz]]
+           (normalize-dep-vector ['foo/bar :classifier "test" :exclusions ['foo/baz]])))))


### PR DESCRIPTION
This is an alternative to #2213 and also solves #2212, albeit with a different solution:

The assumption is that dependency vectors have always been even elements long until we added managed dependencies (Otherwise they'd blow up at runtime). If that's the case, then the only vectors of odd length are the ones without a version explicitly set. This means we can just check a vector's length to verify whether we should inject a `nil` or not after the version identifier.