### PR TITLE
Exclude dot files at any level of the jar hierarchy.

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -11,7 +11,8 @@
             [leiningen.core.classpath :as classpath]
             [clojure.string :as str])
   (:import (clojure.lang DynamicClassLoader)
-           (java.io PushbackReader Reader)))
+           (java.io PushbackReader Reader File)
+           (java.util.regex Pattern)))
 
 (defn make-project-properties [project]
   (with-open [baos (java.io.ByteArrayOutputStream.)]
@@ -234,7 +235,7 @@
                                   ["vcs" "commit"]
                                   ["vcs" "push"]]
    :pedantic? (quote ^:top-displace ranges)
-   :jar-exclusions [#"^\."]
+   :jar-exclusions [#"^\." (re-pattern (Pattern/quote (str File/separator ".")))]
    :eval-in :default
    :offline? (not (nil? (System/getenv "LEIN_OFFLINE")))
    :uberjar-exclusions [#"(?i)^META-INF/[^/]*\.(SF|RSA|DSA)$"]


### PR DESCRIPTION
This could have been done with a single regular expression, but at too high a cost in readability, in my estimation.

This approach does work, and does not break any existing tests. I could not find any tests for the existing `:jar-exclusions` functionality on which to model a new test for this fix, and it would have taken too deep a dive for me to figure out how to write one from scratch, I'm afraid.