### PR TITLE
adding docker deployment to travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: clojure
+sudo: required
+services:
+  - docker
 install: cd leiningen-core; lein install; lein classpath | tail -n 1 > .lein-bootstrap; cd ..
 script: bin/lein test
-sudo: false
 notifications:
   irc: "irc.freenode.org#leiningen"
+after_success:
+  - ./bin/push
 jdk:
   - openjdk6
   - openjdk7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM openjdk:8
+MAINTAINER Phil Hagelberg <phil@hagelb.org>
+
+ARG LEIN_VERSION="stable"
+
+ENV LEIN_ROOT "true"
+
+RUN wget -q -O /usr/bin/lein \
+    "https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein"
+
+RUN chmod +x /usr/bin/lein
+
+RUN lein
+
+ENTRYPOINT ["lein"]

--- a/bin/push
+++ b/bin/push
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+TAG="technomancy/leiningen:$TRAVIS_TAG"
+
+if [ -z "$TRAVIS_TAG"] && [ "master" != "$TRAVIS_BRANCH" ]
+then
+  exit 0
+fi
+
+if [ -z "$TRAVIS_TAG" ]
+then
+  TAG="technomancy/leiningen"
+  docker build . -t "$TAG"
+else
+  docker build --build-arg LEIN_VERSION="$TRAVIS_TAG" . -t "$TAG"
+fi
+
+docker push "$TAG"


### PR DESCRIPTION
Closes #2245 

Technically this isn't finished until you provide your encrypted docker username and password. I am happy to use mine, but I think you will to use yours.

Also, this download the script from githubusercontent, in the future you may want to add the leiningen binaries/scripts directly to the image.