### PR TITLE
Add project coordinate data to JAR metadata

### DIFF
--- a/src/leiningen/jar.clj
+++ b/src/leiningen/jar.clj
@@ -22,10 +22,13 @@
 (defn- unix-path [path]
   (.replace path "\\" "/"))
 
-(def ^:private default-manifest
+(defn- default-manifest [project]
   {"Created-By" (str "Leiningen " (main/leiningen-version))
    "Built-By" (System/getProperty "user.name")
-   "Build-Jdk" (System/getProperty "java.version")})
+   "Build-Jdk" (System/getProperty "java.version")
+   "Leiningen-Project-ArtifactId" (:name project)
+   "Leiningen-Project-GroupId" (:group project)
+   "Leiningen-Project-Version" (:version project)})
 
 (declare ^:private manifest-entry)
 
@@ -55,7 +58,7 @@
 
 (defn ^:internal make-manifest [project]
   (let [project-manifest (into {} (:manifest project))
-        default-manifest' (cond-> default-manifest
+        default-manifest' (cond-> (default-manifest project)
                             ;; Add default "Main-Class" only if :main is not
                             ;; explicitly set to nil
                             (:main project :not-found)

--- a/test/leiningen/test/jar.clj
+++ b/test/leiningen/test/jar.clj
@@ -15,6 +15,7 @@
 
 (def mock-project-1
   {:name "mock-project"
+   :group "mock-group"
    :version "1.0"
    :main 'foo.one-two.three-four.bar
    :manifest [["hello" "world"]
@@ -26,6 +27,7 @@
 
 (def mock-project-2
   {:name "mock-project"
+   :group "mock-group"
    :version "1.0"
    :main 'foo.one-two.three-four.bar
    :manifest {"hello" "world"
@@ -45,9 +47,14 @@
                  manifest-map)]
       (is (= {"Main-Class" "foo.one_two.three_four.bar", "hello" "world"}
              (select-keys mm ["hello" "Main-Class"])))
-      (is (= #{"Manifest-Version" "Main-Class" "hello" "A" "G" "Created-By" "Built-By"
-               "Build-Jdk" "long-line"}
+      (is (= #{"A" "Build-Jdk" "Built-By" "Created-By" "G"
+               "Leiningen-Project-ArtifactId" "Leiningen-Project-GroupId"
+               "Leiningen-Project-Version" "Main-Class" "Manifest-Version"
+               "hello" "long-line"}
              (-> mm keys set)))
+      (is (= (get mm "Leiningen-Project-ArtifactId") "mock-project"))
+      (is (= (get mm "Leiningen-Project-GroupId") "mock-group"))
+      (is (= (get mm "Leiningen-Project-Version") "1.0"))
       (is (= (get mm "long-line") long-line))
       (is (=  #{"my-section-1" "my-section-2"}
              (-> mock-project


### PR DESCRIPTION
This causes entries like:

```
Leiningen-Project-ArtifactId: bar
Leiningen-Project-GroupId: foo
Leiningen-Project-Version: 1.2.3-SNAPSHOT
```

to be added to `META-INF/MANIFEST.MF` in JARS for projects with `project.clj` files like:

```clojure
(defproject foo/bar "1.2.3-SNAPSHOT"
  ...
  )
```