### PR TITLE
Add data.codec to bootstrap classpath dependencies after data.xml upgrade

### DIFF
--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -54,6 +54,7 @@
  org.apache.maven/maven-repository-metadata "3.5.3"
  org.apache.maven/maven-resolver-provider "3.5.3"
  org.clojure/core.specs.alpha "0.2.44"
+ org.clojure/data.codec "0.1.0"
  org.clojure/data.xml "0.2.0-alpha5"
  org.clojure/spec.alpha "0.2.176"
  org.clojure/tools.macro "0.1.5"


### PR DESCRIPTION
This adds the dependency `[org.clojure/data.codec "0.1.0"]` to `resources/leiningen/bootclasspath-deps.clj`. This is a new transitive dependency that snuck in with the upgrade of data.xml in #2569.

My apologies for not noticing this earlier! data.codec is only actually used in one unusual code path in data.xml when a byte array is serialised to an XML string.
