### PR TITLE
Introduce optional chronological versioning to Leiningen

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -12,7 +12,9 @@
             [leiningen.core.classpath :as classpath]
             [clojure.string :as str])
   (:import (clojure.lang DynamicClassLoader)
-           (java.io PushbackReader Reader)))
+           (java.io PushbackReader Reader)
+           (java.text SimpleDateFormat)
+           (java.util Date TimeZone)))
 
 (defn make-project-properties [project]
   (with-open [baos (java.io.ByteArrayOutputStream.)]
@@ -420,11 +422,17 @@
           (format "Duplicate keys: %s"
                   (clojure.string/join ", " duplicates))))))))
 
+(def timestamp (SimpleDateFormat. "yyyyMMdd.HHmmss"))
+(.setTimeZone timestamp (TimeZone/getTimeZone "UTC"))
+
 (defmacro defproject
   "The project.clj file must either def a project map or call this macro.
   See `lein help sample` to see what arguments it accepts."
-  [project-name version & args]
-  (let [f (io/file *file*)]
+  [project-name & args]
+  (let [[version args] (if (odd? (count args))
+                         [(first args) (rest args)]
+                         [(.format timestamp (Date.)) args])
+        f (io/file *file*)]
     `(let [args# ~(unquote-project (argument-list->argument-map args))
            root# ~(if f (.getParent f))]
        (def ~'project


### PR DESCRIPTION
Inspired by [Spec-ulation keynote](https://youtu.be/oyLBGkS5ICk?t=47m31s). When version argument is missing in defproject, uses `yyyyMMdd.HHmmss` timestamp in UTC timezone as the project version.