### PR TITLE
Remove lein-newnew references from templates docs

### DIFF
--- a/doc/TEMPLATES.md
+++ b/doc/TEMPLATES.md
@@ -50,8 +50,8 @@ an artifact-id of "lein-template".
 ## Structure
 
 The files that your template will provide to users are in
-`src/leiningen/new/liquid_cool`. lein-newnew starts you off with just
-one, named "foo.clj". You can see it referenced in
+`src/leiningen/new/liquid_cool`. The template generator starts you off
+with just one, named "foo.clj". You can see it referenced in
 `src/leiningen/new/liquid_cool.clj`, right underneath the
 `->files data` line.
 
@@ -67,7 +67,7 @@ templates](https://github.com/technomancy/leiningen/tree/stable/resources/leinin
 ## Testing Your Template
 
 While developing a template, if you're in the template project directory, 
-lein-newnew will pick it up and you'll be able to test it.  e.g. from the
+leiningen will pick it up and you'll be able to test it.  e.g. from the
 `liquid-cool-template` dir:
 
     $ lein new liquid-cool myproject
@@ -83,7 +83,7 @@ directory on your system.
 
 ## Templating System
 
-lein-newnew uses [stencil][] for templating, which implements the
+The default generated template uses [stencil][] for templating, which implements the
 language-agnostic templating system [Mustache][]. All the available tag types
 can be found in the [Mustache manual][mustache-manual]; we will only go through
 the most common tag type here.


### PR DESCRIPTION
I don't know for suresies that this makes sense.

My cursory understanding is that lein-newnew was integrated into lein 2, and it seems this doc file was adapted from lein-newnew's docs and had some leftover references.

Hopefully somebody more familiar with the templates than myself can verify that these changes make sense.

It's hard to talk clearly about template templates.