### PR TITLE
Use GPL-2.0-or-later as secondary license

### DIFF
--- a/resources/leiningen/new/app/README.md
+++ b/resources/leiningen/new/app/README.md
@@ -38,6 +38,7 @@ http://www.eclipse.org/legal/epl-2.0.
 
 This Source Code may also be made available under the following Secondary
 Licenses when the conditions for such availability set forth in the Eclipse
-Public License, v. 2.0 are satisfied: GNU General Public License, version 2
-with the GNU Classpath Exception which is
-available at https://www.gnu.org/software/classpath/license.html.
+Public License, v. 2.0 are satisfied: GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or (at your
+option) any later version, with the GNU Classpath Exception which is available
+at https://www.gnu.org/software/classpath/license.html.

--- a/resources/leiningen/new/app/project.clj
+++ b/resources/leiningen/new/app/project.clj
@@ -1,7 +1,7 @@
 (defproject {{raw-name}} "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
-  :license {:name "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0"
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.9.0"]]
   :main ^:skip-aot {{namespace}}

--- a/resources/leiningen/new/default/README.md
+++ b/resources/leiningen/new/default/README.md
@@ -16,6 +16,7 @@ http://www.eclipse.org/legal/epl-2.0.
 
 This Source Code may also be made available under the following Secondary
 Licenses when the conditions for such availability set forth in the Eclipse
-Public License, v. 2.0 are satisfied: GNU General Public License, version 2
-with the GNU Classpath Exception which is
-available at https://www.gnu.org/software/classpath/license.html.
+Public License, v. 2.0 are satisfied: GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or (at your
+option) any later version, with the GNU Classpath Exception which is available
+at https://www.gnu.org/software/classpath/license.html.

--- a/resources/leiningen/new/default/project.clj
+++ b/resources/leiningen/new/default/project.clj
@@ -1,7 +1,7 @@
 (defproject {{raw-name}} "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
-  :license {:name "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0"
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.9.0"]]
   :repl-options {:init-ns {{namespace}}})

--- a/resources/leiningen/new/plugin/README.md
+++ b/resources/leiningen/new/plugin/README.md
@@ -27,6 +27,7 @@ http://www.eclipse.org/legal/epl-2.0.
 
 This Source Code may also be made available under the following Secondary
 Licenses when the conditions for such availability set forth in the Eclipse
-Public License, v. 2.0 are satisfied: GNU General Public License, version 2
-with the GNU Classpath Exception which is
-available at https://www.gnu.org/software/classpath/license.html.
+Public License, v. 2.0 are satisfied: GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or (at your
+option) any later version, with the GNU Classpath Exception which is available
+at https://www.gnu.org/software/classpath/license.html.

--- a/resources/leiningen/new/plugin/project.clj
+++ b/resources/leiningen/new/plugin/project.clj
@@ -1,6 +1,6 @@
 (defproject {{name}} "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
-  :license {:name "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0"
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :eval-in-leiningen true)

--- a/resources/leiningen/new/template/README.md
+++ b/resources/leiningen/new/template/README.md
@@ -10,5 +10,13 @@ FIXME
 
 Copyright © {{year}} FIXME
 
-Distributed under the Eclipse Public License either version 1.0 or (at
-your option) any later version.
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License, v. 2.0 are satisfied: GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or (at your
+option) any later version, with the GNU Classpath Exception which is available
+at https://www.gnu.org/software/classpath/license.html.

--- a/resources/leiningen/new/template/project.clj
+++ b/resources/leiningen/new/template/project.clj
@@ -1,6 +1,6 @@
 (defproject {{name}}/lein-template "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
-  :license {:name "EPL-2.0"
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :eval-in-leiningen true)


### PR DESCRIPTION
See: https://github.com/technomancy/leiningen/pull/2403#issuecomment-367117859

Other minor changes:

* Use FSF-suggested wording in license description (added "as
  published by the Free Software Foundation")
* Update README.md and project.clj in resources/leiningen/template