### PR TITLE
Apply explicit middleware and hooks even with disabled implicits

### DIFF
--- a/leiningen-core/dev-resources/p4.clj
+++ b/leiningen-core/dev-resources/p4.clj
@@ -1,0 +1,4 @@
+(defproject middler-no-implicits "0.0.1"
+  :description "Test some middleware."
+  :middleware [leiningen.core.test.project/add-seven]
+  :implicits false)

--- a/leiningen-core/dev-resources/p5.clj
+++ b/leiningen-core/dev-resources/p5.clj
@@ -1,0 +1,4 @@
+(defproject middler-no-implicit-middleware "0.0.1"
+  :description "Test some middleware."
+  :middleware [leiningen.core.test.project/add-seven]
+  :implicit-middleware false)

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -424,6 +424,12 @@
 (deftest test-middleware
   (is (= 7 (:seven (init-project (read (.getFile (io/resource "p2.clj"))))))))
 
+(deftest test-middleware-no-implicits
+  (is (= 7 (:seven (init-project (read (.getFile (io/resource "p4.clj"))))))))
+
+(deftest test-middleware-no-implicit-middleware
+  (is (= 7 (:seven (init-project (read (.getFile (io/resource "p5.clj"))))))))
+
 (deftest test-checkouts
   (let [project (read (.getFile (io/resource "p1.clj")))]
     (is (= #{"checkout-lib1" "checkout-lib2"} (set (map :name (read-checkouts project)))))))


### PR DESCRIPTION
To resolve #2625, this change ensures that any explicitly-declared `:middleware` or `:hooks` entries in a project map will still get applied or loaded, even if `:implicits` or `:implicit-middleware` or `:implicit-hooks` is `false`. Only implicitly-loaded middleware or hooks will be skipped.

The bug (if this is a bug) appears to affect all versions since [flags for disabling implicits were introduced](8b9d66cd7c72e3edf5b5a3b69c4e1eb10750a2cf) for #1621, according to a git bisection using the repro steps in #2625.

This is a first cut of a fix, and extends existing tests. Comments welcome.