### PR TITLE
Add note about file system permissions in get-dependencies

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -293,7 +293,7 @@
        (catch DependencyResolutionException e
          ;; Cannot recur from catch/finally so have to put this in its own defn
          (print-failures e)
-         (warn "This could be due to a typo in :dependencies or network issues.")
+         (warn "This could be due to a typo in :dependencies, file system permissions, or network issues.")
          (warn "If you are behind a proxy, try setting the 'http_proxy' environment variable.")
          (throw (ex-info "Could not resolve dependencies" {:suppress-msg true
                                                            :exit-code 1} e)))


### PR DESCRIPTION
:wave: I just encountered an issue where I couldn't install dependencies because my `~/.m2` directory had been created by a docker container, and only thought to check this after giving up and trying to manually install jars. This PR adds a note to the DependencyResolutionException handler which explicitly mentions that alongside the typo and network issues.

This is my first PR to Leiningen, so please let me know if there's anything else that needs to be done, and thanks for all your hard work :+1:.