### PR TITLE
add consistent load order for lein check

### DIFF
--- a/src/leiningen/check.clj
+++ b/src/leiningen/check.clj
@@ -9,8 +9,8 @@
   "Check syntax and warn on reflection."
   ([project]
      (let [source-files (map io/file (:source-paths project))
-           nses (b/namespaces-on-classpath :classpath source-files
-                                           :ignore-unreadable? false)
+           nses (sort (b/namespaces-on-classpath :classpath source-files
+                                                 :ignore-unreadable? false))
            action `(let [failures# (atom 0)]
                      (doseq [ns# '~nses]
                        ;; load will add the .clj, so can't use ns/path-for.


### PR DESCRIPTION
related:
- https://github.com/technomancy/leiningen/pull/2518
- https://github.com/technomancy/leiningen/issues/2508

# Justification 
I sometimes came across wierd CI failure at running `lein check`.  This seems like as the same problem of above links.

Please review. I'm not sure about my understanding for this problem. I don't have a minimal repro case for now. I would try to make it if needed.