### PR TITLE
Use new clojars repo url

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -281,7 +281,7 @@
 (def default-repositories
   (with-meta
     [["central" {:url "https://repo1.maven.org/maven2/" :snapshots false}]
-     ["clojars" {:url "https://clojars.org/repo/"}]]
+     ["clojars" {:url "https://repo.clojars.org/"}]]
     {:reduce reduce-repo-step}))
 
 (def deploy-repositories

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -49,7 +49,7 @@
 
                :repositories [["central" {:url "https://repo1.maven.org/maven2/"
                                           :snapshots false}]
-                              ["clojars" {:url "https://clojars.org/repo/"}]]})
+                              ["clojars" {:url "https://repo.clojars.org/"}]]})
 
 (deftest test-read-project
   (let [actual (read (.getFile (io/resource "p1.clj")))]

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -75,7 +75,7 @@
            (map #(first-in % [:repository :id])
                 (deep-content xml [:project :repositories])))
         "repositories are named")
-    (is (= ["https://repo1.maven.org/maven2/" "https://clojars.org/repo/"
+    (is (= ["https://repo1.maven.org/maven2/" "https://repo.clojars.org/"
             "http://example.com/repo"]
            (map #(first-in % [:repository :url])
                 (deep-content xml [:project :repositories])))


### PR DESCRIPTION
This switches the default repo url (for resolving artifacts, not
deploying) to point to the CDN-fronted repo. Note that this repo won't
work with Java 6 - users of 6 will need to manually override the default
url to point to the old one (https://clojars.org/repo).