### PR TITLE
Exclude project-specific `profiles.clj` from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ TAGS
 test_projects/*/target
 pom.xml
 deps.txt
+profiles.clj

--- a/resources/leiningen/new/app/gitignore
+++ b/resources/leiningen/new/app/gitignore
@@ -1,6 +1,7 @@
 /target
 /classes
 /checkouts
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar

--- a/resources/leiningen/new/app/hgignore
+++ b/resources/leiningen/new/app/hgignore
@@ -12,3 +12,4 @@ syntax: regexp
 ^target/
 ^classes/
 ^checkouts/
+profiles.clj

--- a/resources/leiningen/new/default/gitignore
+++ b/resources/leiningen/new/default/gitignore
@@ -1,6 +1,7 @@
 /target
 /classes
 /checkouts
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar

--- a/resources/leiningen/new/default/hgignore
+++ b/resources/leiningen/new/default/hgignore
@@ -2,6 +2,7 @@ syntax: glob
 target/**
 classes/**
 checkouts/**
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar

--- a/resources/leiningen/new/plugin/gitignore
+++ b/resources/leiningen/new/plugin/gitignore
@@ -1,6 +1,7 @@
 /target
 /classes
 /checkouts
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar

--- a/resources/leiningen/new/plugin/hgignore
+++ b/resources/leiningen/new/plugin/hgignore
@@ -2,6 +2,7 @@ syntax: glob
 target/**
 classes/**
 checkouts/**
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar

--- a/resources/leiningen/new/template/hgignore
+++ b/resources/leiningen/new/template/hgignore
@@ -2,6 +2,7 @@ syntax: glob
 target/**
 classes/**
 checkouts/**
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar

--- a/test_projects/bad-require/.gitignore
+++ b/test_projects/bad-require/.gitignore
@@ -2,6 +2,7 @@
 /lib
 /classes
 /checkouts
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar

--- a/test_projects/file-not-found-thrower/.gitignore
+++ b/test_projects/file-not-found-thrower/.gitignore
@@ -1,6 +1,7 @@
 /target
 /classes
 /checkouts
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar

--- a/test_projects/java-main/.gitignore
+++ b/test_projects/java-main/.gitignore
@@ -1,6 +1,7 @@
 /target
 /classes
 /checkouts
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar

--- a/test_projects/more-gen-classes/.gitignore
+++ b/test_projects/more-gen-classes/.gitignore
@@ -2,6 +2,7 @@
 /lib
 /classes
 /checkouts
+profiles.clj
 pom.xml
 pom.xml.asc
 *.jar


### PR DESCRIPTION
Fix #2429.