### PR TITLE
Infer default values from .git/config when :scm :git is used

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -134,6 +134,8 @@
   [scm project]
   (->> (case scm
          "auto" (make-git-scm-map (resolve-git-dir project))
+         "git" (merge (make-git-scm-map (resolve-git-dir project))
+                      (make-project-scm-map project))
          ; else
          (make-project-scm-map project))
        xmlify

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -64,6 +64,21 @@
       (is (= "https://github.com/techno/lein" (first-in xml [:project :scm :url])))
       (is (= "the git head" (first-in xml [:project :scm :tag]))))))
 
+(deftest test-pom-scm-git
+  (with-redefs [pom/parse-github-url (constantly ["techno" "lein"])
+                pom/read-git-head (constantly "the git head")]
+    (let [project (with-profile-merged sample-project
+                  ^:leaky {:scm {:name "git"
+                                 :dir "." ;; so resolve-git-dir looks for lein project .git dir, not the sample
+                                 :connection ":connection is not ignored in :scm :git"
+                                 :url "https://github.com/this-is-not/ignored"}})
+        pom (make-pom project)
+        xml (xml/parse-str pom)]
+      (is (= ":connection is not ignored in :scm :git" (first-in xml [:project :scm :connection])))
+      (is (= "scm:git:ssh://git@github.com/techno/lein.git" (first-in xml [:project :scm :developerConnection])))
+      (is (= "https://github.com/this-is-not/ignored" (first-in xml [:project :scm :url])))
+      (is (= "the git head" (first-in xml [:project :scm :tag]))))))
+
 (deftest test-pom-default-values
   (let [xml (xml/parse-str (make-pom sample-project))]
     (is (= "nomnomnom" (first-in xml [:project :groupId]))


### PR DESCRIPTION
Fixes #2274 

Implements the merge of default values inferred from `.git/config` with the values defined under the `:scm` map when scm is "git".

Refactors `write-scm-tag` a little bit so the 3 cases of scm ("auto", "git", :else) return a map that is converted with `xmlify` and `xml-tags`. I think this way is more consistent and it made it easier to implement the merge for `:scm :git`.

@technomancy: what's not implemented here (at least not yet) is the `:replace` metadata, mostly because of the following:

Is it really necessary? I understand the idea is to provide a way to use `:scm :git` while ignoring the values inferred from `.git/config`, the same way as it currently works. Let's say someone would like to not have a `:tag` node in their pom, that can be done by adding `:tag ""` in the :scm map. The same goes for the other keys (like `:connection` and `:developerConnection`). I can see that adding `:replace` metadata requires less keystrokes, but it also makes the code and doc more complex.

Also I'm thinking that the `:replace` metadata can be added later, if people ask for it. This change is not going to be 100% backwards compatible anyways.

Please let me know what you think.