### PR TITLE
Also set proxy settings when deploying

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -311,7 +311,7 @@
 
 (def deploy-repositories
   (with-meta
-    [["clojars" {:url "https://clojars.org/repo/"
+    [["clojars" {:url "https://repo.clojars.org/"
                  :password :gpg :username :gpg}]]
     {:reduce reduce-repo-step}))
 

--- a/src/leiningen/deploy.clj
+++ b/src/leiningen/deploy.clj
@@ -217,7 +217,8 @@ be able to depend on jars that are deployed without a pom."
                         (:version project)]
           :artifact-map files
           :transfer-listener :stdout
-          :repository [repo])
+          :repository [repo]
+          :proxy (classpath/get-proxy-settings))
          (catch org.eclipse.aether.deployment.DeploymentException e
            (when main/*debug* (.printStackTrace e))
            (main/abort (abort-message (.getMessage e)))))))
@@ -236,4 +237,5 @@ be able to depend on jars that are deployed without a pom."
         :artifact-map (into {} artifacts)
         :transfer-listener :stdout
         :repository [repo]
-        :local-repo (:local-repo project)))))
+        :local-repo (:local-repo project)
+        :proxy (classpath/get-proxy-settings)))))


### PR DESCRIPTION
This was prompted by #1319, but I admit I cannot really test this.

The change here simply adds the proxy settings used for dependency resolution also for deployment. According to the Pomegranate Aether docs this is how you do it, I checked that the setting is passed in correctly but I wasn’t able to actually try deploying through a proxy.