### PR TITLE
Update Clojars URL in doc and tests

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -689,24 +689,24 @@ to publish it at [Clojars](https://clojars.org). Once you have
 is easy:
 
     $ lein deploy clojars
-    Created ~/src/my-stuff/target/my-stuff-0.1.0-SNAPSHOT.jar
-    Wrote ~/src/my-stuff/pom.xml
     No credentials found for clojars
-    See `lein help deploying` for how to configure credentials.
+    See `lein help deploying` for how to configure credentials to avoid prompts.
     Username: me
     Password:
-    Retrieving my-stuff/my-stuff/0.1.0-SNAPSHOT/maven-metadata.xml (1k)
-        from https://clojars.org/repo/
-    Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/my-stuff-0.1.0-20120531.032047-14.jar (5k)
-        to https://clojars.org/repo/
-    Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/my-stuff-0.1.0-20120531.032047-14.pom (3k)
-        to https://clojars.org/repo/
-    Retrieving my-stuff/my-stuff/maven-metadata.xml (1k)
-        from https://clojars.org/repo/
+    Created ~/src/my-stuff/target/my-stuff-0.1.0-SNAPSHOT.jar
+    Wrote ~/src/my-stuff/pom.xml
+    Retrieving my-stuff/my-stuff/0.1.0-SNAPSHOT/maven-metadata.xml
+        from https://repo.clojars.org/
+    Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/my-stuff-0.1.0-20190525.161117-2.jar (9k)
+        to https://repo.clojars.org/
+    Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/my-stuff-0.1.0-20190525.161117-2.pom (2k)
+        to https://repo.clojars.org/
+    Retrieving my-stuff/my-stuff/maven-metadata.xml
+        from https://repo.clojars.org/
     Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/maven-metadata.xml (1k)
-        to https://clojars.org/repo/
+        to https://repo.clojars.org/
     Sending my-stuff/my-stuff/maven-metadata.xml (1k)
-        to https://clojars.org/repo/
+        to https://repo.clojars.org/
 
 Once that succeeds it will be available as a package on which other
 projects may depend. For instructions on storing your credentials so

--- a/doc/ja/TUTORIAL_ja.md
+++ b/doc/ja/TUTORIAL_ja.md
@@ -723,24 +723,24 @@ Leiningen の自分自身の JVM は実行され続け、不必要なメモリ�
 一度[アカウントを作れば](https://clojars.org/register)、公開は容易です:
 
     $ lein deploy clojars
-    Created ~/src/my-stuff/target/my-stuff-0.1.0-SNAPSHOT.jar
-    Wrote ~/src/my-stuff/pom.xml
     No credentials found for clojars
-    See `lein help deploying` for how to configure credentials.
+    See `lein help deploying` for how to configure credentials to avoid prompts.
     Username: me
     Password:
-    Retrieving my-stuff/my-stuff/0.1.0-SNAPSHOT/maven-metadata.xml (1k)
-        from https://clojars.org/repo/
-    Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/my-stuff-0.1.0-20120531.032047-14.jar (5k)
-        to https://clojars.org/repo/
-    Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/my-stuff-0.1.0-20120531.032047-14.pom (3k)
-        to https://clojars.org/repo/
-    Retrieving my-stuff/my-stuff/maven-metadata.xml (1k)
-        from https://clojars.org/repo/
+    Created ~/src/my-stuff/target/my-stuff-0.1.0-SNAPSHOT.jar
+    Wrote ~/src/my-stuff/pom.xml
+    Retrieving my-stuff/my-stuff/0.1.0-SNAPSHOT/maven-metadata.xml
+        from https://repo.clojars.org/
+    Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/my-stuff-0.1.0-20190525.161117-2.jar (9k)
+        to https://repo.clojars.org/
+    Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/my-stuff-0.1.0-20190525.161117-2.pom (2k)
+        to https://repo.clojars.org/
+    Retrieving my-stuff/my-stuff/maven-metadata.xml
+        from https://repo.clojars.org/
     Sending my-stuff/my-stuff/0.1.0-SNAPSHOT/maven-metadata.xml (1k)
-        to https://clojars.org/repo/
+        to https://repo.clojars.org/
     Sending my-stuff/my-stuff/maven-metadata.xml (1k)
-        to https://clojars.org/repo/
+        to https://repo.clojars.org/
 
 一度このプロセスが成功すると、
 他のプロジェクトが依存できるパッケージとして利用出来るようになります。

--- a/lein-pprint/README.md
+++ b/lein-pprint/README.md
@@ -23,7 +23,7 @@ Add `[lein-pprint "1.2.0"]` to `:plugins`.
  :test-path ("/home/phil/src/leiningen/lein-pprint/test"),
  :repositories
  (["central" {:url "https://repo1.maven.org/maven2"}]
-  ["clojars" {:url "http://clojars.org/repo/"}]),
+  ["clojars" {:url "https://repo.clojars.org/"}]),
  :uberjar-exclusions [#"^META-INF/DUMMY.SF"],
  :eval-in :leiningen,
  :plugins [[lein-swank "1.4.0-SNAPSHOT"]],

--- a/leiningen-core/pom.xml
+++ b/leiningen-core/pom.xml
@@ -48,7 +48,7 @@
     </repository>
     <repository>
       <id>clojars</id>
-      <url>https://clojars.org/repo/</url>
+      <url>https://repo.clojars.org/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/test/leiningen/test/deps.clj
+++ b/test/leiningen/test/deps.clj
@@ -63,10 +63,10 @@
 
 (deftest ^:online test-snapshots-releases
   (let [pr (assoc sample-project
-                  :repositories ^:replace {"clojars" {:url "https://clojars.org/repo/"
+                  :repositories ^:replace {"clojars" {:url "https://repo.clojars.org/"
                                             :snapshots false}})
         ps (assoc sample-project
-                  :repositories ^:replace {"clojars" {:url "https://clojars.org/repo/"
+                  :repositories ^:replace {"clojars" {:url "https://repo.clojars.org/"
                                             :releases false}})
         slamhound ['slamhound "1.1.0-SNAPSHOT"]
         hooke ['robert/hooke "1.0.1"]


### PR DESCRIPTION
After d2e4a19bcd1f84d5d0a0a7c162b1fe48d46f3d0c, change a few more mentions of `https://clojars.org/repo/` to `https://repo.clojars.org/`, eg in the tutorial.