### PR TITLE
Fix broken pprint plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
           working_directory: ~/leiningen/leiningen-core
           command: lein bootstrap
       - run: GNUPGHOME=test/.gnupg bin/lein test
+      - run:
+          working_directory: lein-pprint
+          command: lein test
       - save_cache:
           paths:
             - $HOME/.m2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,16 @@ jobs:
       - restore_cache:
           key: << checksum "project.clj" >>
       - run:
+          name: Bootstrap leiningen-core
           working_directory: ~/leiningen/leiningen-core
           command: lein bootstrap
-      - run: GNUPGHOME=test/.gnupg bin/lein test
       - run:
+          name: Test Leiningen
+          environment:
+            GNUPGHOME: test/.gnupg
+          command: bin/lein test
+      - run:
+          name: Test lein-pprint
           working_directory: lein-pprint
           command: lein test
       - save_cache:
@@ -20,4 +26,3 @@ jobs:
             - $HOME/.m2
             - $HOME/.lein
           key: << checksum "project.clj" >>
-

--- a/lein-pprint/src/leiningen/pprint.clj
+++ b/lein-pprint/src/leiningen/pprint.clj
@@ -1,25 +1,20 @@
 (ns leiningen.pprint
-  (:require [clojure.pprint :as pprint]
-            [leiningen.core :refer [abort]]))
+  (:require [clojure.pprint :as pprint]))
 
 (defn ^:no-project-needed pprint
-  "Usage: pprint [--not-pretty] [--] [selector...]
+  "Usage: pprint [--no-pretty] [--] [selector...]
 
   When no selectors are specified, pretty-prints a representation of
   the entire project map.  Otherwise pretty-prints the item(s)
   retrieved by (get-in project selector) when reading a selector
   produces something sequential, or (get project selector) when it
-  doesn't.  If \"--not-pretty\" is specified, doesn't pretty-print,
+  doesn't.  If \"--no-pretty\" is specified, doesn't pretty-print,
   just prints."
   [project & keys]
-  (let [[pretty? keys] (loop [args args
-                              pretty? true]
-                         (if-let [[arg & args] (seq args)]
-                           (case arg
-                             "--" [pretty? args]
-                             "--no-pretty" (recur false args)
-                             (abort "Unrecognized argument" (pr-str arg)))))
-        show (if pretty? pprint/pprint println)]
+  (let [[args rest] (split-at 2 keys)
+        [show keys] (if (= args ["--no-pretty" "--"])
+                      [println rest]
+                      [pprint/pprint keys])]
     (if (seq keys)
       (doseq [kstr keys]
         (let [k (read-string kstr)]

--- a/lein-pprint/test/leiningen/pprint_test.clj
+++ b/lein-pprint/test/leiningen/pprint_test.clj
@@ -5,15 +5,20 @@
 (def shallow {:foo "str"})
 (def deep {:foo {:bar "str"}})
 
-(deftest can-pprint-shallow
+(deftest can-pprint-key
   (is (= "\"str\"\n" (with-out-str (pprint shallow ":foo")))))
 
-(deftest can-pprint-deep
-
+(deftest can-pprint-seq
   (is (= "\"str\"\n" (with-out-str (pprint deep "[:foo :bar]")))))
 
-(deftest can-println-shallow
+(deftest can-pprint-key-no-pretty
   (is (= "str\n" (with-out-str (pprint shallow "--no-pretty" "--" ":foo")))))
 
-(deftest can-println-deep
+(deftest can-pprint-seq-no-pretty
   (is (= "str\n" (with-out-str (pprint deep "--no-pretty" "--" "[:foo :bar]")))))
+
+(deftest can-pprint-project
+  (is (= "{:foo \"str\"}\n" (with-out-str (pprint shallow)))))
+
+(deftest can-pprint-project-no-pretty
+  (is (= "{:foo str}\n" (with-out-str (pprint shallow "--no-pretty" "--")))))

--- a/lein-pprint/test/leiningen/pprint_test.clj
+++ b/lein-pprint/test/leiningen/pprint_test.clj
@@ -2,6 +2,18 @@
   (:require [clojure.test :refer :all]
             [leiningen.pprint :refer :all]))
 
-(deftest can-pprint
-  (is (= "1\n" (with-out-str (pprint {:foo 1} ":foo"))))
-  (is (= "1\n" (with-out-str (pprint {:foo {:bar 1}} "[:foo :bar]")))))
+(def shallow {:foo "str"})
+(def deep {:foo {:bar "str"}})
+
+(deftest can-pprint-shallow
+  (is (= "\"str\"\n" (with-out-str (pprint shallow ":foo")))))
+
+(deftest can-pprint-deep
+
+  (is (= "\"str\"\n" (with-out-str (pprint deep "[:foo :bar]")))))
+
+(deftest can-println-shallow
+  (is (= "str\n" (with-out-str (pprint shallow "--no-pretty" "--" ":foo")))))
+
+(deftest can-println-deep
+  (is (= "str\n" (with-out-str (pprint deep "--no-pretty" "--" "[:foo :bar]")))))

--- a/lein-pprint/test/leiningen/test/pprint.clj
+++ b/lein-pprint/test/leiningen/test/pprint.clj
@@ -2,23 +2,27 @@
   (:require [clojure.test :refer :all]
             [leiningen.pprint :refer :all]))
 
-(def shallow {:foo "str"})
-(def deep {:foo {:bar "str"}})
+(def project {:foo {:bar "str"}})
 
-(deftest test-pprint-key
-  (is (= "\"str\"\n" (with-out-str (pprint shallow ":foo")))))
+(defn check [desc keys output]
+  (is (= output (with-out-str (apply pprint project keys)))) desc)
 
-(deftest test-pprint-seq
-  (is (= "\"str\"\n" (with-out-str (pprint deep "[:foo :bar]")))))
+(defn check-no-pretty [desc keys output]
+  (check desc (concat ["--no-pretty" "--"] keys) output))
 
-(deftest test-pprint-key-no-pretty
-  (is (= "str\n" (with-out-str (pprint shallow "--no-pretty" "--" ":foo")))))
+(deftest test-pprint
+  (check "pretty-print a key" [":foo"] "{:bar \"str\"}\n")
 
-(deftest test-pprint-seq-no-pretty
-  (is (= "str\n" (with-out-str (pprint deep "--no-pretty" "--" "[:foo :bar]")))))
+  (check-no-pretty "print a key" [":foo"] "{:bar str}\n")
 
-(deftest test-pprint-project
-  (is (= "{:foo \"str\"}\n" (with-out-str (pprint shallow)))))
+  (check "pretty-print a sequence" ["[:foo :bar]"] "\"str\"\n")
 
-(deftest test-pprint-project-no-pretty
-  (is (= "{:foo str}\n" (with-out-str (pprint shallow "--no-pretty" "--")))))
+  (check-no-pretty "print a sequence" ["[:foo :bar]"] "str\n")
+
+  (check "pretty-print a project" [] "{:foo {:bar \"str\"}}\n")
+
+  (check-no-pretty "print a project" [] "{:foo {:bar str}}\n")
+
+  (check "pretty-print multiple" [":foo" "[:foo :bar]"] "{:bar \"str\"}\n\"str\"\n")
+
+  (check-no-pretty "print multiple" [":foo" "[:foo :bar]"] "{:bar str}\nstr\n"))

--- a/lein-pprint/test/leiningen/test/pprint.clj
+++ b/lein-pprint/test/leiningen/test/pprint.clj
@@ -1,24 +1,24 @@
-(ns leiningen.pprint-test
+(ns leiningen.test.pprint
   (:require [clojure.test :refer :all]
             [leiningen.pprint :refer :all]))
 
 (def shallow {:foo "str"})
 (def deep {:foo {:bar "str"}})
 
-(deftest can-pprint-key
+(deftest test-pprint-key
   (is (= "\"str\"\n" (with-out-str (pprint shallow ":foo")))))
 
-(deftest can-pprint-seq
+(deftest test-pprint-seq
   (is (= "\"str\"\n" (with-out-str (pprint deep "[:foo :bar]")))))
 
-(deftest can-pprint-key-no-pretty
+(deftest test-pprint-key-no-pretty
   (is (= "str\n" (with-out-str (pprint shallow "--no-pretty" "--" ":foo")))))
 
-(deftest can-pprint-seq-no-pretty
+(deftest test-pprint-seq-no-pretty
   (is (= "str\n" (with-out-str (pprint deep "--no-pretty" "--" "[:foo :bar]")))))
 
-(deftest can-pprint-project
+(deftest test-pprint-project
   (is (= "{:foo \"str\"}\n" (with-out-str (pprint shallow)))))
 
-(deftest can-pprint-project-no-pretty
+(deftest test-pprint-project-no-pretty
   (is (= "{:foo str}\n" (with-out-str (pprint shallow "--no-pretty" "--")))))


### PR DESCRIPTION
I requested that the version of `lein-pprint` including `--no-pretty` be published in #2649. Turns out that it's broken in a couple of ways! This PR fixes it to work, and makes the docs consistent with the code.