### PR TITLE
Replace bootclasspath with -Xverify:none

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -201,8 +201,6 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
 else # Not running from a checkout
     add_path CLASSPATH "$LEIN_JAR"
 
-    BOOTCLASSPATH="-Xbootclasspath/a:$LEIN_JAR"
-
     if [ ! -r "$LEIN_JAR" -a "$1" != "self-install" ]; then
         self_install
     fi
@@ -347,7 +345,6 @@ else
     else
         export TRAMPOLINE_FILE
         "$LEIN_JAVA_CMD" \
-            "${BOOTCLASSPATH[@]}" \
             -Dfile.encoding=UTF-8 \
             -Dmaven.wagon.http.ssl.easy=false \
             -Dmaven.wagon.rto=10000 \

--- a/bin/lein
+++ b/bin/lein
@@ -136,7 +136,7 @@ done
 
 BIN_DIR="$(dirname "$SCRIPT")"
 
-export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
+export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-Xverify:none -XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
 
 # This needs to be defined before we call HTTP_CLIENT below
 if [ "$HTTP_CLIENT" = "" ]; then

--- a/bin/lein
+++ b/bin/lein
@@ -201,9 +201,7 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
 else # Not running from a checkout
     add_path CLASSPATH "$LEIN_JAR"
 
-    if [ "$LEIN_SKIP_BOOTCLASSPATH" = "" ]; then
-        BOOTCLASSPATH="-Xbootclasspath/a:$LEIN_JAR"
-    fi
+    BOOTCLASSPATH="-Xbootclasspath/a:$LEIN_JAR"
 
     if [ ! -r "$LEIN_JAR" -a "$1" != "self-install" ]; then
         self_install


### PR DESCRIPTION
Java 9 currently fails on leiningen because Clojure 1.8.0 (latest stable) cannot reside on the BootClassPath. Rather than fixing that or waiting until Clojure 1.9.0, let's disable bytecode verification (which was the source of the startup improvement anyways.)

This allows `lein` to preserve its fast startup, without having to probe java versions.

Fixes technomancy/leiningen#2149