### PR TITLE
Avoid "You have $CLASSPATH set" errors on upgrade

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -285,6 +285,7 @@ elif [ "$1" = "upgrade" ] || [ "$1" = "downgrade" ]; then
                         echo "Leiningen is already up-to-date."
                     fi
                     mv "$TARGET" "$SCRIPT" && chmod +x "$SCRIPT"
+                    unset CLASSPATH
                     exec "$SCRIPT" version
                 else
                     download_failed_message "$LEIN_SCRIPT_URL"


### PR DESCRIPTION
Fixes #2361.

When we exec the newly downloaded leiningen script, it will replace our
current shell process and recalculate the classpath for us, so we can
safely unset this here. This avoids the new script throwing warnings
about the CLASSPATH variable being set (from the previous run) on
upgrades.