### PR TITLE
Support repo auth and proxies in ‘lein deps :verify’ too

### DIFF
--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -250,6 +250,20 @@
                            checksum (assoc :checksum checksum))]
     [repo-name (merge project-policies opts)]))
 
+(defn ^:internal default-aether-args
+  "Returns a map of keyword arguments to be used with Pomegranate Aether
+  dependency resolution for the given project."
+  [{:keys [repositories local-repo offline? update checksum mirrors] :as project}]
+  {:local-repo local-repo
+   :offline? offline?
+   :repositories (->> repositories
+                      (map add-repo-auth)
+                      (map (partial update-policies update checksum)))
+   :mirrors (->> mirrors
+                 (map add-repo-auth)
+                 (map (partial update-policies update checksum)))
+   :proxy (get-proxy-settings)})
+
 (defn- print-failures [e]
   (doseq [result (.getArtifactResults (.getResult e))
           :when (not (.isResolved result))
@@ -267,45 +281,39 @@
 
 (defn- get-dependencies*
   [dependencies-key managed-dependencies-key
-   {:keys [repositories local-repo offline? update
-           checksum mirrors] :as project}
+   {:keys [offline?] :as project}
    {:keys [add-classpath?] :as args}]
   {:pre [(every? vector? (get project dependencies-key))
          (every? vector? (get project managed-dependencies-key))]}
   (try
-    ((if add-classpath?
-       pomegranate/add-dependencies
-       aether/resolve-dependencies)
-     :repository-session-fn *dependencies-session*
-     :local-repo local-repo
-     :offline? offline?
-     :repositories (->> repositories
-                        (map add-repo-auth)
-                        (map (partial update-policies update checksum)))
-     :managed-coordinates (get project managed-dependencies-key)
-     :coordinates (get project dependencies-key)
-     :mirrors (->> mirrors
-                   (map add-repo-auth)
-                   (map (partial update-policies update checksum)))
-     :transfer-listener
-     (bound-fn [e]
-       (let [{:keys [type resource error]} e]
-         (let [{:keys [repository name size trace]} resource]
-           (let [aether-repos (if trace (.getRepositories (.getData trace)))]
-             (case type
-               :started
-               (if-let [repo (first (filter
-                                     #(or (= (.getUrl %) repository)
-                                          ;; sometimes the "base" url
-                                          ;; doesn't have a slash on it
-                                          (= (str (.getUrl %) "/") repository))
-                                     aether-repos))]
-                 (locking *err*
-                   (warn "Retrieving" name "from" (.getId repo)))
-                 ;; else case happens for metadata files
-                 )
-               nil)))))
-     :proxy (get-proxy-settings))
+    (apply
+      (if add-classpath?
+        pomegranate/add-dependencies
+        aether/resolve-dependencies)
+      (apply concat
+        (merge
+          (default-aether-args project)
+          {:managed-coordinates (get project managed-dependencies-key)
+           :coordinates (get project dependencies-key)
+           :repository-session-fn *dependencies-session*
+           :transfer-listener
+           (bound-fn [e]
+             (let [{:keys [type resource error]} e]
+               (let [{:keys [repository name size trace]} resource]
+                 (let [aether-repos (if trace (.getRepositories (.getData trace)))]
+                   (case type
+                     :started
+                     (if-let [repo (first (filter
+                                           #(or (= (.getUrl %) repository)
+                                                ;; sometimes the "base" url
+                                                ;; doesn't have a slash on it
+                                                (= (str (.getUrl %) "/") repository))
+                                           aether-repos))]
+                       (locking *err*
+                         (warn "Retrieving" name "from" (.getId repo)))
+                       ;; else case happens for metadata files
+                       )
+                     nil)))))})))
     (catch DependencyResolutionException e
       ;; Cannot recur from catch/finally so have to put this in its own defn
       (print-failures e)

--- a/leiningen-core/src/leiningen/core/classpath.clj
+++ b/leiningen-core/src/leiningen/core/classpath.clj
@@ -511,12 +511,7 @@
 
 (defn merge-versions-from-managed-coords
   [deps managed-deps]
-  ;; NOTE: there is a new function in the 0.3.1 release of pomegranate that
-  ;;  is needed here, but was accidentally marked as private.  Calling it
-  ;;  via the symbol dereference for now, but this can be changed to a
-  ;;  regular function call once https://github.com/cemerick/pomegranate/pull/74
-  ;;  is merged.
-  (#'aether/merge-versions-from-managed-coords
+  (aether/merge-versions-from-managed-coords
    (normalize-dep-vectors deps)
    managed-deps))
 

--- a/src/leiningen/deps.clj
+++ b/src/leiningen/deps.clj
@@ -61,10 +61,9 @@
                   ;; TODO: check pom signature too
                   :extension "jar.asc")
         dep (into (vec (take 2 dep)) (apply concat dep-map))]
-    (try (->> (aether/resolve-dependencies
-               :repositories (:repositories project)
-               :mirrors (:mirrors project)
-               :coordinates [dep])
+    (try (->> (apply aether/resolve-dependencies
+                (apply concat
+                  (assoc (classpath/default-aether-args project) :coordinates [dep])))
               (aether/dependency-files)
               (filter #(.endsWith (.getName %) ".asc"))
               (first))

--- a/test/leiningen/test/deps.clj
+++ b/test/leiningen/test/deps.clj
@@ -214,11 +214,9 @@
 (deftest ^:online test-verify
   (let [project (-> sample-project
                     (update :repositories (fn [repos]
-                                            (keep (fn [[repo opts]]
-                                                    (when (not= repo "other")
-                                                      [repo (assoc opts :checksum :ignore)]))
-                                                  repos)))
-                    (update :dependencies #(take 2 %)))
+                                            (remove #(= "other" (first %)) repos)))
+                    (update :dependencies #(take 2 %))
+                    (assoc :checksum :ignore))
         _ (deps project)
         out (with-out-str (deps project ":verify"))]
     (doseq [[dep signed] '{[org.clojure/clojure "1.3.0"] :signed


### PR DESCRIPTION
In `lein deps :verify`, Pomegranate’s `aether/resolve-dependencies` is called directly without applying repository auth or proxy settings to repositories and mirrors. This change applies those settings there too, and so should provide a fix for both #2580 and #1643.

My implementation feels awkward, so I’m grateful for any feedback. Basically, I extracted the keyword arguments that need to be passed to `aether/resolve-dependencies` into a new public function `leiningen.core.classpath/default-aether-args`, and then used this from `leiningen.deps`. It is as minimal as I could think of.