### PR TITLE
Pick up fix for CVE-2018-10237

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -9,6 +9,7 @@
                   :exclusions [org.clojure/clojure]]
                  [org.flatland/classlojure "0.7.1"]
                  [robert/hooke "1.3.0"]
+                 [com.google.guava/guava "27.1-jre"]
                  [com.cemerick/pomegranate "1.1.0"
                   :exclusions [org.slf4j/jcl-over-slf4j]]
                  [com.hypirion/io "0.3.1"]


### PR DESCRIPTION
com.cemerick/pomegranate 1.1.0 includes com.google.guava 20.0 as a
transitive dependency. This is vulnerable to CVE-2018-10237, so we
override it to pick up the fix found in later versions.