### PR TITLE
Upgrade data.xml to new 0.2.0-alpha5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   ;; If you update these, update resources/leiningen/bootclasspath-deps.clj too
   :dependencies [[leiningen-core "2.8.2-SNAPSHOT"]
                  ;; needed for pom
-                 [org.clojure/data.xml "0.0.8"]
+                 [org.clojure/data.xml "0.2.0-alpha5"]
                  ;; needed for test
                  [bultitude "0.2.8"]
                  ;; needed for new

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -52,7 +52,7 @@
  org.apache.maven/maven-model-builder "3.5.0"
  org.apache.maven/maven-repository-metadata "3.5.0"
  org.apache.maven/maven-resolver-provider "3.5.0"
- org.clojure/data.xml "0.0.8"
+ org.clojure/data.xml "0.2.0-alpha5"
  org.clojure/tools.macro "0.1.5"
  org.clojure/tools.nrepl "0.2.12"
  org.codehaus.plexus/plexus-component-annotations "1.7.1"


### PR DESCRIPTION
`org.clojure/data.xml 0.2.0-alpha5` has some exciting new features and bugfixes.

It's also the version of org.clojure/data.xml used by tools.deps.alpha. I'd like both in Debian and they need to share deps for head-to-head to work :)

https://github.com/clojure/tools.deps.alpha/blob/744c9c027b1b0d71081a7903b517abbd960a9849/pom.xml#L94-L98