### PR TITLE
Make sure release tags are annotated.

### DIFF
--- a/src/leiningen/vcs.clj
+++ b/src/leiningen/vcs.clj
@@ -83,7 +83,7 @@
           tag (if prefix
                 (str prefix version)
                 version)
-          cmd (->> ["git" "tag" (when sign? "--sign") tag "-m" (str "Release " version)]
+          cmd (->> ["git" "tag" (when sign? "--sign") tag "-a" "-m" (str "Release " version)]
                    (filter some?))]
       (apply eval/sh-with-exit-code "Couldn't tag" cmd))))
 


### PR DESCRIPTION
The git world expects release tags to be of the "annotated" variety.
A lot of the surrounding tools rely on this assumption (such as for
example "git describe").

From the git help:

```
Tag objects (created with -a, -s, or -u) are called "annotated" tags; they contain a creation date, the tagger name and e-mail, a tagging message, and an optional GnuPG signature. Whereas a "lightweight" tag is simply a name for an object (usually a commit object).

Annotated tags are meant for release while lightweight tags are meant for private or temporary object labels. For this reason, some git commands for naming objects (like git describe) will ignore lightweight tags by default.
```