### PR TITLE
Add sort for (compilable-namespaces) to provide consistent compile order in all cases. 

### DIFF
--- a/leiningen-core/pom.xml
+++ b/leiningen-core/pom.xml
@@ -14,7 +14,11 @@
     </license>
   </licenses>
   <scm>
-    <tag>eedfbd673fa8fed03edd6a081f3ba8825ba2bf63</tag>
+    <connection>scm:git:git://github.com/technomancy/leiningen.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/technomancy/leiningen.git</developerConnection>
+    <tag>8584ea670627528a2c67ba1c8d3236608ad4fa3e
+</tag>
+    <url>https://github.com/technomancy/leiningen</url>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/leiningen-core/pom.xml
+++ b/leiningen-core/pom.xml
@@ -16,7 +16,7 @@
   <scm>
     <connection>scm:git:git://github.com/technomancy/leiningen.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/technomancy/leiningen.git</developerConnection>
-    <tag>8584ea670627528a2c67ba1c8d3236608ad4fa3e
+    <tag>352ba0e0601f8aa41428297ae72201970e2d0a14
 </tag>
     <url>https://github.com/technomancy/leiningen</url>
   </scm>

--- a/src/leiningen/compile.clj
+++ b/src/leiningen/compile.clj
@@ -33,7 +33,7 @@
   "Return a seq of namespaces that are both compilable and that have missing or
   out-of-date class files."
   [project]
-  (for [namespace (compilable-namespaces project)
+  (for [namespace (sort (compilable-namespaces project))
         :let [[rel-source source]
               (or (first (for [source-path (:source-paths project)
                                rel-source (map (partial b/path-for namespace) ["clj" "cljc"])

--- a/src/leiningen/compile.clj
+++ b/src/leiningen/compile.clj
@@ -26,14 +26,14 @@
   their class files are present and up-to-date."
   [{:keys [aot source-paths] :as project}]
   (if (or (= :all aot) (= [:all] aot))
-    (b/namespaces-on-classpath :classpath (map io/file source-paths))
-    (find-namespaces-by-regex project aot)))
+    (sort (b/namespaces-on-classpath :classpath (map io/file source-paths)))
+    (sort (find-namespaces-by-regex project aot))))
 
 (defn stale-namespaces
   "Return a seq of namespaces that are both compilable and that have missing or
   out-of-date class files."
   [project]
-  (for [namespace (sort (compilable-namespaces project))
+  (for [namespace (compilable-namespaces project)
         :let [[rel-source source]
               (or (first (for [source-path (:source-paths project)
                                rel-source (map (partial b/path-for namespace) ["clj" "cljc"])

--- a/test/leiningen/test/compile.clj
+++ b/test/leiningen/test/compile.clj
@@ -4,7 +4,9 @@
         [clojure.java.io :only [file]]
         [clojure.java.shell :only [with-sh-dir]]
         [leiningen.compile]
-        [leiningen.test.helper :only [sample-project delete-file-recursively
+        [leiningen.test.helper :only [sample-project 
+                                      delete-file-recursively
+                                      sample-ordered-aot-project
                                       sample-failing-project
                                       sample-reader-cond-project
                                       tricky-name-project
@@ -30,6 +32,13 @@
   (compile sample-project ":all")
   (is (.exists (file "test_projects" "sample" "target"
                      "classes" "nom" "nom" "nom.class"))))
+
+(deftest test-compile-order-sorted
+  (print (str "Count for compile: " (count (compilable-namespaces sample-ordered-aot-project))))
+  (is (= 0
+    (compare 
+      (vec (compilable-namespaces sample-ordered-aot-project))
+      (vec (sort (compilable-namespaces sample-ordered-aot-project)))))))
 
 (deftest test-compile-regex
   (compile more-gen-classes-project "#\"\\.ba.$\"")

--- a/test/leiningen/test/compile.clj
+++ b/test/leiningen/test/compile.clj
@@ -34,7 +34,6 @@
                      "classes" "nom" "nom" "nom.class"))))
 
 (deftest test-compile-order-sorted
-  (print (str "Count for compile: " (count (compilable-namespaces sample-ordered-aot-project))))
   (is (= 0
     (compare 
       (vec (compilable-namespaces sample-ordered-aot-project))

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -44,6 +44,8 @@
 
 (def sample-no-aot-project (read-test-project "sample-no-aot"))
 
+(def sample-ordered-aot-project (read-test-project "sample-ordered-aot"))
+
 (def sample-profile-meta-project (read-test-project "sample-profile-meta"))
 
 (def sample-reader-cond-project (read-test-project "sample-reader-cond"))

--- a/test_projects/sample-ordered-aot/project.clj
+++ b/test_projects/sample-ordered-aot/project.clj
@@ -1,0 +1,7 @@
+(defproject sample-ordered-aot "0.1.0-SNAPSHOT"
+  :description "This project is to drive testing of ordered aot compilation."
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :aot :all)

--- a/test_projects/sample-ordered-aot/src/sample_ordered_aot/baz.clj
+++ b/test_projects/sample-ordered-aot/src/sample_ordered_aot/baz.clj
@@ -1,0 +1,6 @@
+(ns sample-ordered-aot.baz)
+
+(defn baz
+  "I don't do a whole lot."
+  [x]
+  (println x "Hello, World!"))

--- a/test_projects/sample-ordered-aot/src/sample_ordered_aot/foo.clj
+++ b/test_projects/sample-ordered-aot/src/sample_ordered_aot/foo.clj
@@ -1,0 +1,6 @@
+(ns sample-ordered-aot.foo)
+
+(defn foo
+  "I don't do a whole lot."
+  [x]
+  (println x "Hello, World!"))


### PR DESCRIPTION
fixes #2508