### PR TITLE
Fix POM to include source code in output jar

### DIFF
--- a/leiningen-core/pom.xml
+++ b/leiningen-core/pom.xml
@@ -17,13 +17,15 @@
     <tag>2261906d9dd7b8381baf8af3090363c66a91ca79</tag>
   </scm>
   <build>
-    <sourceDirectory>src</sourceDirectory>
-    <testSourceDirectory>test</testSourceDirectory>
     <resources>
+      <resource>
+        <directory>src</directory>
+      </resource>
       <resource>
         <directory>resources</directory>
       </resource>
     </resources>
+    <testSourceDirectory>test</testSourceDirectory>
     <testResources>
       <testResource>
         <directory>resources</directory>


### PR DESCRIPTION
When building leiningen-core for Debian with maven, lintian warned me that it was producing an empty jar. I looked at the contents and noticed indeed, it was basically empty, except for clojars.pem:

```
    96 Thu Dec 21 02:16:06 UTC 2017 META-INF/MANIFEST.MF
     0 Thu Dec 21 02:16:06 UTC 2017 META-INF/
     0 Thu Dec 21 02:16:06 UTC 2017 META-INF/maven/
     0 Thu Dec 21 02:16:06 UTC 2017 META-INF/maven/leiningen-core/
     0 Thu Dec 21 02:16:06 UTC 2017 META-INF/maven/leiningen-core/leiningen-core/
  2106 Thu Dec 21 02:16:06 UTC 2017 clojars.pem
  4102 Thu Dec 21 02:16:04 UTC 2017 META-INF/maven/leiningen-core/leiningen-core/pom.xml
    94 Thu Dec 21 02:16:06 UTC 2017 META-INF/maven/leiningen-core/leiningen-core/pom.properties
```

When looking at other maven-based Clojure projects like [clojure](https://github.com/clojure/clojure/blob/269b2d1760b71b995ed4f13ea026852cd40e94f3/pom.xml#L97-L99) and [pomegranate](https://github.com/cemerick/pomegranate/blob/c5a5535b7026e3547b13563904f331175efa9eeb/pom.xml#L103-L105), I noticed that the source directory is actually specified in the build as a resource, not a sourceDirectory.

After this patch, the maven-built jar has the following (expected) contents:

```
    96 Thu Dec 21 02:49:02 UTC 2017 META-INF/MANIFEST.MF
     0 Thu Dec 21 02:49:02 UTC 2017 META-INF/
     0 Thu Dec 21 02:49:00 UTC 2017 leiningen/
     0 Thu Dec 21 02:49:00 UTC 2017 leiningen/core/
     0 Thu Dec 21 02:49:02 UTC 2017 META-INF/maven/
     0 Thu Dec 21 02:49:02 UTC 2017 META-INF/maven/leiningen-core/
     0 Thu Dec 21 02:49:02 UTC 2017 META-INF/maven/leiningen-core/leiningen-core/
 40177 Thu Dec 21 02:49:00 UTC 2017 leiningen/core/project.clj
    94 Thu Dec 21 02:49:02 UTC 2017 META-INF/maven/leiningen-core/leiningen-core/pom.properties
 28109 Thu Dec 21 02:49:00 UTC 2017 leiningen/core/classpath.clj
  4121 Thu Dec 21 02:48:58 UTC 2017 META-INF/maven/leiningen-core/leiningen-core/pom.xml
 11020 Thu Dec 21 02:49:00 UTC 2017 leiningen/core/pedantic.clj
  2106 Thu Dec 21 02:49:00 UTC 2017 clojars.pem
  4874 Thu Dec 21 02:49:00 UTC 2017 leiningen/core/ssl.clj
 15710 Thu Dec 21 02:49:00 UTC 2017 leiningen/core/eval.clj
  9351 Thu Dec 21 02:49:00 UTC 2017 leiningen/core/utils.clj
 17031 Thu Dec 21 02:49:00 UTC 2017 leiningen/core/main.clj
  7354 Thu Dec 21 02:49:00 UTC 2017 leiningen/core/user.clj
```

And the full leiningen build still works fine.

(Incidentally, the leiningen build worked fine *without* this patch. I believe it's because the leiningen-core source code is [included in the leiningen build](https://github.com/technomancy/leiningen/blob/e20c06bf8535078ebcf2f242833a1c61c49c6f79/project.clj#L38), so the missing code in the leiningen-core jar on the classpath didn't matter. I get the impression I am the only person trying to build this with maven right now...)