### PR TITLE
Update to dynapath 0.2.5

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -8,7 +8,7 @@
                  [classlojure "0.6.6"]
                  [robert/hooke "1.3.0"]
                  [com.cemerick/pomegranate "0.3.1" :exclusions [org.tcrawley/dynapath]]
-                 [org.tcrawley/dynapath "0.2.4"]
+                 [org.tcrawley/dynapath "0.2.5"]
                  [org.apache.maven.wagon/wagon-http "2.10"]
                  [com.hypirion/io "0.3.1"]
                  [pedantic "0.2.0"]]


### PR DESCRIPTION
This version addresses two Java 9 related issues:

* 0.2.4 would fail under Java 9 if AOT'd
* the latest Java 9 build (9-ea+148) broke dynapath's reflection to make
  URLClassLoader modifiable