### PR TITLE
Bump org.apache.maven.indexer version to latest

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [commons-io "2.5"]
                  [bultitude "0.2.8"]
                  [stencil "0.5.0" :exclusions [org.clojure/core.cache]]
-                 [org.apache.maven.indexer/indexer-core "4.1.3"
+                 [org.apache.maven.indexer/indexer-core "5.1.1"
                   :exclusions [org.apache.maven/maven-model
                                org.sonatype.aether/aether-api
                                org.sonatype.aether/aether-util


### PR DESCRIPTION
Rationale: I want to help get leiningen packaged for Debian again ([it hasn't been since 1.7.1](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=819811)). This particular dependency, in addition to the old dynapath and commons-io versions in 2.7.1, are behind the versions currently available in Debian unstable.

At the same time, I'm going to work to get all of the missing dependencies for leiningen in Debian uploaded, and all the out-of-date dependencies in Debian updated.