### PR TITLE
Update DEPLOY.md as proposed in #1890

### DIFF
--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -236,7 +236,8 @@ order to make `lein deploy` with no argument target Clojars, include this in
 your `project.clj`:
 
 ```clj
-{:deploy-repositories [["releases" :clojars]]}
+{:deploy-repositories [["releases" :clojars]
+                       ["snapshots" :clojars]]}
 ```
 
 You can use this to alias any `:repositories` entry; Clojars is just the most


### PR DESCRIPTION
This is a tiny documentation change that can save newcomers some googling. With the proposed change, the confusing error described in #1890 won't be encountered by those who follow the DEPLOY.md docs.

See https://github.com/technomancy/leiningen/issues/1890#issuecomment-174192434

>marick commented on Jan 23, 2016
> For people finding this page via a search for "No connector available to access repository snapshots" lein leiningen who are also inexpert in things Maven-ey:
> 
> This is an error message you can get by deploying a major-minor-tiny-SNAPSHOT version to clojars via lein deploy when you don't have a ["snapshots" :clojars] entry in :deploy-repositories in your project.clj. If you make that latter look like the following, lein deploy will work: