### PR TITLE
Bump the nREPL dep to 0.2.13

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  ;; needed for uberjar
                  [commons-lang "2.6"]
                  ;; needed for repl
-                 [org.clojure/tools.nrepl "0.2.12"]
+                 [org.clojure/tools.nrepl "0.2.13"]
                  ;; needed for change
                  [net.cgrand/sjacket "0.1.1" :exclusions [org.clojure/clojure]]
                  ;; bump versions of various common transitive deps


### PR DESCRIPTION
I guess that's self-explanatory. 0.2.13 is the latest stable version.