### PR TITLE
Remove broken excluded profiles normalization

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -887,8 +887,6 @@
                                    (utils/last-distinct-by first))
         include-profiles (map first include-profiles-meta)
         exclude-profiles (utils/last-distinct (expand-profiles project exclude-profiles))
-        normalize #(if (coll? %) (lookup-profile (:profiles project) %) [%])
-        exclude-profiles (mapcat normalize exclude-profiles)
         profile-map (apply dissoc (:profiles (meta project)) exclude-profiles)
         profiles (map (partial lookup-profile profile-map) include-profiles)
         normalized-profiles (map normalize-values profiles)]


### PR DESCRIPTION
I have been puzzling over this for a bit now, and I think this code from 328b2182b08e1f6e3d72d6bf7ccf2847de1b1224 is simply broken.

* In the case where the `exclude-profiles` argument contains keywords, no ‘normalization’ happens at all; the two removed lines are a noop.
* In the (unusual) case where the `exclude-profiles` argument contains profile maps, these get flattened by `mapcat` into map entries. This is not valid data for excluded-profiles.

I don’t understand what the code was meant to do (#1267 is working fine); but since it is ineffective/broken I’m deleting it here.