### PR TITLE
Remove duplicated test project explanation info from test projects

### DIFF
--- a/test_projects/data-readers-backwards-compatibility/project.clj
+++ b/test_projects/data-readers-backwards-compatibility/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject bug "bug"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.flatland/ordered "1.5.6"]])

--- a/test_projects/jvm-opts/project.clj
+++ b/test_projects/jvm-opts/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject custom/args "0.0.1-SNAPSHOT"
   :description "A test project"
   :dependencies [[org.clojure/clojure "1.8.0"]]

--- a/test_projects/sample-failing/project.clj
+++ b/test_projects/sample-failing/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject nomnomnom "0.5.0-SNAPSHOT"
   :dependencies [[~(symbol "org.clojure" "clojure") ~"1.2.0"]]
   :aot [nom.nom.nom])

--- a/test_projects/sample-fixture-error/project.clj
+++ b/test_projects/sample-fixture-error/project.clj
@@ -1,7 +1,2 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject sample-fixture-error "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/test_projects/sample-no-aot/project.clj
+++ b/test_projects/sample-no-aot/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject nomnomnom "0.5.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [janino "2.5.15"]]

--- a/test_projects/sample-profile-meta/project.clj
+++ b/test_projects/sample-profile-meta/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject nomnomnom "0.5.0-SNAPSHOT"
   :dependencies []
   :profiles {:default [:leiningen/default :my-leaky :my-provided :my-test]

--- a/test_projects/sample-reader-cond/project.clj
+++ b/test_projects/sample-reader-cond/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject nomnomnom "0.5.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [janino "2.5.15"]]

--- a/test_projects/sample/project.clj
+++ b/test_projects/sample/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (def clj-version "1.3.0")
 
 (defproject nomnomnom "0.5.0-SNAPSHOT"

--- a/test_projects/uberjar-merging/project.clj
+++ b/test_projects/uberjar-merging/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject nomnomnom "0.5.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [janino "2.5.15"]

--- a/test_projects/with-aliases/project.clj
+++ b/test_projects/with-aliases/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject project-with-aliases "0.1.0-SNAPSHOT"
   :aliases {"p" ["echo" "p"]
             "a2p" ["with-profile" "+a2" "p"]

--- a/test_projects/with-aliases2/project.clj
+++ b/test_projects/with-aliases2/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject project-with-aliases "0.1.0-SNAPSHOT"
   :a 1
   :profiles {:a2 {:a 2}})

--- a/test_projects/with-resources/project.clj
+++ b/test_projects/with-resources/project.clj
@@ -1,8 +1,3 @@
-;; This project is used for leiningen's test suite, so don't change
-;; any of these values without updating the relevant tests. If you
-;; just want a basic project to work from, generate a new one with
-;; "lein new".
-
 (defproject project-with-resources "0.5.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [janino "2.5.15"]]


### PR DESCRIPTION
Justification:
1) There is already an explanatory README present in the root directory
of test_projects
2) About half of the test projects have this duplicated information.
The other half do not, adding inconsistency to duplication.

An alternative:
1) Add the same duplicated info to all test projects.