### PR TITLE
Prevent boxed math warnings in `lein test`

### DIFF
--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -117,9 +117,10 @@
             (spit ".lein-failures" (if ~*monkeypatch?*
                                      (pr-str @failures#)
                                      "#<disabled :monkeypatch-clojure-test>"))
-            (if ~*exit-after-tests*
-              (System/exit (+ (:error summary#) (:fail summary#)))
-              (+ (:error summary#) (:fail summary#))))))))
+            (let [total# (+ (int (:error summary#)) (int (:fail summary#)))]
+              (if ~*exit-after-tests*
+                (System/exit total#)
+                total#)))))))
 
 (defn- split-selectors [args]
   (let [[nses selectors] (split-with (complement keyword?) args)]


### PR DESCRIPTION
This change prevents `lein test` from generating mysterious boxed math
warnings like the following when `*unchecked-math*` is `:warn-on-boxed` in
the `:test` profile:

    % lein test
    Boxed math warning, /private/var/folders/g8/bx1hjysj0zz4zr8ljghr4b0m0000gn/T/form-init2325898126244193444.clj:1:11129 - call: public static java.lang.Number clojure.lang.Numbers.unchecked_add(java.lang.Object,java.lang.Object).
    Boxed math warning, /private/var/folders/g8/bx1hjysj0zz4zr8ljghr4b0m0000gn/T/form-init2325898126244193444.clj:1:11208 - call: public static java.lang.Number clojure.lang.Numbers.unchecked_add(java.lang.Object,java.lang.Object).

    lein test myapp.core

    Ran 12 tests containing 49 assertions.
    0 failures, 0 errors.