### PR TITLE
Infer classifier when deploying adhoc files

### DIFF
--- a/src/leiningen/deploy.clj
+++ b/src/leiningen/deploy.clj
@@ -155,6 +155,16 @@
       "pom"
       (last (.split f "\\.")))))
 
+(defn classifier
+  "The classifier is be located between the version and extension name of the artifact.
+
+  See http://maven.apache.org/plugins/maven-deploy-plugin/examples/deploying-with-classifiers.html "
+  [version f]
+  (let [pattern (re-pattern (format "%s-(.*)\\.%s" version (extension f)))
+        [_ classifier-of] (re-find pattern f)]
+    (when-not (empty? classifier-of)
+      classifier-of)))
+
 (defn- fail-on-empty-project [project]
   (when-not (:root project)
     (main/abort "Couldn't find project.clj, which is needed for deploy task")))
@@ -213,7 +223,8 @@ be able to depend on jars that are deployed without a pom."
            group-id (namespace identifier)
            repo (repo-for project repository)
            artifacts (for [f files]
-                       [[:extension (extension f)] f])]
+                       [[:extension (extension f)
+                         :classifier (classifier version f)] f])]
        (main/debug "Deploying" files "to" repo)
        (aether/deploy
         :coordinates [(symbol group-id artifact-id) version]

--- a/test/leiningen/test/deploy.clj
+++ b/test/leiningen/test/deploy.clj
@@ -68,3 +68,11 @@
     (is (thrown? clojure.lang.ExceptionInfo (deploy nil))))
   (testing "Fail if project data is missing"
     (is (thrown? clojure.lang.ExceptionInfo (deploy nil "snapshots")))))
+
+(deftest classifiying
+  (are [expected version file] (= expected (classifier version file))
+      "fat" "1.2.3"          "some-project-1.2.3-fat.jar"
+      "fat" "1.2.3-alpha6"   "some-project-1.2.3-alpha6-fat.jar"
+      "fat" "1.2.3-SNAPSHOT" "some-project-1.2.3-SNAPSHOT-fat.jar"
+      nil   "1.2.3"          "some-project-1.2.3-.jar"
+      nil   "1.2.3"          "some-project-1.2.3.jar"))

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -50,6 +50,8 @@
 
 (def sample-fixture-error-project (read-test-project "sample-fixture-error"))
 
+(def sample-deploy-project (read-test-project "sample-deploy"))
+
 (def tricky-name-project (read-test-project "tricky-name"))
 
 (def native-project (read-test-project "native"))

--- a/test_projects/sample-deploy/deploy-me-0.1.0-SNAPSHOT-fat.jarr
+++ b/test_projects/sample-deploy/deploy-me-0.1.0-SNAPSHOT-fat.jarr
@@ -1,0 +1,1 @@
+I am a teapot!

--- a/test_projects/sample-deploy/project.clj
+++ b/test_projects/sample-deploy/project.clj
@@ -1,0 +1,6 @@
+(defproject deploy-me "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.8.0"]])


### PR DESCRIPTION
Infer the classifier from the file path if it exists when performing `lein deploy`. 

Fixes #2161 

See: http://maven.apache.org/plugins/maven-deploy-plugin/examples/deploying-with-classifiers.html