### PR TITLE
(#2216) Fix bug with managed deps in profiles w/:replace

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -539,7 +539,7 @@
   vector in the place where the version string should be."
   [dep]
   ;; Some plugins may replace a keyword with a version string later on, so
-  ;; assume that even lenght vectors are alright. If not, then they will blow up
+  ;; assume that even length vectors are alright. If not, then they will blow up
   ;; at a later stage.
   (if (even? (count dep))
     dep

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -336,6 +336,15 @@
          (normalize-values)))
     (meta raw-map)))
 
+(defn- with-normalized-deps
+  [profile]
+  (let [deps (:dependencies profile)]
+    (assoc profile
+      :dependencies
+      (with-meta
+       (classpath/normalize-dep-vectors deps)
+       (meta deps)))))
+
 (defn- setup-profile-with-empty
   "Setup a profile map with empty defaults."
   [raw-profile]
@@ -347,7 +356,9 @@
       (meta raw-profile))
     (let [empty-defaults (select-keys empty-meta-merge-defaults
                                       (keys raw-profile))]
-      (setup-map-defaults raw-profile empty-defaults))))
+      (setup-map-defaults
+       (with-normalized-deps raw-profile)
+       empty-defaults))))
 
 (defn- setup-map-of-profiles
   "Setup a map of profile maps with empty defaults."

--- a/test/leiningen/test/deps.clj
+++ b/test/leiningen/test/deps.clj
@@ -8,7 +8,8 @@
             [leiningen.core.utils :as utils]
             [leiningen.core.eval :as eval]
             [leiningen.core.classpath :as classpath]
-            [cemerick.pomegranate.aether :as aether]))
+            [cemerick.pomegranate.aether :as aether]
+            [leiningen.core.project :as project]))
 
 (deftest ^:online test-deps
   (let [sample-deps [["rome" "0.9"] ["jdom" "1.0"]]]
@@ -203,3 +204,9 @@
                                                          (fn [dep] (= 'org.clojure/tools.reader (first dep))))
                                                         first
                                                         second)))))))
+
+(deftest test-managed-deps-with-profiles
+  (testing "Able to resolve deps when profile omits versions in deps"
+    (deps (project/set-profiles managed-deps-project [:add-deps])))
+  (testing "Able to resolve deps when profile with ^:replace omits versions in deps"
+    (deps (project/set-profiles managed-deps-project [:replace-deps]))))

--- a/test_projects/managed-deps/project.clj
+++ b/test_projects/managed-deps/project.clj
@@ -23,4 +23,7 @@
                  [org.apache.commons/commons-csv :classifier "sources"]
                  [org.clojure/tools.emitter.jvm "0.1.0-beta5"] ; depends on tools.reader 0.8.5
                  [org.clojure/tools.namespace "0.3.0-alpha3"] ; depends on tools.reader 0.10.0
-                 ])
+                 ]
+
+  :profiles {:add-deps {:dependencies [[org.clojure/clojure]]}
+             :replace-deps {:dependencies ^:replace [[org.clojure/clojure]]}})


### PR DESCRIPTION
Prior to this commit, profiles with `^:replace` on the dependencies
list would never end up having their dependencies vector normalized
so that it would have `nil` placeholders for the versions of
dependencies that were inheriting their version from `:managed-dependencies`.

This commit normalizes the dependencies vector of a profile during
initialization, to make sure that it will always be normalized.