### PR TITLE
Fix warning in lein.ps1 - Fixes #2502

### DIFF
--- a/bin/lein.ps1
+++ b/bin/lein.ps1
@@ -28,7 +28,7 @@ function Set-ParentLocation([string]$file)
 {
     for($dir = [IO.DirectoryInfo]"$PWD"; $dir.Parent; $dir = $dir.Parent)
     {
-        if(Test-Path (Join-Path $dir.FullName $file) -PathType Leaf) { cd $dir }
+        if(Test-Path (Join-Path $dir.FullName $file) -PathType Leaf) { cd $dir.FullName; break }
     }
 }
 


### PR DESCRIPTION
Would be cool if someone could test this, but I think it was just trying to do `cd .\FOO` whereas it was supposed to do either do `cd ..` or `cd x:\absolute\path\to\FOO`.

So for example if I am in `leiningen\leiningen-core` it would try to go to `leiningen\leiningen-core\leiningen`.

Also it should not continue to do `cd ..` if there *is* a `project.clj` in `leiningen-core`, thus the `break`. Am still a little confused about this code snippet...