### PR TITLE
Bump templates to use Clojure 1.10.1

### DIFF
--- a/resources/leiningen/new/app/project.clj
+++ b/resources/leiningen/new/app/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.10.0"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]]
   :main ^:skip-aot {{namespace}}
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/resources/leiningen/new/default/project.clj
+++ b/resources/leiningen/new/default/project.clj
@@ -3,5 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.10.0"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]]
   :repl-options {:init-ns {{namespace}}})


### PR DESCRIPTION
Clojure 1.10.1 improves error reporting seen in many lein commands.