### PR TITLE
Bump commons-io version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  ;; bump versions of various common transitive deps
                  [net.cgrand/parsley "0.9.3" :exclusions [org.clojure/clojure]]
                  [scout "0.1.1"]
-                 [commons-io "2.5"]]
+                 [commons-io "2.6"]]
   ;; checkout-deps don't work with :eval-in :leiningen
   :profiles {:dev {:resource-paths ["leiningen-core/dev-resources"]
                    :test-paths ["leiningen-core/test"]}

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -26,7 +26,7 @@
  com.google.guava/guava "20.0"
  com.hypirion/io "0.3.1"
  commons-codec "1.9"
- commons-io "2.5"
+ commons-io "2.6"
  commons-lang "2.6"
  commons-logging "1.2"
  net.cgrand/parsley "0.9.3"


### PR DESCRIPTION
Upstreaming this patch I wrote to ensure we can build against the latest `commons-io`: https://salsa.debian.org/clojure-team/leiningen-clojure/blob/master/debian/patches/0004-Bump-commons-io-version.patch