### PR TITLE
Fix NullPointerException when trying to fetch gpg public key

### DIFF
--- a/src/leiningen/deps.clj
+++ b/src/leiningen/deps.clj
@@ -43,7 +43,7 @@
 (defn- fetch-key [signature err]
   (if (or (re-find #"Can't check signature: public key not found" err)
           (re-find #"Can't check signature: No public key" err))
-    (let [key (second (re-find #"using \w+ key ID (.+)" err))
+    (let [key (second (re-find #"using \w+ key(?: ID)? (.+)" err))
           {:keys [exit]} (user/gpg "--recv-keys" "--" key)]
       (if (zero? exit)
         (check-signature signature)


### PR DESCRIPTION
When running `lein deps :verify`, there is a `NullPointerException` when Leiningen encounters a signed dependency for which no public key can be found in the keyring.

    gpg: assuming signed data in '/home/glts/.m2/repository/clojure-complete/clojure-complete/0.2.5/clojure-complete-0.2.5.jar'
    gpg: Signature made Sun 04 Feb 2018 22:18:44 CET
    gpg:                using RSA key 67E57A31E9E02368EEAC5CCFBB1DBD3616F1DDB9
    gpg:                issuer "trptcolin@gmail.com"
    gpg: Can't check signature: No public key
    java.lang.NullPointerException: null
     at java.lang.ProcessBuilder.start (ProcessBuilder.java:1012)
        java.lang.Runtime.exec (Runtime.java:620)
        java.lang.Runtime.exec (Runtime.java:528)
        sun.reflect.NativeMethodAccessorImpl.invoke0 (NativeMethodAccessorImpl.java:-2)
        sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
        sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
        java.lang.reflect.Method.invoke (Method.java:498)
        clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:167)
        clojure.lang.Reflector.invokeInstanceMethod (Reflector.java:102)
        leiningen.core.user$gpg.invokeStatic (user.clj:113)
        leiningen.core.user$gpg.doInvoke (user.clj:107)
        clojure.lang.RestFn.invoke (RestFn.java:436)
        leiningen.deps$fetch_key.invokeStatic (deps.clj:47)
        leiningen.deps$fetch_key.invoke (deps.clj:43)
        leiningen.deps$check_signature.invokeStatic (deps.clj:57)
        leiningen.deps$check_signature.invoke (deps.clj:53)
        leiningen.deps$verify.invokeStatic (deps.clj:76)
        leiningen.deps$verify.invoke (deps.clj:73)
        ...

The proposed change tweaks the regexp that looks for a key ID in gpg output. It appears that what used to be the string `key ID` is now simply `key`; the new regexp covers both.

This is with GnuPG 2.2.4 on Ubuntu 18.04.