### PR TITLE
Ensure aliases are replaced when merging profiles

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -124,6 +124,15 @@
     (with-meta obj m)
     obj))
 
+(defn- vary-meta*
+  "Returns an object of the same type and value as obj, with
+  (apply f (meta obj) args) as its metadata, if the object can hold
+  metadata."
+  [obj f & args]
+  (if (instance? clojure.lang.IObj obj)
+    (apply vary-meta obj f args)
+    obj))
+
 (defn- displace?
   "Returns true if the object is marked as displaceable"
   [obj]
@@ -305,6 +314,9 @@
                  :password :gpg :username :gpg}]]
     {:reduce reduce-repo-step}))
 
+(defn- mark-with-replace [obj]
+  (vary-meta* obj assoc :replace true))
+
 (defn normalize-values
   "Transform values within a project or profile map to normalized values, such
   that internal functions can assume that the values are already normalized."
@@ -313,6 +325,7 @@
       (update-each-contained [:repositories :deploy-repositories
                               :mirrors :plugin-repositories] normalize-repos)
       (update-each-contained [:profiles] utils/map-vals normalize-values)
+      (update-each-contained [:aliases] utils/map-vals mark-with-replace)
       (normalize-aot)))
 
 (def ^:private empty-meta-merge-defaults


### PR DESCRIPTION
The simple workaround (and maybe the advised way to go?) for issue #2391 is by adding `^:replace` metadata onto the alias value inside a profile:

```clj
(defproject
  ...
  :aliases {"foo" ["bar"]}
  :profiles {:alice {:aliases {"foo" ^:replace ["baz"]}}}
  ...)
```

Yet, I cannot think of a situation where one wants the standard (meta-)merging of aliases. Users may expect above replace behaviour by default. This PR is a possible realisation of such default behaviour.

Feedback is welcome, as I do not know the entire leiningen codebase by head.

P.S. The tests are failing, but they do not seem related to this PR. It cannot find some dev-resources, such as `leiningen-core/dev-resources/p1.clj`...