### PR TITLE
Do not include project.clj in JAR root (reverts commit 0412001)

### DIFF
--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -199,8 +199,6 @@
                             (:group project) (:name project))
               :bytes (.getBytes (pom/make-pom project))}
              {:type :bytes :path (scope "project.clj")
-              :bytes (.getBytes (slurp (str (:root project) "/project.clj")))}
-             {:type :bytes :path "project.clj"
               :bytes (.getBytes (slurp (str (:root project) "/project.clj")))}]
             (for [doc (map (partial io/file (:root project))
                         (concat readmes licenses))


### PR DESCRIPTION
Consider reverting commit 0412001c, made five years ago for Leiningen 1 compatibility.

In commit d038306 (2012-04-12) JAR format was tidied up a little to contain `project.clj` in a namespaced dir in `META-INF/leiningen` instead of directly in the root (and therefore on the classpath).

In commit 0412001 (2012-06-22), before the release of Leiningen 2, this change was partially undone to retain compatibility with Leiningen 1.

Is Leiningen 1 still fully supported? If not, please consider reverting 0412001 to avoid shadowing issues/not have project.clj included multiple times/not have project.clj on the classpath/slightly tidier JARs.
