### PR TITLE
Don't use UseCGroupMemoryLimitForHeap on OS X

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -523,13 +523,13 @@
 
 ;; give reasonable -Xmx defaults when containerized, if JVM is new enough
 ;; https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
-(defn use-cgroups-memory-limit-for-heap? [version]
+(defn use-cgroups-memory-limit-for-heap? [version os]
   (let [[v u] (re-seq #"[^-_]+" version)]
-    (and (= v "1.8.0") (>= (Integer. u) 131))))
+    (and (= os "Linux") (= v "1.8.0") (>= (Integer. u) 131))))
 
 (def ^:private cgroups-jvm-opts
   ;; this assumes the JVM version Leiningen is run under matches the project
-  (if (use-cgroups-memory-limit-for-heap? (System/getProperty "java.runtime.version"))
+  (if (use-cgroups-memory-limit-for-heap? (System/getProperty "java.runtime.version") (System/getProperty "os.name"))
     ["-XX:+UnlockExperimentalVMOptions" "-XX:+UseCGroupMemoryLimitForHeap"]))
 
 (def default-jvm-opts

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -623,14 +623,14 @@
 
 (deftest cgroups-applied-properly-windows
   (let [os "Windows 7"]
-    (is (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01" os))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01" os)))
     (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_111-internal" os)))
     (is (not (use-cgroups-memory-limit-for-heap? "1.7.0_103" os)))
     (is (not (use-cgroups-memory-limit-for-heap? "1.9.0_12-b06" os)))))
 
 (deftest cgroups-applied-properly-osx
   (let [os "Mac OS X"]
-    (is (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01" os))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01" os)))
     (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_111-internal" os)))
     (is (not (use-cgroups-memory-limit-for-heap? "1.7.0_103" os)))
     (is (not (use-cgroups-memory-limit-for-heap? "1.9.0_12-b06" os)))))

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -614,8 +614,23 @@
       [:c :a :b :d] "target/c+ab+d"
       [:a]          "target/a")))
 
-(deftest cgroups-applied-properly
-  (is (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01"))
-  (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_111-internal")))
-  (is (not (use-cgroups-memory-limit-for-heap? "1.7.0_103")))
-  (is (not (use-cgroups-memory-limit-for-heap? "1.9.0_12-b06"))))
+(deftest cgroups-applied-properly-linux
+  (let [os "Linux"]
+    (is (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01" os))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_111-internal" os)))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.7.0_103" os)))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.9.0_12-b06" os)))))
+
+(deftest cgroups-applied-properly-windows
+  (let [os "Windows 7"]
+    (is (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01" os))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_111-internal" os)))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.7.0_103" os)))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.9.0_12-b06" os)))))
+
+(deftest cgroups-applied-properly-osx
+  (let [os "Mac OS X"]
+    (is (use-cgroups-memory-limit-for-heap? "1.8.0_144-b01" os))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.8.0_111-internal" os)))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.7.0_103" os)))
+    (is (not (use-cgroups-memory-limit-for-heap? "1.9.0_12-b06" os)))))


### PR DESCRIPTION
Trying to fix #2329 - untested for lack of access to a Mac right now.