### PR TITLE
Update bootclasspath dependencies

### DIFF
--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -22,7 +22,7 @@
 {
  clojure-complete "0.2.5"
  com.cemerick/pomegranate "1.1.0"
- com.google.guava/guava "20.0"
+ com.google.guava/guava "27.1-jre"
  com.hypirion/io "0.3.1"
  commons-codec "1.9"
  commons-io "2.6"


### PR DESCRIPTION
The update in 194176d was not reflected in this file.

Addresses [@glts' comment](https://github.com/technomancy/leiningen/pull/2551#issuecomment-491579813).