### PR TITLE
Type-hint leiningen.run/run-form and print metadata in eval file

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -237,7 +237,8 @@
                     (io/file (:target-path project) (str checksum "-init.clj"))
                     (File/createTempFile "form-init" ".clj"))]
     (spit init-file
-          (binding [*print-dup* *eval-print-dup*]
+          (binding [*print-dup* *eval-print-dup*
+                    *print-meta* true]
             (pr-str (if-not (System/getenv "LEIN_FAST_TRAMPOLINE")
                       `(.deleteOnExit (File. ~(.getCanonicalPath init-file))))
                     form)))

--- a/src/leiningen/run.clj
+++ b/src/leiningen/run.clj
@@ -77,7 +77,7 @@
          ;; If the class exists, run its main method.
          class#
          (Reflector/invokeStaticMethod
-          class# "main" (into-array [(into-array String '~args)]))
+          class# "main" ^"[Ljava.lang.Object;" (into-array [(into-array String '~args)]))
 
          ;; If the symbol didn't resolve, give a reasonable message
          (= :not-found ns-flag#)


### PR DESCRIPTION
#1817 attempted to get rid of a reflection warning in the run task. A
fix was committed in 54fd206600fe204b592e4cfe94d756e6338983ac, but it
didn’t have any effect. Here we enable metadata printing when spitting
the form and add a second type hint.

For repro see my comment at #1817.

This may not be the right fix! I have verified that it works though.
