### PR TITLE
Defer to Pomegranate for repository policy defaults

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -245,8 +245,10 @@
           :non-proxy-hosts (get-non-proxy-hosts)})))))
 
 (defn- update-policies [update checksum [repo-name opts]]
-  [repo-name (merge {:update (or update :daily)
-                     :checksum (or checksum :fail)} opts)])
+  (let [project-policies (cond-> {}
+                           update (assoc :update update)
+                           checksum (assoc :checksum checksum))]
+    [repo-name (merge project-policies opts)]))
 
 (defn- print-failures [e]
   (doseq [result (.getArtifactResults (.getResult e))


### PR DESCRIPTION
In #571, the Leiningen default checksum policy was set to `:fail` in anticipation of the same default in Pomegranate. Pomegranate has implemented this change years ago, we no longer need to override the Pomegranate defaults in Leiningen.

See #571 for the history.
