### PR TITLE
[WIP] Respect declaration order of dependencies

### DIFF
--- a/leiningen-core/pom.xml
+++ b/leiningen-core/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.cemerick</groupId>
       <artifactId>pomegranate</artifactId>
-      <version>0.4.0-alpha1</version>
+      <version>0.4.0-alpha2-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>org.tcrawley</groupId>

--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -7,7 +7,7 @@
                  [bultitude "0.2.8" :exclusions [org.tcrawley/dynapath]]
                  [org.flatland/classlojure "0.7.1"]
                  [robert/hooke "1.3.0"]
-                 [com.cemerick/pomegranate "0.4.0-alpha1"
+                 [com.cemerick/pomegranate "0.4.0-alpha2-SNAPSHOT"
                   :exclusions [org.tcrawley/dynapath
                                org.codehaus.plexus/plexus-utils]]
                  [org.tcrawley/dynapath "0.2.5"]

--- a/src/leiningen/deps.clj
+++ b/src/leiningen/deps.clj
@@ -9,9 +9,13 @@
             [cemerick.pomegranate.aether :as aether])
   (:import (org.eclipse.aether.resolution DependencyResolutionException)))
 
+(defn- ordered-deps [deps]
+  (->> (or (:ordered-keys (meta deps)) (keys deps))
+       (map #(find deps %))))
+
 (defn- walk-deps
   ([deps f level]
-     (doseq [[dep subdeps] deps]
+     (doseq [[dep subdeps] (ordered-deps deps)]
        (f dep level)
        (when subdeps
          (walk-deps subdeps f (inc level)))))
@@ -27,7 +31,7 @@
 
 (defn- why-deps
   ([deps target path]
-   (doseq [[[dep version] subdeps] deps]
+   (doseq [[[dep version] subdeps] (ordered-deps deps)]
      (when (= target dep)
        (doall (map-indexed #(println (apply str (repeat %1 "  ")) %2)
                            (conj path [dep version]))))

--- a/test/leiningen/test/deps.clj
+++ b/test/leiningen/test/deps.clj
@@ -5,6 +5,7 @@
                                       managed-deps-project
                                       delete-file-recursively]])
   (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [leiningen.core.utils :as utils]
             [leiningen.core.eval :as eval]
             [leiningen.core.classpath :as classpath]
@@ -21,45 +22,50 @@
     (doseq [[n v] sample-deps]
       (is (.exists (m2-dir n v)) (str n " was not downloaded.")))))
 
+(defn- includes-in-order? [s substrs]
+  (->> substrs
+       (map #(str/index-of s %))
+       (apply <)))
+
 (deftest ^:online test-dependency-hierarchy
   (let [sample-deps [["ring" "1.0.0"] ["rome" "0.9"] ["jdom" "1.0"]]]
     (doseq [[n v] sample-deps]
       (delete-file-recursively (m2-dir n v) :silently))
-    (let [out (with-out-str (deps sample-project ":tree"))]
-      (doseq [dep '[[org.clojure/clojure "1.3.0"]
-                    [ring "1.0.0"]
-                    [ring/ring-core "1.0.0"]
-                    [commons-codec "1.4"]
-                    [commons-fileupload "1.2.1"]
-                    [commons-io "1.4"]
-                    [javax.servlet/servlet-api "2.5"]
-                    [ring/ring-devel "1.0.0"]
-                    [clj-stacktrace "0.2.2"]
-                    [hiccup "0.3.7"]
-                    [ns-tracker "0.1.1"]
-                    [org.clojure/tools.namespace "0.1.0"]
-                    [org.clojure/java.classpath "0.1.0"]
-                    [ring/ring-jetty-adapter "1.0.0"]
-                    [org.mortbay.jetty/jetty-util "6.1.25"]
-                    [org.mortbay.jetty/jetty "6.1.25"]
-                    [org.mortbay.jetty/servlet-api "2.5-20081211"]
-                    [ring/ring-servlet "1.0.0"]
-                    [rome "0.9"]
-                    [jdom "1.0"]]]
-        (is (.contains out (pr-str dep)))))))
+    (let [out (with-out-str (deps sample-project ":tree"))
+          deps '[[org.clojure/clojure "1.3.0"]
+                 [rome "0.9"]
+                 [jdom "1.0"]
+                 [ring "1.0.0"]
+                 [ring/ring-core "1.0.0"]
+                 [commons-codec "1.4"]
+                 [commons-io "1.4"]
+                 [commons-fileupload "1.2.1"]
+                 [javax.servlet/servlet-api "2.5"]
+                 [ring/ring-devel "1.0.0"]
+                 [hiccup "0.3.7"]
+                 [clj-stacktrace "0.2.2"]
+                 [ns-tracker "0.1.1"]
+                 [org.clojure/tools.namespace "0.1.0"]
+                 [org.clojure/java.classpath "0.1.0"]
+                 [ring/ring-jetty-adapter "1.0.0"]
+                 [org.mortbay.jetty/jetty "6.1.25"]
+                 [org.mortbay.jetty/servlet-api "2.5-20081211"]
+                 [org.mortbay.jetty/jetty-util "6.1.25"]
+                 [ring/ring-servlet "1.0.0"]]]
+      (is (includes-in-order? out (map pr-str deps))))))
 
 (deftest ^:online test-plugin-dependency-hierarchy
   (let [sample-plugin-deps [["codox" "0.6.4"]]]
     (doseq [[n v] sample-plugin-deps]
       (delete-file-recursively (m2-dir n v) :silently))
-    (let [out (with-out-str (deps sample-project ":plugin-tree"))]
-      (doseq [plugin-dep '[[codox "0.6.4"]
-                           [codox/codox.leiningen "0.6.4"]
-                           [leinjacker "0.4.1"]
-                           [org.clojure/core.contracts "0.0.1"]
-                           [org.clojure/clojure "1.4.0"]
-                           [org.clojure/core.unify "0.5.3"]]]
-        (is (.contains out (pr-str plugin-dep)))))))
+    (let [out (with-out-str (deps sample-project ":plugin-tree"))
+          plugin-deps '[[codox "0.6.4"]
+                        [codox/codox.leiningen "0.6.4"]
+                        [leinjacker "0.4.1"]
+                        [org.clojure/core.contracts "0.0.1"]
+                        [org.clojure/core.unify "0.5.3"]
+                        [org.clojure/clojure "1.4.0"]]]
+      (is (includes-in-order? out (map pr-str plugin-deps))))))
 
 (deftest ^:online test-snapshots-releases
   (let [pr (assoc sample-project


### PR DESCRIPTION
This change modifies Leiningen’s behaviour to respect/preserve the declaration order of dependencies. Dependency order is visible in tasks such as `lein classpath` or `lein deps :tree`.

The Maven dependency resolution mechanism which Leiningen uses handles dependencies in declaration order and preserves declaration order throughout. Leiningen currently does not take this dependency order information into account. Indeed, this information is not available through Pomegranate, the library to which Leiningen delegates the job of resolving dependencies. With this change (and the one proposed for cemerick/pomegranate#86) we fall back in line with the Maven way of doing things.

For users of Leiningen, the current state of affairs is this: dependencies appear sometimes in random order (`lein classpath`), sometimes in a deterministic but arbitrary order (`lein deps :tree` in alphabetic order).

The proposed new state of affairs is this: dependencies appear in the order in which they are declared, consistent with Maven. There is some risk because dependencies are such a fundamental thing – however, I think the change should be transparent since we would be going from an arbitrary order to an obviously deterministic, user-controllable one.

This is ‘work in progress’ because it relies on the proposed (not vetted, not released) change at cemerick/pomegranate#88. 

I have verified locally that this resolves #2283.
