### PR TITLE
Allow Github repo URL without .git

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -78,7 +78,7 @@
   (if url
     (next
      (or (re-matches #"(?:[A-Za-z-]{2,}@)?github.com:([^/]+)/([^/]+).git" url)
-         (re-matches #"[^:]+://(?:[A-Za-z-]{2,}@)?github.com/([^/]+)/([^/]+).git" url)))))
+         (re-matches #"[^:]+://(?:[A-Za-z-]{2,}@)?github.com/([^/]+)/([^/]+?)(?:.git)?" url)))))
 
 (defn- github-urls [url]
   (if-let [[user repo] (parse-github-url url)]


### PR DESCRIPTION
Github allows you to clone a repository using the https:// url without a .git ending. Leiningen should still generate the correct pom file in this case.
Came across this since quite a few projects on Clojars have no link to Github.
![screen shot 2018-10-27 at 15 09 43](https://user-images.githubusercontent.com/738978/47604478-c67e0880-d9fa-11e8-8a9d-d594640ced26.png)
Realized that for my project the reason was that lein didn't generate the `scm` as I was expecting. With this change it extracted the info correctly. Guess I am not the only one cloning projects by copying the url directly from the browser.

And thanks for all the great work on lein 🙂 