### PR TITLE
Trim whitespace in Git HEAD commit hash

### DIFF
--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -212,7 +212,7 @@
   (try
     (let [git-ref (sh/sh "git" "rev-parse" "HEAD" :dir git-dir)]
       (if (= (:exit git-ref) 0)
-        (:out git-ref)
+        (.trim (:out git-ref))
         (read-git-head-file git-dir)))
     (catch java.io.IOException e (read-git-head-file git-dir))))
 

--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -55,7 +55,7 @@
   (try
     (let [git-ref (sh/sh "git" "rev-parse" "HEAD" :dir git-dir)]
       (if (= (:exit git-ref) 0)
-        (:out git-ref)
+        (.trim (:out git-ref))
         (read-git-head-file git-dir)))
     (catch IOException e (read-git-head-file git-dir))))
 


### PR DESCRIPTION
The Git commit hash in both the generated pom.xml and the pom.properties file includes a trailing newline, but only when the code path is taken that runs `git rev-parse`. Other code paths (`read-git-ref`, `read-git-head-file`) already trim what they read so do it here as well.

Have to make the same change twice because of duplicated code.

No tests, but verified locally. Thank you!