### PR TITLE
Add support for string deps in project.clj

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * The `search` task no longer downloads indices but hits live search APIs. (Phil Hagelberg)
 * Remove duplicate exclusions in `lein deps` (Emlyn Corrin)
 * Leiningen is now installable again via chocolatey (Florian Anderiasch)
+* Dependency names can be specified as strings in addition to symbols (Wes Morgan)
 
 ## 2.7.1 / 2016-09-22
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -218,3 +218,19 @@ property.
 
 **Q:** `lein`/`lein.bat` won't download `leiningen-x.y.z-SNAPSHOT.jar`  
 **A:** You probably downloaded `lein`/`lein.bat` from the [master branch](https://github.com/technomancy/leiningen/tree/master/bin). Unless you plan to build leiningen yourself or help develop it, we suggest you use the latest stable version: [lein](https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein)/[lein.bat](https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein.bat)
+
+**Q:** I have a dependency whose group ID and/or artifact ID starts with a
+  number (which is invalid for symbols in Clojure). How can I add it to my
+  project's dependencies?  
+**A:** As of version 2.7.2, Leiningen supports string dependency names like
+  this:
+
+```clj
+:dependencies [["net.3scale/3scale-api" "3.0.2"]]
+```
+
+Prior to version 2.7.2, this is the workaround:
+
+```clj
+:dependencies [[~(symbol "net.3scale" "3scale-api") "3.0.2"]]
+```

--- a/leiningen-core/dev-resources/p1.clj
+++ b/leiningen-core/dev-resources/p1.clj
@@ -6,7 +6,9 @@
                  [clucy "0.2.2" :exclusions [org.clojure/clojure]]
                  [lancet "1.0.1"]
                  [robert/hooke "1.1.2"]
-                 [stencil "0.2.0"]]
+                 [stencil "0.2.0"]
+                 ["net.3scale/3scale-api" "3.0.2"]
+                 ["clj-http" "3.4.1"]]
   :twelve ~(+ 6 2 4)
   :disable-implicit-clean true
   :eval-in-leiningen true)

--- a/leiningen-core/pom.xml
+++ b/leiningen-core/pom.xml
@@ -14,7 +14,7 @@
     </license>
   </licenses>
   <scm>
-    <tag>f42a5cfec3c3bbe1fcc7cb63130955519bb7ca3a
+    <tag>bbbead38b2bbf6e4e7bb315b67dbde6948a6eb84
 </tag>
     <url/>
   </scm>
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http</artifactId>
-      <version>2.10</version>
+      <version>2.12</version>
     </dependency>
     <dependency>
       <groupId>com.hypirion</groupId>
@@ -117,6 +117,11 @@
       <groupId>pedantic</groupId>
       <artifactId>pedantic</artifactId>
       <version>0.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>1.7.22</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -49,13 +49,13 @@
   [profile]
   (vector? profile))
 
-(defn artifact-namespace
+(defn group-id
   [id]
   (if (string? id)
     (first (str/split id #"/"))
     (or (namespace id) (name id))))
 
-(defn artifact-name
+(defn artifact-id
   [id]
   (if (string? id)
     (last (str/split id #"/"))
@@ -63,8 +63,8 @@
 
 (defn artifact-map
   [id]
-  {:artifact-id (artifact-name id)
-   :group-id (artifact-namespace id)})
+  {:artifact-id (artifact-id id)
+   :group-id (group-id id)})
 
 (defn exclusion-map
   "Transform an exclusion vector into a map that is easier to combine with

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -9,7 +9,8 @@
             [cemerick.pomegranate.aether :as aether]
             [leiningen.core.utils :as utils]
             [leiningen.core.user :as user]
-            [leiningen.core.classpath :as classpath])
+            [leiningen.core.classpath :as classpath]
+            [clojure.string :as str])
   (:import (clojure.lang DynamicClassLoader)
            (java.io PushbackReader Reader)))
 
@@ -48,10 +49,22 @@
   [profile]
   (vector? profile))
 
+(defn artifact-namespace
+  [id]
+  (if (string? id)
+    (first (str/split id #"/"))
+    (or (namespace id) (name id))))
+
+(defn artifact-name
+  [id]
+  (if (string? id)
+    (last (str/split id #"/"))
+    (name id)))
+
 (defn artifact-map
   [id]
-  {:artifact-id (name id)
-   :group-id (or (namespace id) (name id))})
+  {:artifact-id (artifact-name id)
+   :group-id (artifact-namespace id)})
 
 (defn exclusion-map
   "Transform an exclusion vector into a map that is easier to combine with

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -36,11 +36,13 @@
                :eval-in :leiningen,
                :license {:name "Eclipse Public License"}
 
-               :dependencies '[[leiningen-core/leiningen-core "2.0.0-SNAPSHOT"]
+               :dependencies `[[leiningen-core/leiningen-core "2.0.0-SNAPSHOT"]
                                [clucy/clucy "0.2.2" :exclusions [[org.clojure/clojure]]]
                                [lancet/lancet "1.0.1"]
                                [robert/hooke "1.1.2"]
                                [stencil/stencil "0.2.0"]
+                               [~(symbol "net.3scale" "3scale-api") "3.0.2"]
+                               [clj-http/clj-http "3.4.1"]
                                [org.clojure/tools.nrepl "0.2.12"
                                 :exclusions [[org.clojure/clojure]]]
                                [clojure-complete/clojure-complete "0.2.4"

--- a/sample.project.clj
+++ b/sample.project.clj
@@ -42,6 +42,8 @@
   ;; to specify a prefix. This prefix is used to extract natives in
   ;; jars that don't adhere to the default "<os>/<arch>/" layout that
   ;; Leiningen expects.
+  ;; You can also strings like ["group-id/name" version] for instances
+  ;; where the dependency name isn't a valid symbol literal.
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.jclouds/jclouds "1.0" :classifier "jdk15"]
                  [net.sf.ehcache/ehcache "2.3.1" :extension "pom"]
@@ -49,6 +51,7 @@
                                               [javax.jms/jms :classifier "*"]
                                               com.sun.jdmk/jmxtools
                                               com.sun.jmx/jmxri]]
+                 ["net.3scale/3scale-api" "3.0.2"]
                  [org.lwjgl.lwjgl/lwjgl "2.8.5"]
                  [org.lwjgl.lwjgl/lwjgl-platform "2.8.5"
                   :classifier "natives-osx"


### PR DESCRIPTION
This is needed for rare cases where maven artifact-ids and/or group-ids
aren't valid symbols (e.g. they start with a number).

Test coverage added.

This PR was suggested in my bug report #2241.