### PR TITLE
Apply default metadata to composite profiles, too

### DIFF
--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -494,6 +494,17 @@
              (merge-profiles [:a])
              (dissoc :profiles)))))
 
+(deftest test-profiles-default-meta
+  (is (= [:repl]
+         (-> (init-project
+              {:profiles {:repl {:a {:A 1}}}})
+             (profiles-with-matching-meta :repl))))
+  (is (= [:repl]
+         (-> (init-project
+              {:profiles {:a {:A 1}
+                          :repl [:a]}})
+             (profiles-with-matching-meta :repl)))))
+
 (deftest test-override-default
   (is (= {:A 1, :B 2, :C 3}
          (-> (make-project


### PR DESCRIPTION
This change applies default profile metadata (`leiningen.core.project/default-profile-metadata`) also to composite profiles, ie values in the profile map that are vectors, not maps. This fixes #2132.

An alternative solution would be to enhance the function [`leiningen.core.project/profiles-with-matching-meta`](https://github.com/technomancy/leiningen/blob/2.9.1/leiningen-core/src/leiningen/core/project.clj#L1016-L1018) instead; that function should perhaps recurse when it encounters composite profiles rather than just look at the map values’ metadata.

(The code around profile handling is quite complicated, and I don’t really have a good handle on it yet.)