### PR TITLE
Only warn on ranges that could contain more than one possible version

### DIFF
--- a/leiningen-core/src/leiningen/core/pedantic.clj
+++ b/leiningen-core/src/leiningen/core/pedantic.clj
@@ -42,10 +42,12 @@
         (.transformGraph node context))))
 
 (defn- range?
-  "Does the path point to a DependencyNode asking for a version range?"
+  "Does the path point to a DependencyNode asking for a version range that includes more than one possible version?"
   [{:keys [node]}]
   (when-let [vc (.getVersionConstraint node)]
-    (not (nil? (.getRange vc)))))
+    (when-let [r (.getRange vc)]
+      (or (nil? (.getUpperBound r))
+          (not= (.getLowerBound r) (.getUpperBound r))))))
 
 (defn- set-ranges!
   "Set ranges to contain all paths that asks for a version range"


### PR DESCRIPTION
The AWS SDK version 2+ contains lots of dependency version ranges of the form `[2.0.1,2.0.1]` (where upper and lower bound are identical). I'm not sure what the reason is for this, but it causes leiningen to print lots of verbose warnings. For instance the Kinesis Client Library generates warnings like:
```
WARNING!!! version ranges found for:
[software.amazon.kinesis/amazon-kinesis-client "2.0.1"] -> [software.amazon.awssdk/kinesis "2.0.1"] -> [software.amazon.awssdk/sdk-core "[2.0.1,2.0.1]"]
Consider using [software.amazon.kinesis/amazon-kinesis-client "2.0.1" :exclusions [software.amazon.awssdk/sdk-core]].
[software.amazon.kinesis/amazon-kinesis-client "2.0.1"] -> [software.amazon.awssdk/kinesis "2.0.1"] -> [software.amazon.awssdk/auth "[2.0.1,2.0.1]"]
Consider using [software.amazon.kinesis/amazon-kinesis-client "2.0.1" :exclusions [software.amazon.awssdk/auth]].
[software.amazon.kinesis/amazon-kinesis-client "2.0.1"] -> [software.amazon.awssdk/kinesis "2.0.1"] -> [software.amazon.awssdk/http-client-spi "[2.0.1,2.0.1]"]
Consider using [software.amazon.kinesis/amazon-kinesis-client "2.0.1" :exclusions [software.amazon.awssdk/http-client-spi]].
[software.amazon.kinesis/amazon-kinesis-client "2.0.1"] -> [software.amazon.awssdk/kinesis "2.0.1"] -> [software.amazon.awssdk/regions "[2.0.1,2.0.1]"]
Consider using [software.amazon.kinesis/amazon-kinesis-client "2.0.1" :exclusions [software.amazon.awssdk/regions]].
[software.amazon.kinesis/amazon-kinesis-client "2.0.1"] -> [software.amazon.awssdk/kinesis "2.0.1"] -> [software.amazon.awssdk/annotations "[2.0.1,2.0.1]"]
```
and so on for more than 900 lines.

Would it make sense to only warn when a version range could actually contain more than one version (i.e. lower is different to upper, or at least one is unbounded)?