### PR TITLE
Cache ~/.gnupg directory in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,6 @@ jobs:
       - run:
           working_directory: ~/leiningen/leiningen-core
           command: lein bootstrap
-      # Disable IPv6 for GnuPG tests as we experienced flaky key servers in CI.
-      - run: mkdir -p ~/.gnupg && echo disable-ipv6 >> ~/.gnupg/dirmngr.conf
       - run: bin/lein test
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,5 +18,6 @@ jobs:
           paths:
             - $HOME/.m2
             - $HOME/.lein
+            - $HOME/.gnupg
           key: << checksum "project.clj" >>
 


### PR DESCRIPTION
GPG tests in CI still occasionally fail, it’s the public keys that sometimes cannot be downloaded.

I don’t know CircleCI, but I imagine if we cache the ~/.gnupg directory, then successful runs will store the downloaded public keys in there.