### PR TITLE
Fix #2284: avoid visiting checkouts we've already seen

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -1041,7 +1041,7 @@ Also initializes the project; see read-raw for a version that skips init."
   dependencies."
   [project]
   (for [dep (.listFiles (io/file (:root project) "checkouts"))
-        :let [project-file (io/file dep "project.clj")
+        :let [project-file (.getCanonicalFile (io/file dep "project.clj"))
               checkout-project (read-dependency-project project-file)]
         :when checkout-project]
     checkout-project))


### PR DESCRIPTION
Checkouts are recursive by default and the same checkout project may be
reachable via several paths when symlinks are used. Avoid visiting projects
multiple times by keeping track of seen projects while accumulating
checkouts classpath entries.