### PR TITLE
add a detailed explanation into doc/TUTORIAL.md

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -270,11 +270,12 @@ It also contains other relevant settings regarding repositories such as update f
 
 ### Checkout Dependencies
 
-Sometimes it is necessary to develop two projects in parallel but it
-is very inconvenient to run `lein install` and restart your repl all
-the time to get your changes picked up. Leiningen provides a solution
-called *checkout dependencies* (or just *checkouts*). To use it,
-create a directory called `checkouts` in the project root, like so:
+Sometimes it is necessary to develop two or more projects in parallel,
+the main project and its dependencies, but it is very inconvenient to
+run `lein install` and restart your repl all the time to get your
+changes picked up. Leiningen provides a solution called *checkout
+dependencies* (or just *checkouts*). To use it, create a directory
+called `checkouts` in the project root, like so:
 
     .
     |-- project.clj


### PR DESCRIPTION
I wrote a small patch for #2554 .

The main change is as follows.

original:
> Sometimes it is necessary to develop two projects in parallel but ...

patch:
> Sometimes it is necessary to develop two or more projects in parallel,
> the main project and its dependencies, but ...

This patch also contains applying auto line fold on the paragraph.

I think this patch is just a draft and there could be better writing.
If so, please adopt the better one.
