### PR TITLE
Add `scheme` at reply options and transport to ack-server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Update nREPL to 0.7. (Bozhidar Batsov)
+* Add scheme configuration support to REPL-y and use configured transport when starting the ack-server. (Paulo Feodrippe, Bozhidar Batsov)
 
 ## 2.9.3 / 2020-03-16
 


### PR DESCRIPTION
# Have to wait for the below referenced PR so this can be merged

Repl-y does not accept a scheme option at actual version,
but a PR there (https://github.com/trptcolin/reply/pull/194)
is being developed for it.

The changes here add support to pass the `scheme` to repl-y
so `lein repl` can start without problems for new transports
(see more at https://github.com/nrepl/fastlane).