### PR TITLE
fix :plugins not use the configuration in the ~/.lein/profiles.clj

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -867,10 +867,12 @@
   "Compute a fresh version of the project map, with middleware applied,
   including and excluding the specified profiles."
   [project include-profiles & [exclude-profiles]]
-  (-> project
-      (init-profiles include-profiles exclude-profiles)
-      (load-plugins)
-      (activate-middleware)))
+  (let [keep-info (select-keys project [:local-repo :mirrors])]
+    (-> project
+        (init-profiles include-profiles exclude-profiles)
+        (merge keep-info)
+        (load-plugins)
+        (activate-middleware))))
 
 (defn merge-profiles
   "Compute a fresh version of the project map with the given profiles merged
@@ -904,13 +906,13 @@
   "Initializes a project by loading certificates, plugins, middleware, etc.
 Also merges default profiles."
   ([project default-profiles]
-     (-> (project-with-profiles (doto project
-                                  (load-certificates)
-                                  (init-lein-classpath)
-                                  (load-plugins)))
-         (init-profiles default-profiles)
-         (load-plugins)
-         (activate-middleware)))
+   (-> (project-with-profiles project)
+       (init-profiles default-profiles)
+       (doto
+         (load-certificates)
+         (init-lein-classpath)
+         (load-plugins))
+       (activate-middleware)))
   ([project] (init-project project [:default])))
 
 (defn add-profiles

--- a/src/leiningen/new.clj
+++ b/src/leiningen/new.clj
@@ -24,7 +24,7 @@
                        (:plugin-repositories user-profiles))]
     (merge {:templates [[template-symbol template-version]]
             :repositories repositories}
-           (select-keys user-profiles [:mirrors]))))
+           (select-keys user-profiles [:mirrors :local-repo]))))
 
 (defn resolve-remote-template [name sym]
   (try (cp/resolve-dependencies :templates (fake-project name) :add-classpath? true)


### PR DESCRIPTION
The configuration in ~/.lein/profiles.clj will lose efficacy,  when you
write  a top level :plugins in the project.clj.
simple test passed!