### PR TITLE
Update bultitude dependency to 0.3.0 & new maintainer

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -5,7 +5,7 @@
   :description "Library for core functionality of Leiningen."
   ;; If you update these, update resources/leiningen/bootclasspath-deps.clj too
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [bultitude "0.2.8" :exclusions [org.tcrawley/dynapath]]
+                 [timofreiberg/bultitude "0.3.0" :exclusions [org.tcrawley/dynapath]]
                  [org.flatland/classlojure "0.7.1"]
                  [robert/hooke "1.3.0"]
                  [com.cemerick/pomegranate "1.1.0"

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  ;; needed for pom
                  [org.clojure/data.xml "0.0.8"]
                  ;; needed for test
-                 [bultitude "0.2.8"]
+                 [timofreiberg/bultitude "0.3.0"]
                  ;; needed for new
                  [stencil "0.5.0" :exclusions [org.clojure/core.cache]]
                  ;; needed for uberjar

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -20,7 +20,7 @@
             (dissoc 'leiningen-core)
             (pp/pprint))))
 {
- bultitude "0.2.8"
+ timofreiberg/bultitude "0.3.0"
  clojure-complete "0.2.5"
  com.cemerick/pomegranate "1.1.0"
  com.google.guava/guava "20.0"


### PR DESCRIPTION
I started maintaining bultitude recently and fixed an [issue](https://github.com/TimoFreiberg/bultitude/issues/4) described here: https://github.com/TimoFreiberg/bultitude/pull/3

> lein test breaks on files that start with in-ns, and which refer to keyword
> abbreviations (::foo/bar) and namespaced map abbreviations (#::foo{:bar :baz}).

I am not sure about the edit to the `resources/leiningen/bootclasspath-deps.clj` file, when I ran the commented code inside it generated a map with several differences to the literal in the file.