### PR TITLE
Enforce TLS 1.2 for PowerShell downloader

### DIFF
--- a/bin/lein.bat
+++ b/bin/lein.bat
@@ -154,7 +154,7 @@ if "x%HTTP_CLIENT%" == "x" goto TRY_POWERSHELL
 call powershell -? >nul 2>&1
 if NOT ERRORLEVEL 0 goto TRY_WGET
     set LAST_HTTP_CLIENT=powershell
-    powershell -Command "& {param($a,$f) $client = New-Object System.Net.WebClient;  $client.Proxy.Credentials =[System.Net.CredentialCache]::DefaultNetworkCredentials; $client.DownloadFile($a, $f)}" ""%2"" ""%1""
+    powershell -Command "& {param($a,$f) $client = New-Object System.Net.WebClient; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $client.Proxy.Credentials =[System.Net.CredentialCache]::DefaultNetworkCredentials; $client.DownloadFile($a, $f)}" ""%2"" ""%1""
     SET RC=%ERRORLEVEL%
     goto EXITRC
 


### PR DESCRIPTION
GitHub has stopped supporting TLS < 1.2 just a few days ago:
https://github.com/blog/2507-weak-cryptographic-standards-removed
...as I found out yesterday attempting to install Leiningen 😐

On up-to-date Windows 10 PowerShell is configured to only use TLS 1.0 and SSL 3 (`Tls, Ssl3` from [here](https://msdn.microsoft.com/ru-ru/library/system.net.securityprotocoltype(v=vs.110).aspx)).

With this change, installation succeeds.

From what I understand, tests to not cover installation scripts and thus don't need any updates.