### PR TITLE
Include repository policies in POM

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -201,22 +201,25 @@
             :exclusions exclusions
             :scope scope})]))
 
+(defn- policy-tags [type opts]
+  (seq (keep (partial apply xml-tags)
+             {:enabled (str (if (nil? (type opts))
+                              true
+                              (boolean
+                               (type opts))))
+              :update-policy (or (some-> opts type :update name)
+                                 (some-> opts :update name))
+              :checksum-policy (or (some-> opts type :checksum name)
+                                   (some-> opts :checksum name))})))
+
 (defmethod xml-tags ::repository
   ([_ [id opts]]
      [::pom/repository
       (map (partial apply xml-tags)
            {:id id
             :url (:url opts)
-            :snapshots (xml-tags :enabled
-                                 (str (if (nil? (:snapshots opts))
-                                        true
-                                        (boolean
-                                         (:snapshots opts)))))
-            :releases (xml-tags :enabled
-                                (str (if (nil? (:releases opts))
-                                       true
-                                       (boolean
-                                        (:releases opts)))))})]))
+            :snapshots (policy-tags :snapshots opts)
+            :releases (policy-tags :releases opts)})]))
 
 (defmethod xml-tags ::license
   ([_ opts]

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -172,6 +172,14 @@
            (map #(first-in % [::pom/repository ::pom/releases ::pom/enabled])
                 (deep-content xml [::pom/project ::pom/repositories])))
         "releases are enabled")
+    (is (= [nil nil "always"]
+           (map #(first-in % [::pom/repository ::pom/snapshots ::pom/updatePolicy])
+                (deep-content xml [::pom/project ::pom/repositories])))
+        "snapshots update policy is included")
+    (is (= [nil nil "warn"]
+           (map #(first-in % [::pom/repository ::pom/releases ::pom/checksumPolicy])
+                (deep-content xml [::pom/project ::pom/repositories])))
+        "releases checksum policy is included")
     (is (= "src" (first-in xml [::pom/project ::pom/build ::pom/sourceDirectory]))
         "source directory is included")
     (is (= "test" (first-in xml [::pom/project ::pom/build ::pom/testSourceDirectory]))

--- a/test_projects/sample/project.clj
+++ b/test_projects/sample/project.clj
@@ -23,6 +23,8 @@
   :test-selectors {:integration :integration
                    :default (complement :integration)
                    :random (fn [_] (> (rand) ~(float 1/2)))}
-  :repositories {"other" "http://example.com/repo"}
+  :repositories [["other" {:url "http://example.com/repo"
+                           :update :always
+                           :releases {:checksum :warn}}]]
   :deploy-repositories {"snapshots" ~(format "file://%s/lein-repo"
                                              (System/getProperty "java.io.tmpdir"))})


### PR DESCRIPTION
I continue my ramble through the backlog …

This teaches the `pom` task to include update and checksum policies in the generated POM, and so fixes #2377.
