### PR TITLE
invoke GPG unattended with passphrase

### DIFF
--- a/doc/GPG.md
+++ b/doc/GPG.md
@@ -16,12 +16,14 @@
   - [How Leiningen uses GPG](#how-leiningen-uses-gpg)
     - [Signing a file](#signing-a-file)
     - [Overriding the gpg defaults](#overriding-the-gpg-defaults)
+    - [Setting the gpg passphrase for unattended deploys](#setting-the-gpg-passphrase-for-unattended-deploys)
   - [Troubleshooting](#troubleshooting)
     - [Debian based distributions](#debian-based-distributions-1)
       - [gpg: can't query passphrase in batch mode](#gpg-cant-query-passphrase-in-batch-mode)
     - [Mac OSX](#mac-osx)
       - [Unable to get GPG installed via Homebrew and OSX Keychain to work](#unable-to-get-gpg-installed-via-homebrew-and-osx-keychain-to-work)
       - [GPG doesn't ask for a passphrase](#gpg-doesnt-ask-for-a-passphrase)
+      - [gpg: decryption failed: secret key not available](#gpg-decryption-failed-secret-key-not-available)
     - [GPG prompts for passphrase but does not work with Leiningen](#gpg-prompts-for-passphrase-but-does-not-work-with-leiningen)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -248,6 +250,33 @@ repository specification in your project definition:
          [["releases" {:url "https://blueant.com/archiva/internal/releases"
                        :signing {:gpg-key "2ADFB13E"}}]
          ["snapshots" "https://blueant.com/archiva/internal/snapshots"]]
+       ...)
+
+### Setting the gpg passphrase for unattended deploys
+
+It's also possible to provide the passphrase required to unlock your
+keyring. This is meant only for unattended deploys, for example in a
+continuous integration system like Travis CI or CircleCI or Jenkins. 
+
+Passphrase can be configured in the environment: 
+
+    (defproject ham-biscuit "0.1.0"
+       ...
+       :signing {:gpg-key "bob@bobsons.net"
+                 :gpg-passphrase :env/gpgpass} ;; looks up GPGPASS from env
+       ...)
+
+In your CI service your gpg keyring will need to be encrypted and
+injected into the build, and the passphrase likewise encrypted such that
+the environment variable is visible only to the build.
+
+For testing purposes the pasphrase can also be set as a string literal
+but this is strongly discouraged in any production usage.
+
+    (defproject ham-biscuit "0.1.0"
+       ...
+       :signing {:gpg-key "bob@bobsons.net"
+                 :gpg-passphrase "my-passphrase-in-the-clear"}
        ...)
 
 ## Troubleshooting

--- a/leiningen-core/src/leiningen/core/user.clj
+++ b/leiningen-core/src/leiningen/core/user.clj
@@ -145,6 +145,16 @@
   []
   (zero? (:exit (gpg "--version"))))
 
+(defn gpg-version
+  "parse and return the version of gpg available"
+  []
+  (let [pattern #"gpg\s+\(GnuPG\)\s+(\d+)\.(\d+)\.(\d+)"]
+    (if-let [[_ major minor patch]
+             (re-find pattern (:out (gpg "--version")))]
+      {:major (Integer/parseInt major)
+       :minor (Integer/parseInt minor)
+       :patch (Integer/parseInt patch)})))
+
 (defn credentials-fn
   "Decrypt map from credentials.clj.gpg in Leiningen home if present."
   ([] (let [cred-file (io/file (leiningen-home) "credentials.clj.gpg")]

--- a/test/leiningen/test/deploy.clj
+++ b/test/leiningen/test/deploy.clj
@@ -68,14 +68,24 @@
            ["--yes" "-ab" "--" "foo.jar"]))
     (is (= (signing-args "foo.jar" {:gpg-key "123456"})
            ["--yes" "-ab" "--default-key" "123456" "--" "foo.jar"]))
-    (is (= (signing-args "foo.jar" {:gpg-key "123456" :gpg-passphrase "abc"})
-           ["--yes" "-ab" "--default-key" "123456"
-            "--passphrase-fd" "0" "--pinentry-mode" "loopback"
-            "--" "foo.jar"]))
-    (is (= (signing-args "foo.jar" {:gpg-passphrase "abc"})
-           ["--yes" "-ab"
-            "--passphrase-fd" "0" "--pinentry-mode" "loopback"
-            "--" "foo.jar"]))
+    (with-redefs [user/gpg-version (fn [] {:major 2 :minor 1 :patch 0})]
+      (is (= (signing-args "foo.jar" {:gpg-key "123456" :gpg-passphrase "abc"})
+             ["--yes" "-ab" "--default-key" "123456"
+              "--passphrase-fd" "0" "--pinentry-mode" "loopback"
+              "--" "foo.jar"]))
+      (is (= (signing-args "foo.jar" {:gpg-passphrase "abc"})
+             ["--yes" "-ab"
+              "--passphrase-fd" "0" "--pinentry-mode" "loopback"
+              "--" "foo.jar"])))
+    (with-redefs [user/gpg-version (fn [] {:major 1 :minor 4 :patch 0})]
+      (is (= (signing-args "foo.jar" {:gpg-key "123456" :gpg-passphrase "abc"})
+             ["--yes" "-ab" "--default-key" "123456"
+              "--passphrase-fd" "0" "--batch"
+              "--" "foo.jar"]))
+      (is (= (signing-args "foo.jar" {:gpg-passphrase "abc"})
+             ["--yes" "-ab"
+              "--passphrase-fd" "0" "--batch"
+              "--" "foo.jar"])))
     (is (= (signing-passphrase {}) nil))
     (is (= (signing-passphrase {:gpg-passphrase "abc"}) "abc"))
     (with-redefs [user/getenv (fn [v] (if (= v "LEIN_GPG_PASSPHRASE") "abc" nil))]

--- a/test/leiningen/test/deploy.clj
+++ b/test/leiningen/test/deploy.clj
@@ -2,6 +2,7 @@
   (:use [clojure.test]
         [clojure.java.io :only [file]]
         [leiningen.deploy]
+        [leiningen.core.user :as user]
         [leiningen.test.helper :only [delete-file-recursively
                                       tmp-dir sample-project
                                       sample-deploy-project]]))
@@ -66,7 +67,21 @@
     (is (= (signing-args "foo.jar" nil)
            ["--yes" "-ab" "--" "foo.jar"]))
     (is (= (signing-args "foo.jar" {:gpg-key "123456"})
-           ["--yes" "-ab" "--default-key" "123456" "--" "foo.jar"])))
+           ["--yes" "-ab" "--default-key" "123456" "--" "foo.jar"]))
+    (is (= (signing-args "foo.jar" {:gpg-key "123456" :gpg-passphrase "abc"})
+           ["--yes" "-ab" "--default-key" "123456"
+            "--passphrase-fd" "0" "--pinentry-mode" "loopback"
+            "--" "foo.jar"]))
+    (is (= (signing-args "foo.jar" {:gpg-passphrase "abc"})
+           ["--yes" "-ab"
+            "--passphrase-fd" "0" "--pinentry-mode" "loopback"
+            "--" "foo.jar"]))
+    (is (= (signing-passphrase {}) nil))
+    (is (= (signing-passphrase {:gpg-passphrase "abc"}) "abc"))
+    (with-redefs [user/getenv (fn [v] (if (= v "LEIN_GPG_PASSPHRASE") "abc" nil))]
+      (is (= (signing-passphrase {:gpg-passphrase :env}) "abc")))
+    (with-redefs [user/getenv (fn [v] (if (= v "MYPASS") "abc" nil))]
+      (is (= (signing-passphrase {:gpg-passphrase :env/mypass}) "abc"))))
   (testing "Key selection"
     (is (= (:gpg-key (signing-opts {:signing {:gpg-key "key-project"}}
                                    ["repo" {:signing {:gpg-key "key-repo"}}]))


### PR DESCRIPTION

The purpose of this pull request is to ask if the approach will be accepted *before* I finish up the integration and testing.

The concept is to offer "gpg --passphrase-fd 0" as an alternate way to supply a passphrase, for example to perform unattended jar signing in TravisCI or similar.

So the key changes were to add some syntax for specifying the passphrase in the project.clj via an environment variable (which can be encrypted in a way that won't be revealed in Travis CI). And then some enhancement to the way gpg is launched to supply that passphrase on stdin. A few unit tests were added too.

If folks are okay with this approach I will probably close the pull request and keep working to complete the implementation, and then reopen a new pull request with the complete change when I think it's closer to done.

thanks

