### PR TITLE
Fix empty/default test selector logic

### DIFF
--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -183,14 +183,14 @@
                                             {:only only-form}
                                             (:test-selectors project))
                                      given-selectors)
-        selectors (if (and (empty? selectors)
-                           (:default (:test-selectors project)))
-                    [[(:default (:test-selectors project)) ()]]
-                    selectors)]
+        selectors-or-default (if (and (empty? selectors)
+                                      (:default (:test-selectors project)))
+                               [[(:default (:test-selectors project)) ()]]
+                               selectors)]
     (when (and (empty? selectors)
                (seq given-selectors))
       (main/abort "Please specify :test-selectors in project.clj"))
-    [nses selectors]))
+    [nses selectors-or-default]))
 
 (defn test
   "Run the project's tests.


### PR DESCRIPTION
This check in `leiningen.test/read-args` was intended to catch unknown or misspelled test selectors, but was never actually triggered:

```clojure
(when (and (empty? selectors)
           (seq given-selectors))
  (main/abort "Please specify :test-selectors in project.clj"))
```

When an unknown selector is passed to `lein test :unknown`, Leiningen silently falls back to the `:default` selector. The change here fixes the logic, `lein test :unknown` now aborts.