### PR TITLE
Fix boolean logic in Java version check for cgroups memory limit JVM option

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -523,13 +523,16 @@
 
 ;; give reasonable -Xmx defaults when containerized, if JVM is new enough
 ;; https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
+(defn use-cgroups-memory-limit-for-heap?  [version]
+  (let [[v u] (re-seq #"[^-_]+" version)
+        v' (Integer. (apply str (re-seq #"\d" v)))
+        u' (Integer. u)]
+    (and (>= v' 180) (>= u' 131))))
+
 (def ^:private cgroups-jvm-opts
   ;; this assumes the JVM version Leiningen is run under matches the project
-  (let [[v u] (re-seq #"[^-_]+" (System/getProperty "java.runtime.version"))]
-    (if (or (and (= v "1.8.0") (>= (Integer. u) 131))
-            (not= v "1.7.0")
-            (not= v "1.6.0"))
-      ["-XX:+UnlockExperimentalVMOptions" "-XX:+UseCGroupMemoryLimitForHeap"])))
+  (when (use-cgroups-memory-limit-for-heap? (System/getProperty "java.runtime.version"))
+    ["-XX:+UnlockExperimentalVMOptions" "-XX:+UseCGroupMemoryLimitForHeap"]))
 
 (def default-jvm-opts
   [;; actually does the opposite; omits trace unless this is set

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -523,11 +523,12 @@
 
 ;; give reasonable -Xmx defaults when containerized, if JVM is new enough
 ;; https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
-(defn use-cgroups-memory-limit-for-heap?  [version]
+(defn use-cgroups-memory-limit-for-heap? [version]
   (let [[v u] (re-seq #"[^-_]+" version)
         v' (Integer. (apply str (re-seq #"\d" v)))
         u' (Integer. u)]
-    (and (>= v' 180) (>= u' 131))))
+    (or (and (>= v' 180) (>= u' 131))
+        (> v' 180))))
 
 (def ^:private cgroups-jvm-opts
   ;; this assumes the JVM version Leiningen is run under matches the project

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -524,15 +524,12 @@
 ;; give reasonable -Xmx defaults when containerized, if JVM is new enough
 ;; https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
 (defn use-cgroups-memory-limit-for-heap? [version]
-  (let [[v u] (re-seq #"[^-_]+" version)
-        v' (Integer. (apply str (re-seq #"\d" v)))
-        u' (Integer. u)]
-    (or (and (>= v' 180) (>= u' 131))
-        (> v' 180))))
+  (let [[v u] (re-seq #"[^-_]+" version)]
+    (and (= v "1.8.0") (>= (Integer. u) 131))))
 
 (def ^:private cgroups-jvm-opts
   ;; this assumes the JVM version Leiningen is run under matches the project
-  (when (use-cgroups-memory-limit-for-heap? (System/getProperty "java.runtime.version"))
+  (if (use-cgroups-memory-limit-for-heap? (System/getProperty "java.runtime.version"))
     ["-XX:+UnlockExperimentalVMOptions" "-XX:+UseCGroupMemoryLimitForHeap"]))
 
 (def default-jvm-opts

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -613,3 +613,9 @@
       [:e :b :c :d] "target/e+bcd"
       [:c :a :b :d] "target/c+ab+d"
       [:a]          "target/a")))
+
+(deftest cgroups-applied-properly
+  (is (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01"))
+  (is (use-cgroups-memory-limit-for-heap? "1.9.0_12-b06"))
+  (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_111-internal")))
+  (is (not (use-cgroups-memory-limit-for-heap? "1.7.0_103"))))

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -616,6 +616,6 @@
 
 (deftest cgroups-applied-properly
   (is (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01"))
-  (is (use-cgroups-memory-limit-for-heap? "1.9.0_12-b06"))
   (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_111-internal")))
-  (is (not (use-cgroups-memory-limit-for-heap? "1.7.0_103"))))
+  (is (not (use-cgroups-memory-limit-for-heap? "1.7.0_103")))
+  (is (not (use-cgroups-memory-limit-for-heap? "1.9.0_12-b06"))))


### PR DESCRIPTION
This was written about in https://github.com/technomancy/leiningen/issues/2321

There's an issue in the code which means Java versions that don't support `UseCGroupMemoryLimitForHeap` are still having it applied.