### PR TITLE
Make sure release tags are annotated

### DIFF
--- a/src/leiningen/vcs.clj
+++ b/src/leiningen/vcs.clj
@@ -83,7 +83,7 @@
           tag (if prefix
                 (str prefix version)
                 version)
-          cmd (->> ["git" "tag" (when sign? "--sign") tag "-m" (str "Release " version)]
+          cmd (->> ["git" "tag" (when sign? "--sign") tag "-a" "-m" (str "Release " version)]
                    (filter some?))]
       (apply eval/sh-with-exit-code "Couldn't tag" cmd))))
 

--- a/test/leiningen/test/vcs.clj
+++ b/test/leiningen/test/vcs.clj
@@ -5,11 +5,14 @@
 (deftest parsed-args
   (testing "VCS tag argument parsing"
     (are [args parsed-args] (= (vcs/parse-tag-args args) parsed-args)
-      [] {:sign? true}
-      ["v"] {:prefix "v" :sign? true}
-      ["v" "--sign"] {:prefix "v" :sign? true}
-      ["--sign"] {:sign? true}
-      ["--no-sign"] {:sign? false}
-      ["--no-sign" "v"] {:prefix "v" :sign? false}
-      ["-s"] {:sign? true}
-      ["v" "r"] {:prefix "r" :sign? true})))
+      [] {:sign? true :annotate? true}
+      ["v"] {:prefix "v" :sign? true :annotate? true}
+      ["v" "--sign"] {:prefix "v" :sign? true :annotate? true}
+      ["--sign"] {:sign? true :annotate? true}
+      ["--no-sign"] {:sign? false :annotate? true}
+      ["--no-sign" "v"] {:prefix "v" :sign? false :annotate? true}
+      ["--no-annotate"] {:sign? true :annotate? false}
+      ["--annotate"] {:sign? true :annotate? true}
+      ["--no-sign" "--no-annotate" "v"] {:sign? false :annotate? false :prefix "v"}
+      ["-s"] {:sign? true :annotate? true}
+      ["v" "r"] {:prefix "r" :sign? true :annotate? true})))


### PR DESCRIPTION
The git world expects release tags to be of the "annotated" variety.

Currently, tags created with --no-sign are not annotated.

A lot of the surrounding tools rely on this assumption (such as for example "git describe"). This means git describe does not work properly with tags created by leinigen when they are created with --no-sign.

From the git help:

"
Tag objects (created with -a, -s, or -u) are called "annotated" tags; they contain a creation date, the tagger name and e-mail, a tagging message, and an optional GnuPG signature. Whereas a "lightweight" tag is simply a name for an object (usually a commit object).

Annotated tags are meant for release while lightweight tags are meant for private or temporary object labels. For this reason, some git commands for naming objects (like git describe) will ignore lightweight tags by default.
"