### PR TITLE
Only warn about each exclusion once

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -382,7 +382,7 @@
         (doseq [r ranges]
           (warn r)))
       (warn "\nConsider using these exclusions:")
-      (doseq [ex exclusions]
+      (doseq [ex (distinct exclusions)]
         (warn ex))
       (warn))))
 


### PR DESCRIPTION
In one of my projects, `lein deps :tree` produces output like below. I think it would be clearer (and less daunting for the user) to only print each distinct exclusion once.
(I haven't actually tested the change, so I may have missed something, but hopefully it should be this simple?)
```
Consider using these exclusions:
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-hive_2.11 "2.0.0" :exclusions [org.antlr/ST4 org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-sql_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.apache.spark/spark-core_2.11 "2.0.0" :exclusions [org.slf4j/slf4j-log4j12 org.slf4j/slf4j-api]]
[org.slf4j/slf4j-log4j12 "1.7.12" :exclusions [org.slf4j/slf4j-api]]
```