### PR TITLE
Protect the '.' in the regex

### DIFF
--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -154,7 +154,7 @@ First write your credentials map to `~/.lein/credentials.clj` like so:
 
 ```clj
 {#"blueant" {:password "locative1"}
- #"https://clojars.org/repo"
+ #"https://clojars\.org/repo"
  {:username "milgrim" :password "locative1"}
  "s3p://s3-repo-bucket/releases"
  {:username "AKIAIN..." :passphrase "1TChrGK4s..."}}


### PR DESCRIPTION
This is a minor issue, but it looks a bit safer to me.

Of course I tried it.