### PR TITLE
Make profiles string in target path smarter

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -470,26 +470,29 @@
 (defn- keyword-composite-profile? [profile]
   (and (composite-profile? profile) (every? keyword? profile)))
 
-(defn- keyword-composite-profiles [project]
-  (filter (comp keyword-composite-profile? val)
-          (-> project meta :profiles)))
-
-(defn- longest-matching-composite [profiles composites]
-  (->> composites
+(defn- ordered-keyword-composite-profiles [project]
+  (->> project meta :profiles
+       (filter (comp keyword-composite-profile? val))
+       (remove (comp empty? val))
        (sort-by count)
-       (reverse)
+       (reverse)))
+
+(defn- first-matching-composite [profiles composites]
+  (->> composites
        (filter (fn [[_ v]] (= v (take (count v) profiles))))
        (first)))
 
 (defn- normalize-profile-names [project profiles]
-  (let [composites (keyword-composite-profiles project)]
-    (loop [profiles   profiles
+  (let [composites (ordered-keyword-composite-profiles project)]
+    (loop [profiles'  profiles
            normalized ()]
-      (if (seq profiles)
-        (if-let [[k v] (longest-matching-composite profiles composites)]
-          (recur (drop (count v) profiles) (cons k normalized))
-          (recur (rest profiles) (cons (first profiles) normalized)))
-        (reverse normalized)))))
+      (if (seq profiles')
+        (if-let [[k v] (first-matching-composite profiles' composites)]
+          (recur (drop (count v) profiles') (cons k normalized))
+          (recur (rest profiles') (cons (first profiles') normalized)))
+        (if (= (count profiles) (count normalized))
+          profiles
+          (normalize-profile-names project (reverse normalized)))))))
 
 (defn profile-scope-target-path [project profiles]
   (let [n #(if (map? %) (subs (sha1 (pr-str %)) 0 8) (name %))]

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -594,11 +594,19 @@
 (deftest test-profile-scope-target-path
   (let [project (with-meta
                   {:target-path "target/%s"}
-                  {:profiles {:ab [:a :b] :a {} :b {} :c {} :d {}}})]
+                  {:profiles {:ab  [:a :b]
+                              :abc [:a :b :c]
+                              :a   {}
+                              :b   {}
+                              :c   {}
+                              :d   {}}})]
     (are [ps tp] (= (profile-scope-target-path project ps) {:target-path tp})
-      [:a :b]    "target/ab"
-      [:a :b :c] "target/ab+c"
-      [:b :c]    "target/b+c"
-      [:b :a]    "target/ab"
-      [:c :b :a] "target/ab+c"
-      [:a]       "target/a")))
+      [:a :b]       "target/ab"
+      [:a :b :c]    "target/abc"
+      [:b :c]       "target/b+c"
+      [:b :a]       "target/b+a"
+      [:c :b :a]    "target/c+b+a"
+      [:c :a :b]    "target/c+ab"
+      [:a :b :c :d] "target/abc+d"
+      [:c :a :b :d] "target/c+ab+d"
+      [:a]          "target/a")))

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -595,11 +595,13 @@
   (let [project (with-meta
                   {:target-path "target/%s"}
                   {:profiles {:ab  [:a :b]
-                              :abc [:a :b :c]
+                              :abc [:ab :c]
+                              :bcd [:b :c :d]
                               :a   {}
                               :b   {}
                               :c   {}
-                              :d   {}}})]
+                              :d   {}
+                              :e   {}}})]
     (are [ps tp] (= (profile-scope-target-path project ps) {:target-path tp})
       [:a :b]       "target/ab"
       [:a :b :c]    "target/abc"
@@ -608,5 +610,6 @@
       [:c :b :a]    "target/c+b+a"
       [:c :a :b]    "target/c+ab"
       [:a :b :c :d] "target/abc+d"
+      [:e :b :c :d] "target/e+bcd"
       [:c :a :b :d] "target/c+ab+d"
       [:a]          "target/a")))

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -590,3 +590,15 @@
                 [["central" {:url "https://repo1.maven.org/maven2/"
                              :snapshots false}]
                  ["clojars" {:url "https://clojars.org/repo/"}]]}})))))))
+
+(deftest test-profile-scope-target-path
+  (let [project (with-meta
+                  {:target-path "target/%s"}
+                  {:profiles {:ab [:a :b] :a {} :b {} :c {} :d {}}})]
+    (are [ps tp] (= (profile-scope-target-path project ps) {:target-path tp})
+      [:a :b]    "target/ab"
+      [:a :b :c] "target/ab+c"
+      [:b :c]    "target/b+c"
+      [:b :a]    "target/ab"
+      [:c :b :a] "target/ab+c"
+      [:a]       "target/a")))


### PR DESCRIPTION
Currently if Leiningen is passed a target path like:

```clojure
:target-path "target/%s/"
```

Then the `%s` is substituted with a string of profiles. For example:

```
target/base+system+user+provided+dev
```

However, because the `:default` profile is a collection of all of these, it would be more concise for the target path to be:

```
target/default
```

This PR alters the `profile-scope-target-path` function to replace subsets of profiles that match a composite profile. So for example:

```clojure
[:base :system :user :provided :dev]      => "default"
[:base :system :user :provided :dev :foo] => "default+foo"
[:base :system :user :provided]           => "base+system+user+provided"
```

Currently composite profiles are added to the beginning of the string. Should order matter in this case?