### PR TITLE
Bump version of reply and clojure-complete

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -542,7 +542,7 @@
                 ;; bump deps in leiningen's own project.clj with these
                 :dependencies '[^:displace [org.clojure/tools.nrepl "0.2.12"
                                             :exclusions [org.clojure/clojure]]
-                                ^:displace [clojure-complete "0.2.4"
+                                ^:displace [clojure-complete "0.2.5"
                                             :exclusions [org.clojure/clojure]]]
                 :checkout-deps-shares [:source-paths
                                        :test-paths

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -46,7 +46,7 @@
                                [clj-http/clj-http "3.4.1"]
                                [org.clojure/tools.nrepl "0.2.12"
                                 :exclusions [[org.clojure/clojure]]]
-                               [clojure-complete/clojure-complete "0.2.4"
+                               [clojure-complete/clojure-complete "0.2.5"
                                 :exclusions [[org.clojure/clojure]]]],
                :twelve 12 ; testing unquote
 

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -21,7 +21,7 @@
             (pp/pprint))))
 {
  bultitude "0.2.8"
- clojure-complete "0.2.4"
+ clojure-complete "0.2.5"
  com.cemerick/pomegranate "0.4.0-alpha1"
  com.google.guava/guava "20.0"
  com.hypirion/io "0.3.1"

--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -198,9 +198,9 @@
 
 (def reply-profile
   {:dependencies
-   '[^:displace [reply "0.3.7"
+   '[^:displace [reply "0.3.8"
                  :exclusions [org.clojure/clojure ring/ring-core]]
-     [clojure-complete "0.2.4"]]})
+     [clojure-complete "0.2.5"]]})
 
 (defn- trampoline-repl [project port]
   (let [init-option (get-in project [:repl-options :init])


### PR DESCRIPTION
This PR closes https://github.com/technomancy/leiningen/issues/2380 . clojure-complete "0.2.5" is released with the fix and reply is also released with the updated clojure-complete library as "0.3.8". This PR bumps the version of clojure-complete and reply. Tested it locally and it's working fine now.

Just saw a PR (https://github.com/technomancy/leiningen/pull/2397) that only upgrades reply version. I tested that PR and it still causes the NPE. Though clojure-complete is not used directly I don't know why an older version causes error with reply upgraded. have upgraded both and let me know if there is any place I have missed.

cc @venantius 