### PR TITLE
elides printing of exception when require of user ns throws

### DIFF
--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -225,7 +225,10 @@
    ;; TODO: remove in favour of :injections in the :repl profile
    `(do ~(when-let [init-ns (init-ns project)]
            `(try (doto '~init-ns require in-ns)
-                 (catch Exception e# (println e#) (ns ~init-ns))))
+                 (catch Exception e#
+                   (when-not (= (str '~init-ns) "user")
+                     (println e#))
+                   (ns ~init-ns))))
         (when-not (resolve 'when-some)
           (binding [*out* *err*]
             (println "As of 2.8.2, the repl task is incompatible with"

--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -226,7 +226,7 @@
    `(do ~(when-let [init-ns (init-ns project)]
            `(try (doto '~init-ns require in-ns)
                  (catch Exception e#
-                   (when-not (= (str '~init-ns) "user")
+                   (when-not (= '~init-ns '~'user)
                      (println e#))
                    (ns ~init-ns))))
         (when-not (resolve 'when-some)


### PR DESCRIPTION
this is one approach for fixing https://github.com/technomancy/leiningen/issues/2549

when require of user fails, it's appropriate to silently ignore that, as user is an implicit ns

~I'm concerned about the step of comparing as strings. The equality check is negative when comparing as symbols, and I'd like to know why.~