### PR TITLE
Update TUTORIAL.md with {:insecure? true} in Running Code section

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -408,7 +408,7 @@ to run in the context of your project. Since we've added `clj-http` to
     nil
     user=> (require '[clj-http.client :as http])
     nil
-    user=> (def response (http/get "https://leiningen.org"))
+    user=> (def response (http/get "https://leiningen.org" {:insecure? true}))
     #'user/response
     user=> (keys response)
     (:status :headers :body :request-time :trace-redirects :orig-content-encoding)


### PR DESCRIPTION
Because without prior configuration, the previous command fails due to:

Syntax error (SunCertPathBuilderException) compiling at (form-init6802313204423860054.clj:1:15).
unable to find valid certification path to requested target