### PR TITLE
Exclude project-specific `.prepl-port` from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .lein*
 /.classpath
 /.nrepl-port
+/.prepl-port
 /.project
 /.settings
 /hs_err_pid*.log
@@ -15,8 +16,10 @@
 /lein_ja.man
 /leiningen-core/.lein-plugins/checksum
 /leiningen-core/.nrepl-port
+/leiningen-core/.prepl-port
 /leiningen-core/dev-resources/target
 /lein-pprint/.nrepl-port
+/lein-pprint/.prepl-port
 /logs
 /scratch.clj
 /target

--- a/resources/leiningen/new/app/gitignore
+++ b/resources/leiningen/new/app/gitignore
@@ -8,5 +8,6 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.prepl-port
 .hgignore
 .hg/

--- a/resources/leiningen/new/app/hgignore
+++ b/resources/leiningen/new/app/hgignore
@@ -8,6 +8,7 @@ pom.xml.asc
 
 syntax: regexp
 ^.nrepl-port
+^.prepl-port
 ^.lein-.*
 ^target/
 ^classes/

--- a/resources/leiningen/new/default/gitignore
+++ b/resources/leiningen/new/default/gitignore
@@ -8,5 +8,6 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.prepl-port
 .hgignore
 .hg/

--- a/resources/leiningen/new/default/hgignore
+++ b/resources/leiningen/new/default/hgignore
@@ -9,5 +9,6 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.prepl-port
 .gitignore
 .git/**

--- a/resources/leiningen/new/plugin/gitignore
+++ b/resources/leiningen/new/plugin/gitignore
@@ -8,5 +8,6 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.prepl-port
 .hgignore
 .hg/

--- a/resources/leiningen/new/plugin/hgignore
+++ b/resources/leiningen/new/plugin/hgignore
@@ -9,5 +9,6 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.prepl-port
 .gitignore
 .git/**

--- a/resources/leiningen/new/template/gitignore
+++ b/resources/leiningen/new/template/gitignore
@@ -7,5 +7,6 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.prepl-port
 .hgignore
 .hg/

--- a/resources/leiningen/new/template/hgignore
+++ b/resources/leiningen/new/template/hgignore
@@ -9,5 +9,6 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.prepl-port
 .gitignore
 .git/**

--- a/test_projects/file-not-found-thrower/.gitignore
+++ b/test_projects/file-not-found-thrower/.gitignore
@@ -8,3 +8,4 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.prepl-port

--- a/test_projects/java-main/.gitignore
+++ b/test_projects/java-main/.gitignore
@@ -8,3 +8,4 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.prepl-port


### PR DESCRIPTION
The socket prepl is a relatively new tool built into Clojure that allows you to REPL into a running application. Some new tools like https://github.com/Olical/conjure, use this feature and as nrepl it can generate a file with the current prepl opened port.

This PR just adds ignores for this new file in the templates and in the lein solution.