### PR TITLE
rm "master" from :repl-options :prompt example

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -361,7 +361,7 @@
   ;; Options to change the way the REPL behaves.
   :repl-options { ;; Specify the string to print when prompting for input.
                  ;; defaults to something like (fn [ns] (str *ns* "=> "))
-                 :prompt (fn [ns] (str "your command for <" ns ">, master? " ))
+                 :prompt (fn [ns] (str "your command for <" ns ">? " ))
                  ;; What to print when the repl session starts.
                  :welcome (println "Welcome to the magical world of the repl!")
                  ;; Specify the ns to start the REPL in (overrides :main in


### PR DESCRIPTION
Avoid avoidable nod to "master-slave" idiom in sample `project.clj` configuration.

Resulting shortened example

+ demonstrates the same syntax, string concatenation wrapping around confirmation of the `ns`
+ is still relatable. One can still read the example and understand it to be a function that takes `ns` and returns a string and that string is a repl prompt.
+ is shorter. hurray for brevity
+ avoids an avoidable "master" mention, as in "master-slave", as in disturbing.