### PR TITLE
Fix regexp used to parse system property JVM arguments

### DIFF
--- a/leiningen-core/test/leiningen/core/test/eval.clj
+++ b/leiningen-core/test/leiningen/core/test/eval.clj
@@ -54,7 +54,10 @@
   (is (= ["-Dfoo='ba\"r'" "-Dbar=\"ba\"'z'" "arg"]
          (get-jvm-opts-from-env (str "    -Dfoo='ba\"r'"
                                      "    -Dbar=\"ba\"'z'"
-                                     "    arg")))))
+                                     "    arg"))))
+  (is (nil? (parse-d-property "-Xmx1g")))
+  (is (= ["line.separator" "\n"]
+         (parse-d-property "-Dline.separator=\n"))))
 
 (deftest test-file-encoding-in-jvm-args
   (is (contains?


### PR DESCRIPTION
The regular expression used to parse system property JVM args in `leiningen.core.eval` fails to match (legitimate) values containing a newline character. This lead to a `NullPointerException` in #1891.

This change tweaks the regexp from

    -D(.*?)=(.*)

to

    -D(.*?)=(?s)(.*)

(and factors out duplicated logic), and thereby fixes #1891.
