### PR TITLE
Upgrade data.xml to 0.2.0-alpha5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   ;; If you update these, update resources/leiningen/bootclasspath-deps.clj too
   :dependencies [[leiningen-core "2.9.1"]
                  ;; needed for pom
-                 [org.clojure/data.xml "0.0.8"]
+                 [org.clojure/data.xml "0.2.0-alpha5"]
                  ;; needed for test
                  [timofreiberg/bultitude "0.3.0"
                   :exclusions [org.clojure/clojure]]

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -54,7 +54,7 @@
  org.apache.maven/maven-repository-metadata "3.5.3"
  org.apache.maven/maven-resolver-provider "3.5.3"
  org.clojure/core.specs.alpha "0.2.44"
- org.clojure/data.xml "0.0.8"
+ org.clojure/data.xml "0.2.0-alpha5"
  org.clojure/spec.alpha "0.2.176"
  org.clojure/tools.macro "0.1.5"
  org.codehaus.plexus/plexus-component-annotations "1.7.1"

--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -9,6 +9,7 @@
             [clojure.string :as s]
             [clojure.java.shell :as sh]
             [clojure.data.xml :as xml]
+            [clojure.data.xml.name :as name]
             [leiningen.core.classpath :as classpath]))
 
 (def pom-uri "http://maven.apache.org/POM/4.0.0")
@@ -119,10 +120,11 @@
 
 (defn- pomify-sexp [x]
   (cond
-    (vector? x) (let [[tag & [attrs & content :as all-content]] x]
+    (vector? x) (let [[tag & [attrs & content :as all-content]] x
+                      tag (cond-> tag (not (name/namespaced? tag)) pomify)]
                   (if (map? attrs)
-                    (into [(pomify tag) attrs] (map pomify-sexp) content)
-                    (into [(pomify tag)] (map pomify-sexp) all-content)))
+                    (into [tag attrs] (map pomify-sexp) content)
+                    (into [tag] (map pomify-sexp) all-content)))
     (seq? x) (map pomify-sexp x)
     :else x))
 

--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -11,6 +11,13 @@
             [clojure.data.xml :as xml]
             [leiningen.core.classpath :as classpath]))
 
+(def pom-uri "http://maven.apache.org/POM/4.0.0")
+
+(def ^:private xsi-uri "http://www.w3.org/2001/XMLSchema-instance")
+
+(xml/alias-uri 'pom pom-uri
+               'xsi xsi-uri)
+
 (defn- relativize [project]
   (let [root (str (:root project) (System/getProperty "file.separator"))]
     (reduce #(update-in %1 [%2]
@@ -108,7 +115,16 @@
   (s/replace string #"[-_](\w)" (comp s/upper-case second)))
 
 (defn- pomify [key]
-  (->> key name camelize keyword))
+  (->> key name camelize (xml/qname pom-uri)))
+
+(defn- pomify-sexp [x]
+  (cond
+    (vector? x) (let [[tag & [attrs & content :as all-content]] x]
+                  (if (map? attrs)
+                    (into [(pomify tag) attrs] (map pomify-sexp) content)
+                    (into [(pomify tag)] (map pomify-sexp) all-content)))
+    (seq? x) (map pomify-sexp x)
+    :else x))
 
 (defmulti ^:private xml-tags
   (fn [tag value] (keyword "leiningen.pom" (name tag))))
@@ -157,22 +173,22 @@
 (defmethod xml-tags ::exclusions
   [tag values]
   (and (seq values)
-       [:exclusions
+       [::pom/exclusions
         (for [exclusion-spec values
               :let [[dep & {:keys [classifier extension]}]
                     (if (symbol? exclusion-spec)
                       [exclusion-spec]
                       exclusion-spec)]]
-          [:exclusion (map (partial apply xml-tags)
-                           (merge (project/artifact-map dep)
-                                  {:classifier classifier
-                                   :type extension}))])]))
+          [::pom/exclusion (map (partial apply xml-tags)
+                                (merge (project/artifact-map dep)
+                                       {:classifier classifier
+                                        :type extension}))])]))
 
 (defmethod xml-tags ::dependency
   ([_ [dep version & {:keys [optional classifier
                              exclusions scope
                              extension]}]]
-     [:dependency
+     [::pom/dependency
       (map (partial apply xml-tags)
            {:group-id (or (namespace dep) (name dep))
             :artifact-id (name dep)
@@ -185,7 +201,7 @@
 
 (defmethod xml-tags ::repository
   ([_ [id opts]]
-     [:repository
+     [::pom/repository
       (map (partial apply xml-tags)
            {:id id
             :url (:url opts)
@@ -204,11 +220,11 @@
   ([_ opts]
      (and opts
           (if-let [tags (if (string? opts)
-                          [:name opts]
+                          [::pom/name opts]
                           (seq (for [key [:name :url :distribution :comments]
                                      :let [val (opts key)] :when val]
-                                 [key (name val)])))]
-            [:license tags]))))
+                                 [(pomify key) (name val)])))]
+            [::pom/license tags]))))
 
 (defn- license-tags [project]
   (seq (concat (for [k [:license :licence]
@@ -220,88 +236,90 @@
 
 (defn- resource-tags [project type]
   (if-let [resources (seq (:resource-paths project))]
-    (let [types (keyword (str (name type) "s"))]
+    (let [types (pomify (str (name type) "s"))]
       (vec (concat [types]
                    (for [resource resources]
-                     [type [:directory resource]]))))))
+                     [(pomify type) [::pom/directory resource]]))))))
 
 (defmethod xml-tags ::build
   ([_ [project test-project]]
      (let [[src & extra-src] (concat (:source-paths project)
                                      (:java-source-paths project))
            [test & extra-test] (:test-paths test-project)]
-       [:build
-        [:sourceDirectory src]
+       [::pom/build
+        [::pom/sourceDirectory src]
         (xml-tags :testSourceDirectory test)
         (resource-tags project :resource)
         (resource-tags test-project :testResource)
         (if-let [extensions (seq (:extensions project))]
-          (vec (concat [:extensions]
+          (vec (concat [::pom/extensions]
                        (for [[dep version] extensions]
-                         [:extension
-                          [:artifactId (name dep)]
-                          [:groupId (or (namespace dep) (name dep))]
-                          [:version version]]))))
-        [:directory (:target-path project)]
-        [:outputDirectory (:compile-path project)]
-        [:plugins
+                         [::pom/extension
+                          [::pom/artifactId (name dep)]
+                          [::pom/groupId (or (namespace dep) (name dep))]
+                          [::pom/version version]]))))
+        [::pom/directory (:target-path project)]
+        [::pom/outputDirectory (:compile-path project)]
+        [::pom/plugins
             (if-let [plugins (seq (:pom-plugins project))]
                            (for [[dep version plugin-addition] plugins]
-                             [:plugin
-                              [:groupId (or (namespace dep) (name dep))]
-                              [:artifactId (name dep)]
-                              [:version version]
-                              (if (map? plugin-addition) (seq plugin-addition))
-                              (if (vector? plugin-addition) (seq (apply hash-map plugin-addition)))
-                              (if (list? plugin-addition) (vec plugin-addition))
+                             [::pom/plugin
+                              [::pom/groupId (or (namespace dep) (name dep))]
+                              [::pom/artifactId (name dep)]
+                              [::pom/version version]
+                              (pomify-sexp
+                                (cond
+                                  (map? plugin-addition) (seq plugin-addition)
+                                  (vector? plugin-addition) (seq (apply hash-map plugin-addition))
+                                  (list? plugin-addition) (vec plugin-addition)))
                            ]
                           ))
         (if (or (seq extra-src) (seq extra-test))
-           [:plugin
-            [:groupId "org.codehaus.mojo"]
-            [:artifactId "build-helper-maven-plugin"]
-            [:version "1.7"]
-            [:executions
+           [::pom/plugin
+            [::pom/groupId "org.codehaus.mojo"]
+            [::pom/artifactId "build-helper-maven-plugin"]
+            [::pom/version "1.7"]
+            [::pom/executions
              (if (seq extra-src)
-               [:execution
-                [:id "add-source"]
-                [:phase "generate-sources"]
-                [:goals [:goal "add-source"]]
-                [:configuration
-                 (vec (concat [:sources]
-                              (map (fn [x] [:source x]) extra-src)))]])
+               [::pom/execution
+                [::pom/id "add-source"]
+                [::pom/phase "generate-sources"]
+                [::pom/goals [::pom/goal "add-source"]]
+                [::pom/configuration
+                 (vec (concat [::pom/sources]
+                              (map (fn [x] [::pom/source x]) extra-src)))]])
              (if (seq extra-test)
-               [:execution
-                [:id "add-test-source"]
-                [:phase "generate-test-sources"]
-                [:goals [:goal "add-test-source"]]
-                [:configuration
-                 (vec (concat [:sources]
-                              (map (fn [x] [:source x]) extra-test)))]])]])]])))
+               [::pom/execution
+                [::pom/id "add-test-source"]
+                [::pom/phase "generate-test-sources"]
+                [::pom/goals [::pom/goal "add-test-source"]]
+                [::pom/configuration
+                 (vec (concat [::pom/sources]
+                              (map (fn [x] [::pom/source x]) extra-test)))]])]])]])))
 
 (defmethod xml-tags ::parent
   ([_ [dep version & opts]]
      (let [opts (apply hash-map opts)]
-       [:parent
-        [:artifactId (name dep)]
-        [:groupId (or (namespace dep) (name dep))]
-        [:version version]
-        [:relativePath (:relative-path opts)]])))
+       [::pom/parent
+        [::pom/artifactId (name dep)]
+        [::pom/groupId (or (namespace dep) (name dep))]
+        [::pom/version version]
+        [::pom/relativePath (:relative-path opts)]])))
 
 (defmethod xml-tags ::mailing-list
   ([_ opts]
      (if opts
-       [:mailingLists
-        [:mailingList
-         [:name (:name opts)]
-         [:subscribe (:subscribe opts)]
-         [:unsubscribe (:unsubscribe opts)]
-         [:post (:post opts)]
-         [:archive (:archive opts)]
+       [::pom/mailingLists
+        [::pom/mailingList
+         [::pom/name (:name opts)]
+         [::pom/subscribe (:subscribe opts)]
+         [::pom/unsubscribe (:unsubscribe opts)]
+         [::pom/post (:post opts)]
+         [::pom/archive (:archive opts)]
          (if-let [other-archives (:other-archives opts)]
-           (vec (concat [:otherArchives]
+           (vec (concat [::pom/otherArchives]
                         (for [other other-archives]
-                          [:otherArchive other]))))]])))
+                          [::pom/otherArchive other]))))]])))
 
 (defn- distinct-key [k xs]
   ((fn step [seen xs]
@@ -337,23 +355,22 @@
            managed-deps (:managed-dependencies test-project)
            deps (:dependencies test-project)]
        (list
-        [:project {:xsi:schemaLocation
-                   (str "http://maven.apache.org/POM/4.0.0"
-                        " http://maven.apache.org/xsd/maven-4.0.0.xsd")
-                   :xmlns "http://maven.apache.org/POM/4.0.0"
-                   :xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"}
-         [:modelVersion "4.0.0"]
+        [::pom/project {:xmlns pom-uri
+                        :xmlns/xsi xsi-uri
+                        ::xsi/schemaLocation
+                        (str pom-uri " http://maven.apache.org/xsd/maven-4.0.0.xsd")}
+         [::pom/modelVersion "4.0.0"]
          (and (:parent project) (xml-tags :parent (:parent project)))
-         [:groupId (:group project)]
-         [:artifactId (:name project)]
-         [:packaging (:packaging project "jar")]
-         [:version (:version project)]
-         (and (:classifier project) [:classifier (:classifier project)])
-         [:name (:name project)]
-         [:description (:description project)]
+         [::pom/groupId (:group project)]
+         [::pom/artifactId (:name project)]
+         [::pom/packaging (:packaging project "jar")]
+         [::pom/version (:version project)]
+         (and (:classifier project) [::pom/classifier (:classifier project)])
+         [::pom/name (:name project)]
+         [::pom/description (:description project)]
          (xml-tags :url (:url project))
          (if-let [licenses (license-tags project)]
-           [:licenses licenses])
+           [::pom/licenses licenses])
          (xml-tags :mailing-list (:mailing-list project))
          (write-scm-tag (guess-scm project) project)
          ;; TODO: this results in lots of duplicate entries
@@ -362,7 +379,7 @@
          (xml-tags :dependencyManagement
                    (xml-tags :dependencies (distinct-key dep-key managed-deps)))
          (xml-tags :dependencies (distinct-key dep-key deps))
-         (and (:pom-addition project) (:pom-addition project))]))))
+         (and (:pom-addition project) (pomify-sexp (:pom-addition project)))]))))
 
 (defn snapshot? [project]
   (and (:version project)

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -1,7 +1,7 @@
 (ns leiningen.test.pom
   (:use [clojure.test]
         [clojure.java.io :only [file delete-file]]
-        [leiningen.pom :as pom :only [make-pom pom snapshot?]]
+        [leiningen.pom :as lein-pom :only [make-pom pom pom-uri snapshot?]]
         [leiningen.core.user :as user]
         [leiningen.test.helper
          :only [sample-project sample-profile-meta-project
@@ -16,11 +16,16 @@
                       (with-redefs [user/profiles (constantly {})]
                         (f))))
 
+(xml/alias-uri 'pom pom-uri)
+
 (deftest test-pom-file-is-created
   (let [pom-file (file (:root sample-project) "pom.xml")]
     (delete-file pom-file true)
     (pom sample-project)
     (is (.exists pom-file))))
+
+(defn parse-xml [s]
+  (xml/parse-str s :skip-whitespace true))
 
 (defn deep-content [xml tags]
   (reduce #(->> %1
@@ -51,38 +56,38 @@
       (project/merge-profiles (with-profile project name profile) [name])))
 
 (deftest test-pom-scm-auto
-  (with-redefs [pom/parse-github-url (constantly ["techno" "lein"])
-                pom/read-git-head (constantly "the git head")]
+  (with-redefs [lein-pom/parse-github-url (constantly ["techno" "lein"])
+                lein-pom/read-git-head (constantly "the git head")]
     (let [project (with-profile-merged sample-project
                   ^:leaky {:scm {:name "auto"
                                  :dir "." ;; so resolve-git-dir looks for lein project .git dir, not the sample
                                  :connection "https://example.org/ignored-url"
                                  :url "https://github.com/this-is/ignored"}})
         pom (make-pom project)
-        xml (xml/parse-str pom)]
-      (is (= "scm:git:git://github.com/techno/lein.git" (first-in xml [:project :scm :connection])))
-      (is (= "scm:git:ssh://git@github.com/techno/lein.git" (first-in xml [:project :scm :developerConnection])))
-      (is (= "https://github.com/techno/lein" (first-in xml [:project :scm :url])))
-      (is (= "the git head" (first-in xml [:project :scm :tag]))))))
+        xml (parse-xml pom)]
+      (is (= "scm:git:git://github.com/techno/lein.git" (first-in xml [::pom/project ::pom/scm ::pom/connection])))
+      (is (= "scm:git:ssh://git@github.com/techno/lein.git" (first-in xml [::pom/project ::pom/scm ::pom/developerConnection])))
+      (is (= "https://github.com/techno/lein" (first-in xml [::pom/project ::pom/scm ::pom/url])))
+      (is (= "the git head" (first-in xml [::pom/project ::pom/scm ::pom/tag]))))))
 
 (deftest test-pom-scm-git
-  (with-redefs [pom/read-git-origin (constantly "git@github.com:techno/lein.git")
-                pom/read-git-head (constantly "the git head")]
+  (with-redefs [lein-pom/read-git-origin (constantly "git@github.com:techno/lein.git")
+                lein-pom/read-git-head (constantly "the git head")]
     (let [project (with-profile-merged sample-project
                   ^:leaky {:scm {:name "git"
                                  :dir "." ;; so resolve-git-dir looks for lein project .git dir, not the sample
                                  :connection ":connection is not ignored in :scm :git"
                                  :url "https://github.com/this-is-not/ignored"}})
         pom (make-pom project)
-        xml (xml/parse-str pom)]
-      (is (= ":connection is not ignored in :scm :git" (first-in xml [:project :scm :connection])))
-      (is (= "scm:git:ssh://git@github.com/techno/lein.git" (first-in xml [:project :scm :developerConnection])))
-      (is (= "https://github.com/this-is-not/ignored" (first-in xml [:project :scm :url])))
-      (is (= "the git head" (first-in xml [:project :scm :tag]))))))
+        xml (parse-xml pom)]
+      (is (= ":connection is not ignored in :scm :git" (first-in xml [::pom/project ::pom/scm ::pom/connection])))
+      (is (= "scm:git:ssh://git@github.com/techno/lein.git" (first-in xml [::pom/project ::pom/scm ::pom/developerConnection])))
+      (is (= "https://github.com/this-is-not/ignored" (first-in xml [::pom/project ::pom/scm ::pom/url])))
+      (is (= "the git head" (first-in xml [::pom/project ::pom/scm ::pom/tag]))))))
 
 (deftest test-pom-scm-git-with-empty-values
-  (with-redefs [pom/parse-github-url (constantly ["techno" "lein"])
-                pom/read-git-head (constantly "the git head")]
+  (with-redefs [lein-pom/parse-github-url (constantly ["techno" "lein"])
+                lein-pom/read-git-head (constantly "the git head")]
     (let [project (with-profile-merged sample-project
                   ^:leaky {:scm {:name "git"
                                  :dir "." ;; so resolve-git-dir looks for lein project .git dir, not the sample
@@ -90,169 +95,170 @@
                                  :developerConnection nil
                                  :url "https://github.com/this-is-not/ignored"}})
         pom (make-pom project)
-        xml (xml/parse-str pom)]
-      (is (nil? (first-in xml [:project :scm :connection]))
+        xml (parse-xml pom)]
+      (is (nil? (first-in xml [::pom/project ::pom/scm ::pom/connection]))
           ":connection is not present because the project defines an empty value for it")
-      (is (nil? (first-in xml [:project :scm :developerConnection]))
+      (is (nil? (first-in xml [::pom/project ::pom/scm ::pom/developerConnection]))
           ":developerConnection is not present because the project defines an empty value for it")
-      (is (= "https://github.com/this-is-not/ignored" (first-in xml [:project :scm :url])))
-      (is (= "the git head" (first-in xml [:project :scm :tag]))))))
+      (is (= "https://github.com/this-is-not/ignored" (first-in xml [::pom/project ::pom/scm ::pom/url])))
+      (is (= "the git head" (first-in xml [::pom/project ::pom/scm ::pom/tag]))))))
 
 (deftest test-pom-scm-git-with-https-url
-  (with-redefs [pom/read-git-origin (constantly "https://github.com/techno/lein.git")
-                pom/read-git-head (constantly "the git head")]
+  (with-redefs [lein-pom/read-git-origin (constantly "https://github.com/techno/lein.git")
+                lein-pom/read-git-head (constantly "the git head")]
     (let [project (with-profile-merged sample-project
                   ^:leaky {:scm {:name "git"
                                  :dir "." ;; so resolve-git-dir looks for lein project .git dir, not the sample
                                  :connection ":connection is not ignored in :scm :git"
                                  :url "https://github.com/this-is-not/ignored"}})
         pom (make-pom project)
-        xml (xml/parse-str pom)]
-      (is (= ":connection is not ignored in :scm :git" (first-in xml [:project :scm :connection])))
-      (is (= "scm:git:ssh://git@github.com/techno/lein.git" (first-in xml [:project :scm :developerConnection])))
-      (is (= "https://github.com/this-is-not/ignored" (first-in xml [:project :scm :url])))
-      (is (= "the git head" (first-in xml [:project :scm :tag]))))))
+        xml (parse-xml pom)]
+      (is (= ":connection is not ignored in :scm :git" (first-in xml [::pom/project ::pom/scm ::pom/connection])))
+      (is (= "scm:git:ssh://git@github.com/techno/lein.git" (first-in xml [::pom/project ::pom/scm ::pom/developerConnection])))
+      (is (= "https://github.com/this-is-not/ignored" (first-in xml [::pom/project ::pom/scm ::pom/url])))
+      (is (= "the git head" (first-in xml [::pom/project ::pom/scm ::pom/tag]))))))
 
 (deftest test-pom-scm-git-with-non-git-url
-  (with-redefs [pom/read-git-origin (constantly "https://github.com/techno/lein")
-                pom/read-git-head (constantly "the git head")]
+  (with-redefs [lein-pom/read-git-origin (constantly "https://github.com/techno/lein")
+                lein-pom/read-git-head (constantly "the git head")]
     (let [project (with-profile-merged sample-project
                   ^:leaky {:scm {:name "git"
                                  :dir "." ;; so resolve-git-dir looks for lein project .git dir, not the sample
                                  :connection ":connection is not ignored in :scm :git"
                                  :url "https://github.com/this-is-not/ignored"}})
         pom (make-pom project)
-        xml (xml/parse-str pom)]
-      (is (= ":connection is not ignored in :scm :git" (first-in xml [:project :scm :connection])))
-      (is (= "scm:git:ssh://git@github.com/techno/lein.git" (first-in xml [:project :scm :developerConnection])))
-      (is (= "https://github.com/this-is-not/ignored" (first-in xml [:project :scm :url])))
-      (is (= "the git head" (first-in xml [:project :scm :tag]))))))
+        xml (parse-xml pom)]
+      (is (= ":connection is not ignored in :scm :git" (first-in xml [::pom/project ::pom/scm ::pom/connection])))
+      (is (= "scm:git:ssh://git@github.com/techno/lein.git" (first-in xml [::pom/project ::pom/scm ::pom/developerConnection])))
+      (is (= "https://github.com/this-is-not/ignored" (first-in xml [::pom/project ::pom/scm ::pom/url])))
+      (is (= "the git head" (first-in xml [::pom/project ::pom/scm ::pom/tag]))))))
 
 (deftest test-pom-default-values
-  (let [xml (xml/parse-str (make-pom sample-project))]
-    (is (= "nomnomnom" (first-in xml [:project :groupId]))
+  (let [xml (parse-xml (make-pom sample-project))]
+    (is (= "nomnomnom" (first-in xml [::pom/project ::pom/groupId]))
         "group is correct")
-    (is (= "nomnomnom" (first-in xml [:project :artifactId]))
+    (is (= "nomnomnom" (first-in xml [::pom/project ::pom/artifactId]))
         "artifact is correct")
-    (is (= "nomnomnom" (first-in xml [:project :name]))
+    (is (= "nomnomnom" (first-in xml [::pom/project ::pom/name]))
         "name is correct")
-    (is (= "0.5.0-SNAPSHOT" (first-in xml [:project :version]))
+    (is (= "0.5.0-SNAPSHOT" (first-in xml [::pom/project ::pom/version]))
         "version is correct")
-    (is (nil? (first-in xml [:project :parent]))
+    (is (nil? (first-in xml [::pom/project ::pom/parent]))
         "no parent")
-    (is (= "http://leiningen.org" (first-in xml [:project :url]))
+    (is (= "http://leiningen.org" (first-in xml [::pom/project ::pom/url]))
         "url is correct")
     (is (= ["Eclipse Public License" "http://www.eclipse.org/legal/epl-v10.html"]
-           (->> (deep-content xml [:project :licenses])
+           (->> (deep-content xml [::pom/project ::pom/licenses])
                 (map :content) first (map :content) (map first)))
         "no license")
-    (is (= "A test project" (first-in xml [:project :description]))
+    (is (= "A test project" (first-in xml [::pom/project ::pom/description]))
         "description is included")
-    (is (= nil (first-in xml [:project :mailingLists]))
+    (is (= nil (first-in xml [::pom/project ::pom/mailingLists]))
         "no mailing list")
     (is (= ["central" "clojars" "other"]
-           (map #(first-in % [:repository :id])
-                (deep-content xml [:project :repositories])))
+           (map #(first-in % [::pom/repository ::pom/id])
+                (deep-content xml [::pom/project ::pom/repositories])))
         "repositories are named")
     (is (= ["https://repo1.maven.org/maven2/" "https://repo.clojars.org/"
             "http://example.com/repo"]
-           (map #(first-in % [:repository :url])
-                (deep-content xml [:project :repositories])))
+           (map #(first-in % [::pom/repository ::pom/url])
+                (deep-content xml [::pom/project ::pom/repositories])))
         "repositories have correct location")
     (is (= ["false" "true" "true"]
-           (map #(first-in % [:repository :snapshots :enabled])
-                (deep-content xml [:project :repositories])))
+           (map #(first-in % [::pom/repository ::pom/snapshots ::pom/enabled])
+                (deep-content xml [::pom/project ::pom/repositories])))
         "some snapshots are enabled")
     (is (= ["true" "true" "true"]
-           (map #(first-in % [:repository :releases :enabled])
-                (deep-content xml [:project :repositories])))
+           (map #(first-in % [::pom/repository ::pom/releases ::pom/enabled])
+                (deep-content xml [::pom/project ::pom/repositories])))
         "releases are enabled")
-    (is (= "src" (first-in xml [:project :build :sourceDirectory]))
+    (is (= "src" (first-in xml [::pom/project ::pom/build ::pom/sourceDirectory]))
         "source directory is included")
-    (is (= "test" (first-in xml [:project :build :testSourceDirectory]))
+    (is (= "test" (first-in xml [::pom/project ::pom/build ::pom/testSourceDirectory]))
         "test directory is included")
     (is (= ["resources"]
-           (map #(first-in % [:resource :directory])
-                (deep-content xml [:project :build :resources])))
+           (map #(first-in % [::pom/resource ::pom/directory])
+                (deep-content xml [::pom/project ::pom/build ::pom/resources])))
         "resource directories use project without :default or :dev profile")
     (is (= ["resources"]
-           (map #(first-in % [:testResource :directory])
-                (deep-content xml [:project :build :testResources])))
+           (map #(first-in % [::pom/testResource ::pom/directory])
+                (deep-content xml [::pom/project ::pom/build ::pom/testResources])))
         "test resource directories use :dev :default and :test profiles")
-    (is (= "target" (first-in xml [:project :build :directory]))
+    (is (= "target" (first-in xml [::pom/project ::pom/build ::pom/directory]))
         "target directory is included")
-    (is (= nil (first-in xml [:project :build :extensions]))
+    (is (= nil (first-in xml [::pom/project ::pom/build ::pom/extensions]))
         "no extensions")
-    (is (= (lthelper/fix-path-delimiters "target/classes") (first-in xml [:project :build :outputDirectory]))
+    (is (= (lthelper/fix-path-delimiters "target/classes")
+           (first-in xml [::pom/project ::pom/build ::pom/outputDirectory]))
         "classes directory is included")
     (is (= ["org.clojure" "rome" "ring"]
-           (map #(first-in % [:dependency :groupId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/groupId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["clojure" "rome" "ring"]
-           (map #(first-in % [:dependency :artifactId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/artifactId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["1.3.0" "0.9" "1.0.0"]
-           (map #(first-in % [:dependency :version])
-                (deep-content xml [:project :dependencies]))))))
+           (map #(first-in % [::pom/dependency ::pom/version])
+                (deep-content xml [::pom/project ::pom/dependencies]))))))
 
 (deftest test-dependencies-are-test-scoped
-  (let [xml (xml/parse-str
+  (let [xml (parse-xml
              (make-pom (with-profile-merged
                          sample-project
                          :test {:dependencies '[[peridot "0.0.5"]]})))]
     (is (= ["org.clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :groupId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/groupId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :artifactId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/artifactId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["1.3.0" "0.9" "1.0.0" "0.0.5"]
-           (map #(first-in % [:dependency :version])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/version])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "test"]
-           (map #(first-in % [:dependency :scope])
-                (deep-content xml [:project :dependencies]))))))
+           (map #(first-in % [::pom/dependency ::pom/scope])
+                (deep-content xml [::pom/project ::pom/dependencies]))))))
 
 (deftest dev-dependencies-are-test-scoped
-  (let [xml (xml/parse-str
+  (let [xml (parse-xml
              (make-pom (with-profile-merged
                          sample-project
                          :dev
                          {:dependencies '[[peridot "0.0.5"]]})))]
     (is (= ["org.clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :groupId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/groupId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :artifactId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/artifactId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["1.3.0" "0.9" "1.0.0" "0.0.5"]
-           (map #(first-in % [:dependency :version])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/version])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "test"]
-           (map #(first-in % [:dependency :scope])
-                (deep-content xml [:project :dependencies]))))))
+           (map #(first-in % [::pom/dependency ::pom/scope])
+                (deep-content xml [::pom/project ::pom/dependencies]))))))
 
 (deftest provided-dependencies-are-provided-scoped
-  (let [xml (xml/parse-str
+  (let [xml (parse-xml
              (make-pom (with-profile-merged
                          sample-project
                          :provided
                          {:dependencies '[[peridot "0.0.5"]]})))]
     (is (= ["org.clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :groupId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/groupId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :artifactId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/artifactId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["1.3.0" "0.9" "1.0.0" "0.0.5"]
-           (map #(first-in % [:dependency :version])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/version])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "provided"]
-           (map #(first-in % [:dependency :scope])
-                (deep-content xml [:project :dependencies]))))))
+           (map #(first-in % [::pom/dependency ::pom/scope])
+                (deep-content xml [::pom/project ::pom/dependencies]))))))
 
 (deftest dependency-options
-  (let [xml (xml/parse-str
+  (let [xml (parse-xml
              (make-pom (with-profile-merged
                          sample-project
                          ^:leaky {:dependencies '[[peridot "0.0.5"
@@ -265,39 +271,39 @@
                                                      :classifier "cla"
                                                      :extension "dom"]]]]})))]
     (is (= ["org.clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :groupId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/groupId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :artifactId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/artifactId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["1.3.0" "0.9" "1.0.0" "0.0.5"]
-           (map #(first-in % [:dependency :version])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/version])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "provided"]
-           (map #(first-in % [:dependency :scope])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/scope])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "true"]
-           (map #(first-in % [:dependency :optional])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/optional])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "sources"]
-           (map #(first-in % [:dependency :classifier])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/classifier])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "pom"]
-           (map #(first-in % [:dependency :type])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/type])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "ring-mock"]
-           (map #(first-in % [:dependency :exclusions :exclusion :artifactId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/exclusions ::pom/exclusion ::pom/artifactId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "ring-mock"]
-           (map #(first-in % [:dependency :exclusions :exclusion :groupId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/exclusions ::pom/exclusion ::pom/groupId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "cla"]
-           (map #(first-in % [:dependency :exclusions :exclusion :classifier])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/exclusions ::pom/exclusion ::pom/classifier])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "dom"]
-           (map #(first-in % [:dependency :exclusions :exclusion :type])
-                (deep-content xml [:project :dependencies])))))
-  (let [xml (xml/parse-str
+           (map #(first-in % [::pom/dependency ::pom/exclusions ::pom/exclusion ::pom/type])
+                (deep-content xml [::pom/project ::pom/dependencies])))))
+  (let [xml (parse-xml
              (make-pom (with-profile-merged
                          sample-project
                          ^:leaky {:dependencies '[[peridot "0.0.5"
@@ -305,44 +311,44 @@
                                                    :exclusions
                                                    [ring-mock]]]})))]
     (is (= ["org.clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :groupId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/groupId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["clojure" "rome" "ring" "peridot"]
-           (map #(first-in % [:dependency :artifactId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/artifactId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["1.3.0" "0.9" "1.0.0" "0.0.5"]
-           (map #(first-in % [:dependency :version])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/version])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "provided"]
-           (map #(first-in % [:dependency :scope])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/scope])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil "ring-mock"]
-           (map #(first-in % [:dependency :exclusions :exclusion :artifactId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/exclusions ::pom/exclusion ::pom/artifactId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil nil]
-           (map #(first-in % [:dependency :exclusions :exclusion :classifier])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/exclusions ::pom/exclusion ::pom/classifier])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil nil nil  nil]
-           (map #(first-in % [:dependency :exclusions :exclusion :type])
-                (deep-content xml [:project :dependencies]))))))
+           (map #(first-in % [::pom/dependency ::pom/exclusions ::pom/exclusion ::pom/type])
+                (deep-content xml [::pom/project ::pom/dependencies]))))))
 
 (deftest dependencies-are-required-when-overlapped-by-builtin-profiles
-  (let [xml (xml/parse-str
+  (let [xml (parse-xml
              (make-pom (with-profile-merged
                          sample-project
                          :dev {:dependencies '[[rome "0.8"]]})))]
     (is (= ["org.clojure" "rome" "ring"]
-           (map #(first-in % [:dependency :groupId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/groupId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["clojure" "rome" "ring"]
-           (map #(first-in % [:dependency :artifactId])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/artifactId])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= ["1.3.0" "0.8" "1.0.0"]
-           (map #(first-in % [:dependency :version])
-                (deep-content xml [:project :dependencies]))))
+           (map #(first-in % [::pom/dependency ::pom/version])
+                (deep-content xml [::pom/project ::pom/dependencies]))))
     (is (= [nil "test" nil]
-           (map #(first-in % [:dependency :scope])
-                (deep-content xml [:project :dependencies]))))))
+           (map #(first-in % [::pom/dependency ::pom/scope])
+                (deep-content xml [::pom/project ::pom/dependencies]))))))
 
 (deftest test-pom-has-classifier-when-defined
   (is (not (re-find #"classifier"
@@ -351,29 +357,29 @@
          (-> (make-pom (with-profile-merged
                          sample-project
                          ^:leaky {:classifier "stuff"}))
-              xml/parse-str
-              (first-in [:project :classifier])))))
+              parse-xml
+              (first-in [::pom/project ::pom/classifier])))))
 
 (deftest test-pom-adds-java-source-paths
   (is (= (vec (map lthelper/fix-path-delimiters ["java/src" "java/another"]))
          (-> (make-pom (with-profile-merged sample-project
                          ^:leaky
                          {:java-source-paths ["java/src" "java/another"]}))
-             xml/parse-str
-             (deep-content [:project :build :plugins :plugin :executions
-                            :execution :configuration :sources])
+             parse-xml
+             (deep-content [::pom/project ::pom/build ::pom/plugins ::pom/plugin ::pom/executions
+                            ::pom/execution ::pom/configuration ::pom/sources])
              ((partial mapcat :content))))))
 
 (deftest test-pom-handles-global-exclusions
   (is (= [["clojure"] ["clojure"] ["clojure"]]
          (-> (make-pom (with-profile-merged sample-project
                          ^:leaky {:exclusions '[org.clojure/clojure]}))
-             xml/parse-str
-             (deep-content [:project :dependencies])
-             ((partial map #(deep-content % [:dependency :exclusions])))
+             parse-xml
+             (deep-content [::pom/project ::pom/dependencies])
+             ((partial map #(deep-content % [::pom/dependency ::pom/exclusions])))
              ((partial map
                        (partial map
-                                #(first-in % [:exclusion :artifactId]))))))))
+                                #(first-in % [::pom/exclusion ::pom/artifactId]))))))))
 
 (deftest test-pom-tries-to-pprint
   (is (re-find #"(?m)^\s+<groupId>nomnomnom</groupId>$"
@@ -387,43 +393,43 @@
       (is (thrown? Exception (pom project))))))
 
 (deftest test-classifier-kept
-  (let [xml (xml/parse-str (make-pom lthelper/native-project))]
+  (let [xml (parse-xml (make-pom lthelper/native-project))]
     (is (= [["gdx-platform" nil] ["gdx-platform" "natives-desktop"]]
-           (for [dep (deep-content xml [:project :dependencies])
-                 :let [artifact (first-in dep [:dependency :artifactId])]
+           (for [dep (deep-content xml [::pom/project ::pom/dependencies])
+                 :let [artifact (first-in dep [::pom/dependency ::pom/artifactId])]
                  :when (= "gdx-platform" artifact)]
-             [artifact (first-in dep [:dependency :classifier])])))))
+             [artifact (first-in dep [::pom/dependency ::pom/classifier])])))))
 
 (deftest test-override-base-profile
   (testing "leaky explicit profile"
     (let [p (make-pom (with-profile-merged sample-project
                         ^:leaky
                         {:dependencies [['nrepl/nrepl "0.4.5"]]}))
-          deps (deep-content (xml/parse-str p) [:project :dependencies])
+          deps (deep-content (parse-xml p) [::pom/project ::pom/dependencies])
           nrepls (filter #(re-find #"nrepl" (pr-str %)) deps)
-          versions (map #(deep-content % [:dependency :version]) nrepls)]
+          versions (map #(deep-content % [::pom/dependency ::pom/version]) nrepls)]
       (is (= [["0.4.5"]] versions))))
   (testing "pom-scope"
     (let [p (make-pom (with-profile-merged sample-project
                         ^{:pom-scope :test}
                         {:dependencies [['nrepl/nrepl "0.4.5"]]}))
-          deps (deep-content (xml/parse-str p) [:project :dependencies])
+          deps (deep-content (parse-xml p) [::pom/project ::pom/dependencies])
           nrepls (filter #(re-find #"nrepl" (pr-str %)) deps)
-          versions (map #(deep-content % [:dependency :version]) nrepls)]
+          versions (map #(deep-content % [::pom/dependency ::pom/version]) nrepls)]
       (is (= [["0.4.5"]] versions)))))
 
 (deftest test-leaky-profile
   (let [p (make-pom sample-profile-meta-project)
-        deps (deep-content (xml/parse-str p) [:project :dependencies])
+        deps (deep-content (parse-xml p) [::pom/project ::pom/dependencies])
         t-m (filter #(re-find #"tools.macro" (pr-str %)) deps)
         j-c (filter #(re-find #"java.classpath" (pr-str %)) deps)
         t-n (filter #(re-find #"tools.namespace" (pr-str %)) deps)]
-    (is (= [["0.1.2"]] (map #(deep-content % [:dependency :version]) t-m)))
-    (is (= [["0.2.2"]] (map #(deep-content % [:dependency :version]) j-c)))
-    (is (= [["0.2.6"]] (map #(deep-content % [:dependency :version]) t-n)))
-    (is (= [nil] (map #(deep-content % [:dependency :scope]) t-m)))
-    (is (= [["test"]] (map #(deep-content % [:dependency :scope]) j-c)))
-    (is (= [["provided"]] (map #(deep-content % [:dependency :scope]) t-n)))))
+    (is (= [["0.1.2"]] (map #(deep-content % [::pom/dependency ::pom/version]) t-m)))
+    (is (= [["0.2.2"]] (map #(deep-content % [::pom/dependency ::pom/version]) j-c)))
+    (is (= [["0.2.6"]] (map #(deep-content % [::pom/dependency ::pom/version]) t-n)))
+    (is (= [nil] (map #(deep-content % [::pom/dependency ::pom/scope]) t-m)))
+    (is (= [["test"]] (map #(deep-content % [::pom/dependency ::pom/scope]) j-c)))
+    (is (= [["provided"]] (map #(deep-content % [::pom/dependency ::pom/scope]) t-n)))))
 
 (deftest test-determine-release-type
   (testing "Version containing SNAPSHOT is treated as snapshot"
@@ -436,40 +442,40 @@
 (deftest test-managed-dependencies
   (doseq [proj [managed-deps-snapshot-project
                 managed-deps-project]]
-    (let [xml (xml/parse-str
+    (let [xml (parse-xml
                (make-pom proj))]
       (testing "normal dependencies are written to pom properly"
         (is (= ["org.clojure" "rome" "ring" "ring" "ring" "commons-codec"
                 "commons-math" "org.apache.commons" "org.clojure" "org.clojure"]
-               (map #(first-in % [:dependency :groupId])
-                    (deep-content xml [:project :dependencies]))))
+               (map #(first-in % [::pom/dependency ::pom/groupId])
+                    (deep-content xml [::pom/project ::pom/dependencies]))))
         (is (= ["clojure" "rome" "ring" "ring-codec" "ring-headers"
                 "commons-codec" "commons-math" "commons-csv"
                 "tools.emitter.jvm" "tools.namespace"]
-               (map #(first-in % [:dependency :artifactId])
-                    (deep-content xml [:project :dependencies]))))
+               (map #(first-in % [::pom/dependency ::pom/artifactId])
+                    (deep-content xml [::pom/project ::pom/dependencies]))))
         (is (= [nil nil nil nil nil "1.6" nil nil "0.1.0-beta5" "0.3.0-alpha3"]
-               (map #(first-in % [:dependency :version])
-                    (deep-content xml [:project :dependencies])))))
+               (map #(first-in % [::pom/dependency ::pom/version])
+                    (deep-content xml [::pom/project ::pom/dependencies])))))
       (testing "managed dependencies are written to pom properly"
         (is (= ["org.clojure" "rome" "ring" "ring" "ring" "commons-math"
                 "org.apache.commons" "ring" "org.clojure"]
-               (map #(first-in % [:dependency :groupId])
-                    (deep-content xml [:project :dependencyManagement :dependencies]))))
+               (map #(first-in % [::pom/dependency ::pom/groupId])
+                    (deep-content xml [::pom/project ::pom/dependencyManagement ::pom/dependencies]))))
         (is (= ["clojure" "rome" "ring" "ring-codec" "ring-headers"
                 "commons-math" "commons-csv" "ring-defaults" "tools.reader"]
-               (map #(first-in % [:dependency :artifactId])
-                    (deep-content xml [:project :dependencyManagement :dependencies]))))
+               (map #(first-in % [::pom/dependency ::pom/artifactId])
+                    (deep-content xml [::pom/project ::pom/dependencyManagement ::pom/dependencies]))))
         (is (= ["1.3.0" "0.9" "1.0.0" "1.0.1" "0.2.0" "1.2" "1.4" "0.2.1" "1.0.0-beta3"]
-               (map #(first-in % [:dependency :version])
-                    (deep-content xml [:project :dependencyManagement :dependencies]))))
+               (map #(first-in % [::pom/dependency ::pom/version])
+                    (deep-content xml [::pom/project ::pom/dependencyManagement ::pom/dependencies]))))
         (is (= [nil nil nil nil nil "sources" "sources" nil nil]
-               (map #(first-in % [:dependency :classifier])
-                    (deep-content xml [:project :dependencyManagement :dependencies]))))))))
+               (map #(first-in % [::pom/dependency ::pom/classifier])
+                    (deep-content xml [::pom/project ::pom/dependencyManagement ::pom/dependencies]))))))))
 
 (deftest test-pom-plugins
-  (let [xml              (xml/parse-str (make-pom with-pom-plugins-project))
-        plugins          (deep-content xml [:project :build :plugins])
+  (let [xml              (parse-xml (make-pom with-pom-plugins-project))
+        plugins          (deep-content xml [::pom/project ::pom/build ::pom/plugins])
         get-plugin       (fn [re]
                            (first (filter #(re-find re (pr-str %)) plugins)))
         simple-plugin    (get-plugin #"simple-plugin")
@@ -479,37 +485,37 @@
     (testing "two-parameter version adds maven plugin"
       (is (= simple-plugin
              (xml/sexp-as-element
-               [:plugin
-                [:groupId "two.parameter"]
-                [:artifactId "simple-plugin"]
-                [:version "1.0.0"]]))))
+               [::pom/plugin
+                [::pom/groupId "two.parameter"]
+                [::pom/artifactId "simple-plugin"]
+                [::pom/version "1.0.0"]]))))
     (testing "vector as third parameter is interpreted as a mapping"
       (is (= plugin-with-vec
              (xml/sexp-as-element
-               [:plugin
-                [:groupId "three.parameter"]
-                [:artifactId "with-vec"]
-                [:version "1.0.1"]
-                [:a 3]]))))
+               [::pom/plugin
+                [::pom/groupId "three.parameter"]
+                [::pom/artifactId "with-vec"]
+                [::pom/version "1.0.1"]
+                [::pom/a 3]]))))
     (testing "hashmap as third parameter is converted to tags"
       (is (= plugin-with-map
              (xml/sexp-as-element
-               [:plugin
-                [:groupId "three.parameter"]
-                [:artifactId "with-map"]
-                [:version "1.0.2"]
-                [:a 1]
-                [:b 2]
-                [:c 3]]))))
+               [::pom/plugin
+                [::pom/groupId "three.parameter"]
+                [::pom/artifactId "with-map"]
+                [::pom/version "1.0.2"]
+                [::pom/a 1]
+                [::pom/b 2]
+                [::pom/c 3]]))))
     (testing "list as third parameter keeps structure"
       (is (= plugin-with-list
              (xml/sexp-as-element
-               [:plugin
-                [:groupId "three.parameter"]
-                [:artifactId "with-list"]
-                [:version "1.0.3"]
-                [:root
-                 [:a 1]
-                 [:b
-                  [:c 2]
-                  [:d 3]]]]))))))
+               [::pom/plugin
+                [::pom/groupId "three.parameter"]
+                [::pom/artifactId "with-list"]
+                [::pom/version "1.0.3"]
+                [::pom/root
+                 [::pom/a 1]
+                 [::pom/b
+                  [::pom/c 2]
+                  [::pom/d 3]]]]))))))


### PR DESCRIPTION
This change upgrades the data.xml dependency from version 0.0.8 (2014-08-11) to 0.2.0-alpha5 (2017-11-14).

There is no pressing need for doing this upgrade, but still I consider it worthwhile for the benefit of Leiningen plugins, and also justifiable given the recent version bump activity of significant dependencies such as nREPL and Clojure itself. Originally this work was begun by @ehashman in #2456.

Between 0.0.8 and 0.2.0-alpha5, data.xml gained namespace support, a critical feature of any serious XML handling library. The library was basically rewritten by the new maintainer, and then stabilised. For a (subjectively) long time now, 0.2.0-alpha5 has been a solid release of data.xml that I have been very happy to use.

I suggest going with 0.2.0-alpha5 rather than 0.2.0-alpha6, to align with tools.deps.alpha (for the sake of possible Linux dist packaging work, #2456), and because the latter only contains some fixes related to ClojureScript.

Let me know what you think!
