### PR TITLE
Found a redundency in code and reduced it

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -160,11 +160,9 @@
                       [exclusion-spec]
                       exclusion-spec)]]
           [:exclusion (map (partial apply xml-tags)
-                           {:group-id (or (namespace dep)
-                                          (name dep))
-                            :artifact-id (name dep)
-                            :classifier classifier
-                            :type extension})])]))
+                           (merge (project/artifact-map dep)
+                                  {:classifier classifier
+                                   :type extension}))])]))
 
 (defmethod xml-tags ::dependency
   ([_ [dep version & {:keys [optional classifier


### PR DESCRIPTION
While reading the code I found the same snippet of code being used here as the functions in `leiningen.core.project` so I simply made the core in `leiningen.pom` use that.