### PR TITLE
[#2272] Catch exceptions on malformed profiles.clj files

### DIFF
--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -1,6 +1,7 @@
 (ns leiningen.core.utils
   (:require [clojure.java.io :as io]
-            [clojure.java.shell :as sh])
+            [clojure.java.shell :as sh]
+            [clojure.edn :as edn])
   (:import (com.hypirion.io RevivableInputStream)
            (clojure.lang LineNumberingPushbackReader)
            (java.io ByteArrayOutputStream PrintStream File FileDescriptor
@@ -40,7 +41,7 @@
   "Returns the first Clojure form in a file if it exists."
   [file]
   (if (.exists file)
-    (try (read-string (slurp file))
+    (try (edn/read-string (slurp file))
         (catch Exception e
          (binding [*out* *err*] ;; TODO: use main/warn for this in 3.0
            (println "Error reading"

--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -1,7 +1,6 @@
 (ns leiningen.core.utils
   (:require [clojure.java.io :as io]
-            [clojure.java.shell :as sh]
-            [clojure.edn :as edn])
+            [clojure.java.shell :as sh])
   (:import (com.hypirion.io RevivableInputStream)
            (clojure.lang LineNumberingPushbackReader)
            (java.io ByteArrayOutputStream PrintStream File FileDescriptor
@@ -41,14 +40,18 @@
   "Returns the first Clojure form in a file if it exists."
   [file]
   (if (.exists file)
-    (try (edn/read-string (slurp file))
+    (try (read-string (slurp file))
         (catch Exception e
          (binding [*out* *err*] ;; TODO: use main/warn for this in 3.0
            (println "Error reading"
                    (.getName file)
                    "from"
-                   (.getParent file)))
-         (throw e)))))
+                   (.getParent file))
+           (if (zero? (.length file))
+             (println "File cannot be empty")
+             (if (.contains (.getMessage e) "EOF while reading")
+               (println "Invalid content was found")
+               (println (.getMessage e)))))))))
 
 (defn symlink?
   "Checks if a File is a symbolic link or points to another file."

--- a/leiningen-core/test/leiningen/core/test/utils.clj
+++ b/leiningen-core/test/leiningen/core/test/utils.clj
@@ -1,0 +1,14 @@
+(ns leiningen.core.test.utils
+  (:require [leiningen.core.utils :as utils]
+            [clojure.test :refer [deftest testing is]]
+            [clojure.java.io :as io]))
+
+(def profiles "./leiningen-core/test/resources/")
+
+(def sample-profile {:user {:plugins '[[lein-pprint "1.1.1"]]}})
+
+(deftest read-profiles
+  (testing "Empty profile file"
+    (is (nil? (utils/read-file (io/file (str profiles "profiles-empty.clj"))))))
+  (testing "Non-empty profile file"
+    (is (= (utils/read-file (io/file (str profiles "profiles.clj"))) sample-profile))))

--- a/leiningen-core/test/resources/profiles.clj
+++ b/leiningen-core/test/resources/profiles.clj
@@ -1,0 +1,1 @@
+{:user {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
Using clojure.edn/read-string results in nil instead of an exception

    user=> (edn/read-string "")
    nil
    user=> (read-string "")
    RuntimeException EOF while reading  clojure.lang.Util.runtimeException (Util.java:221)