### PR TITLE
Fix #2571: filter the timestamp from pom.properties

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -24,8 +24,11 @@
       (when (.exists git-head)
         (if-let [revision (utils/read-git-head git-head)]
           (.setProperty properties "revision" revision)))
-      (.store properties baos "Leiningen"))
-    (str baos)))
+      (.store properties baos nil))
+    (-> baos
+        str
+        ;; Strip off all the comments printed by java.util.Properties: by default the timestamp is printed
+        utils/strip-properties-comments)))
 
 (defn- warn [& args]
   ;; TODO: remove with 3.0.0

--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -1,6 +1,7 @@
 (ns leiningen.core.utils
   (:require [clojure.java.io :as io]
-            [clojure.java.shell :as sh])
+            [clojure.java.shell :as sh]
+            [clojure.string :as str])
   (:import (com.hypirion.io RevivableInputStream)
            (clojure.lang LineNumberingPushbackReader)
            (java.io ByteArrayOutputStream PrintStream File FileDescriptor
@@ -269,3 +270,9 @@
      (finally
        (System/setErr
         (-> FileDescriptor/err FileOutputStream. PrintStream.)))))
+
+(defn strip-properties-comments
+  "Takes a string containing serialized java.util.Properties
+  and removes all the comment lines (those beginning with #)"
+  [s]
+  (str/replace s #"(\A|\R)(#.+(\R|\z))+" "$1"))

--- a/leiningen-core/test/leiningen/core/test/utils.clj
+++ b/leiningen-core/test/leiningen/core/test/utils.clj
@@ -12,3 +12,16 @@
     (is (nil? (utils/read-file (io/file (str profiles "profiles-empty.clj"))))))
   (testing "Non-empty profile file"
     (is (= (utils/read-file (io/file (str profiles "profiles.clj"))) sample-profile))))
+
+(deftest properties-strip-comments
+  (with-open [baos (java.io.ByteArrayOutputStream.)]
+    (let [properties (doto (java.util.Properties.)
+                       (.setProperty "version" "0.1.0-SNAPSHOT")
+                       (.setProperty "groupId" "groupId")
+                       (.setProperty "artifactId" "(:name project)"))]
+      (.store properties baos "Extra comment")
+      (let [str (-> baos
+                    str
+                    utils/strip-properties-comments)]
+        (with-open [input-stream (io/input-stream (.getBytes str))]
+          (is (= properties (doto (java.util.Properties.) (.load input-stream)))))))))


### PR DESCRIPTION
The regex might look pretty scary. The timezone string generation is buried in locale code, the rest follows the format of `java.util.Date.toString()`. Works when the comment is `nil` as well (then the first comment line is omitted).