### PR TITLE
Update nREPL to 0.4.3

### DIFF
--- a/leiningen-core/src/leiningen/core/eval.clj
+++ b/leiningen-core/src/leiningen/core/eval.clj
@@ -305,13 +305,13 @@
     (and (not pending?) (some #{"done" "interrupted" "error"} status))))
 
 (defmethod eval-in :nrepl [project form]
-  (require 'clojure.tools.nrepl)
+  (require 'nrepl.core)
   (let [port-file (io/file (:target-path project) "repl-port")
-        connect (resolve 'clojure.tools.nrepl/connect)
-        client (resolve 'clojure.tools.nrepl/client)
-        client-session (resolve 'clojure.tools.nrepl/client-session)
-        message (resolve 'clojure.tools.nrepl/message)
-        recv (resolve 'clojure.tools.nrepl.transport/recv)]
+        connect (resolve 'nrepl/connect)
+        client (resolve 'nrepl/client)
+        client-session (resolve 'nrepl/client-session)
+        message (resolve 'nrepl/message)
+        recv (resolve 'nrepl.transport/recv)]
     (if (.exists port-file)
       (let [transport (connect :host "localhost"
                                :port (Integer. (slurp port-file)))

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -553,7 +553,7 @@
                 :test-selectors {:default (with-meta '(constantly true)
                                             {:displace true})}
                 ;; bump deps in leiningen's own project.clj with these
-                :dependencies '[^:displace [org.clojure/tools.nrepl "0.2.12"
+                :dependencies '[^:displace [nrepl/nrepl "0.4.1"
                                             :exclusions [org.clojure/clojure]]
                                 ^:displace [clojure-complete "0.2.5"
                                             :exclusions [org.clojure/clojure]]]

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -553,7 +553,7 @@
                 :test-selectors {:default (with-meta '(constantly true)
                                             {:displace true})}
                 ;; bump deps in leiningen's own project.clj with these
-                :dependencies '[^:displace [nrepl/nrepl "0.4.1"
+                :dependencies '[^:displace [nrepl/nrepl "0.4.3"
                                             :exclusions [org.clojure/clojure]]
                                 ^:displace [clojure-complete "0.2.5"
                                             :exclusions [org.clojure/clojure]]]

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -44,7 +44,7 @@
                                [stencil/stencil "0.2.0"]
                                [~(symbol "net.3scale" "3scale-api") "3.0.2"]
                                [clj-http/clj-http "3.4.1"]
-                               [org.clojure/tools.nrepl "0.2.12"
+                               [nrepl/nrepl "0.4.1"
                                 :exclusions [[org.clojure/clojure]]]
                                [clojure-complete/clojure-complete "0.2.5"
                                 :exclusions [[org.clojure/clojure]]]],
@@ -286,7 +286,7 @@
 (def test-profiles (atom {:qa {:resource-paths ["/etc/myapp"]}
                           :test {:resource-paths ["test/hi"]}
                           :repl {:dependencies
-                                 '[[org.clojure/tools.nrepl "0.2.0-beta6"
+                                 '[[nrepl/nrepl "0.4.1"
                                     :exclusions [org.clojure/clojure]]
                                    [org.thnetos/cd-client "0.3.4"
                                     :exclusions [org.clojure/clojure]]]}

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -44,7 +44,7 @@
                                [stencil/stencil "0.2.0"]
                                [~(symbol "net.3scale" "3scale-api") "3.0.2"]
                                [clj-http/clj-http "3.4.1"]
-                               [nrepl/nrepl "0.4.1"
+                               [nrepl/nrepl "0.4.3"
                                 :exclusions [[org.clojure/clojure]]]
                                [clojure-complete/clojure-complete "0.2.5"
                                 :exclusions [[org.clojure/clojure]]]],
@@ -286,7 +286,7 @@
 (def test-profiles (atom {:qa {:resource-paths ["/etc/myapp"]}
                           :test {:resource-paths ["test/hi"]}
                           :repl {:dependencies
-                                 '[[nrepl/nrepl "0.4.1"
+                                 '[[nrepl/nrepl "0.4.3"
                                     :exclusions [org.clojure/clojure]]
                                    [org.thnetos/cd-client "0.3.4"
                                     :exclusions [org.clojure/clojure]]]}

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  ;; needed for uberjar
                  [commons-lang "2.6"]
                  ;; needed for repl
-                 [org.clojure/tools.nrepl "0.2.13"]
+                 [nrepl "0.4.1"]
                  ;; needed for change
                  [net.cgrand/sjacket "0.1.1" :exclusions [org.clojure/clojure]]
                  ;; bump versions of various common transitive deps
@@ -31,7 +31,7 @@
                              leiningen.core.ssl ; lazy-loaded
                              cemerick.pomegranate
                              classlojure.core
-                             clojure.tools.nrepl]}}
+                             nrepl.core]}}
   :test-selectors {:default (complement :disabled)
                    :offline (comp (partial not-any? identity)
                                   (juxt :online :disabled))}

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  ;; needed for uberjar
                  [commons-lang "2.6"]
                  ;; needed for repl
-                 [nrepl "0.4.1"]
+                 [nrepl "0.4.3"]
                  ;; needed for change
                  [net.cgrand/sjacket "0.1.1" :exclusions [org.clojure/clojure]]
                  ;; bump versions of various common transitive deps

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -54,7 +54,7 @@
  org.apache.maven/maven-resolver-provider "3.5.0"
  org.clojure/data.xml "0.0.8"
  org.clojure/tools.macro "0.1.5"
- nrepl "0.4.1g"
+ nrepl "0.4.1"
  org.codehaus.plexus/plexus-component-annotations "1.7.1"
  org.codehaus.plexus/plexus-interpolation "1.24"
  org.codehaus.plexus/plexus-utils "3.0.24"

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -54,7 +54,7 @@
  org.apache.maven/maven-resolver-provider "3.5.0"
  org.clojure/data.xml "0.0.8"
  org.clojure/tools.macro "0.1.5"
- org.clojure/tools.nrepl "0.2.12"
+ nrepl "0.4.1g"
  org.codehaus.plexus/plexus-component-annotations "1.7.1"
  org.codehaus.plexus/plexus-interpolation "1.24"
  org.codehaus.plexus/plexus-utils "3.0.24"

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -54,7 +54,7 @@
  org.apache.maven/maven-resolver-provider "3.5.0"
  org.clojure/data.xml "0.0.8"
  org.clojure/tools.macro "0.1.5"
- nrepl "0.4.1"
+ nrepl "0.4.3"
  org.codehaus.plexus/plexus-component-annotations "1.7.1"
  org.codehaus.plexus/plexus-interpolation "1.24"
  org.codehaus.plexus/plexus-utils "3.0.24"

--- a/sample.project.clj
+++ b/sample.project.clj
@@ -387,12 +387,12 @@
                  ;; Only one of #{:nrepl-handler :nrepl-middleware}
                  ;; may be used at a time.
                  ;; Use a different server-side nREPL handler.
-                 :nrepl-handler (clojure.tools.nrepl.server/default-handler)
+                 :nrepl-handler (nrepl.server/default-handler)
                  ;; Add server-side middleware to nREPL stack.
                  :nrepl-middleware [my.nrepl.thing/wrap-amazingness
                                     ;; TODO: link to more detailed documentation.
                                     ;; Middleware without appropriate metadata
-                                    ;; (see clojure.tools.nrepl.middleware/set-descriptor!
+                                    ;; (see nrepl.middleware/set-descriptor!
                                     ;; for details) will simply be appended to the stack
                                     ;; of middleware (rather than ordered based on its
                                     ;; expectations and requirements).

--- a/test/leiningen/test/deps.clj
+++ b/test/leiningen/test/deps.clj
@@ -141,7 +141,7 @@
 
 (deftest ^:online test-managed-deps
   (let [is-clojure-dep? #(#{'org.clojure/clojure
-                            'org.clojure/tools.nrepl}
+                            'nrepl/nrepl}
                           (first %))
         remove-clojure-deps #(remove is-clojure-dep? %)
         managed-deps (remove-clojure-deps (:managed-dependencies managed-deps-project))

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -367,19 +367,19 @@
   (testing "leaky explicit profile"
     (let [p (make-pom (with-profile-merged sample-project
                         ^:leaky
-                        {:dependencies [['nrepl/nrepl "0.4.1"]]}))
+                        {:dependencies [['nrepl/nrepl "0.4.3"]]}))
           deps (deep-content (xml/parse-str p) [:project :dependencies])
           nrepls (filter #(re-find #"nrepl" (pr-str %)) deps)
           versions (map #(deep-content % [:dependency :version]) nrepls)]
-      (is (= [["0.4.1"]] versions))))
+      (is (= [["0.4.3"]] versions))))
   (testing "pom-scope"
     (let [p (make-pom (with-profile-merged sample-project
                         ^{:pom-scope :test}
-                        {:dependencies [['nrepl/nrepl "0.4.1"]]}))
+                        {:dependencies [['nrepl/nrepl "0.4.3"]]}))
           deps (deep-content (xml/parse-str p) [:project :dependencies])
           nrepls (filter #(re-find #"nrepl" (pr-str %)) deps)
           versions (map #(deep-content % [:dependency :version]) nrepls)]
-      (is (= [["0.4.1"]] versions)))))
+      (is (= [["0.4.3"]] versions)))))
 
 (deftest test-leaky-profile
   (let [p (make-pom sample-profile-meta-project)

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -367,19 +367,19 @@
   (testing "leaky explicit profile"
     (let [p (make-pom (with-profile-merged sample-project
                         ^:leaky
-                        {:dependencies [['org.clojure/tools.nrepl "0.2.2"]]}))
+                        {:dependencies [['nrepl/nrepl "0.4.1"]]}))
           deps (deep-content (xml/parse-str p) [:project :dependencies])
           nrepls (filter #(re-find #"nrepl" (pr-str %)) deps)
           versions (map #(deep-content % [:dependency :version]) nrepls)]
-      (is (= [["0.2.2"]] versions))))
+      (is (= [["0.4.1"]] versions))))
   (testing "pom-scope"
     (let [p (make-pom (with-profile-merged sample-project
                         ^{:pom-scope :test}
-                        {:dependencies [['org.clojure/tools.nrepl "0.2.2"]]}))
+                        {:dependencies [['nrepl/nrepl "0.4.1"]]}))
           deps (deep-content (xml/parse-str p) [:project :dependencies])
           nrepls (filter #(re-find #"nrepl" (pr-str %)) deps)
           versions (map #(deep-content % [:dependency :version]) nrepls)]
-      (is (= [["0.2.2"]] versions)))))
+      (is (= [["0.4.1"]] versions)))))
 
 (deftest test-leaky-profile
   (let [p (make-pom sample-profile-meta-project)


### PR DESCRIPTION
As no one really commented on #2434 I've decided to try an alternative approach. Here's my preferred (quick) solution to the migration to the new nREPL. I know this is probably less than ideal, but it's a one time deal, and I'd really appreciate your support as I rather be dealing with nREPL improvements than with migration paths.

nREPL was recently moved out of clojure-contrib and its development
continued under a dedicated org (https://github.com/nrepl). The new project is (and will remain
to be) completely backwards compatible on the nREPL API level, but
the namespace had to be changed.

This fixes #2434.