### PR TITLE
Remove doctoc comments from static help text

### DIFF
--- a/src/leiningen/help.clj
+++ b/src/leiningen/help.clj
@@ -66,9 +66,18 @@
     (some #(if (= (symbol subtask-name) (:name (meta %))) %)
           (:subtasks (meta task)))))
 
+(defn- clean-static-help
+  "Returns a string containing help content. Removes doctoc comments if they
+  are present."
+  [help-text]
+   (let [doctoc-text #"<!-- END doctoc generated TOC please keep comment here to allow auto update -->"]
+     (if (boolean (re-find doctoc-text help-text))
+       (string/triml (second (string/split help-text doctoc-text))))
+       help-text))
+
 (defn- static-help [name]
   (if-let [resource (io/resource (format "leiningen/help/%s" name))]
-    (slurp resource)))
+    (clean-static-help (slurp resource))))
 
 (declare help-for)
 

--- a/src/leiningen/help.clj
+++ b/src/leiningen/help.clj
@@ -70,10 +70,10 @@
   "Returns a string containing help content. Removes doctoc comments if they
   are present."
   [help-text]
-   (let [doctoc-text #"<!-- END doctoc generated TOC please keep comment here to allow auto update -->"]
-     (if (boolean (re-find doctoc-text help-text))
-       (string/triml (second (string/split help-text doctoc-text))))
-       help-text))
+   (let [doctoc-text "<!-- END doctoc generated TOC please keep comment here to allow auto update -->"]
+     (if (string/includes? help-text doctoc-text)
+       (string/triml (second (string/split help-text (re-pattern doctoc-text))))
+       help-text)))
 
 (defn- static-help [name]
   (if-let [resource (io/resource (format "leiningen/help/%s" name))]


### PR DESCRIPTION
Addresses issue #2302.

This is a rough first go. Any thoughts on splitting the text on a matched pattern? Since these are private functions, I haven't added any tests, but if they're required let me know. I did do a check on the `faq` file to make sure the fix works and it seems to be fine.