### PR TITLE
print progress in lein release

### DIFF
--- a/src/leiningen/release.clj
+++ b/src/leiningen/release.clj
@@ -129,9 +129,12 @@ bump. If none is given, it defaults to :patch."
   ([project] (release project *level*))
   ([project level]
      (binding [*level* (if level (read-string level))]
-       (doseq [task (:release-tasks project)]
-         (let [current-project (project/init-project (project/read))]
-           (main/resolve-and-apply current-project task))))))
+       (let [release-tasks (:release-tasks project)
+             task-count (count release-tasks)]
+         (doseq [[i task] (map vector (range 1 (inc task-count)) release-tasks)]
+           (apply main/info "[" i "/" task-count "] Running lein" task)
+           (let [current-project (project/init-project (project/read))]
+             (main/resolve-and-apply current-project task)))))))
 
 ;; support existing release plugin:
 ;; https://github.com/technomancy/leiningen/issues/1544


### PR DESCRIPTION
# justification
This make it easier to rollback release-tasks or complete them by hand.
https://github.com/technomancy/leiningen/issues/2402

>  * If a release fails, show the user which steps succeeded, which one
>  failed, and which ones are left to run.

`lein release` works like this with this patch.

```
$ cat project.clj 
;; This is Leiningen's own project configuration. See doc/TUTORIAL.md
;; file as well as sample.project.clj for help writing your own.

(defproject leiningen "2.9.1"
...
  :release-tasks [["echo" "aaa"]
                  ["echo" "bbb"]
                  ["echo" "ccc"]]
  :source-paths ["leiningen-core/src" "src"]
  :eval-in :leiningen)
$ bin/lein release
[ 0 / 3 ] Executing lein echo aaa
aaa
[ 1 / 3 ] Executing lein echo bbb
bbb
[ 2 / 3 ] Executing lein echo ccc
ccc
[ 3 / 3 ] Completed lein release.
```