### PR TITLE
Memoize application of middleware

### DIFF
--- a/leiningen-core/src/leiningen/core/main.clj
+++ b/leiningen-core/src/leiningen/core/main.clj
@@ -443,13 +443,14 @@ Get the latest version of Leiningen at https://leiningen.org or by executing
     (project/ensure-dynamic-classloader)
     (aether/register-wagon-factory! "http" insecure-http-abort)
     (user/init)
-    (let [project (if (.exists (io/file *cwd* "project.clj"))
-                    (project/read (str (io/file *cwd* "project.clj")))
-                    (default-project))]
-      (when (:exact-lein-version project) (verify-exact-version project))
-      (when (:min-lein-version project) (verify-min-version project))
-      (configure-http)
-      (resolve-and-apply project raw-args))
+    (binding [project/*memoize-middleware* true]
+      (let [project (if (.exists (io/file *cwd* "project.clj"))
+                      (project/read (str (io/file *cwd* "project.clj")))
+                      (default-project))]
+        (when (:exact-lein-version project) (verify-exact-version project))
+        (when (:min-lein-version project) (verify-min-version project))
+        (configure-http)
+        (resolve-and-apply project raw-args)))
     (catch Exception e
       (if (or *debug* (not (:exit-code (ex-data e))))
         (stacktrace/print-cause-trace e)


### PR DESCRIPTION
This change introduces memoization of middleware. This is meant to improve performance when using middleware that is expensive or slow to apply. The performance improvement is particularly significant when running tasks like "install", "jar" or "pom" which involve repeated merging and unmerging of profiles, as both of these operations involve reapplying middleware.

To avoid issues with embedded use in long running applications, this memoization is only enabled by default when running `lein` on the command line. Memoization can also be disabled by specifying `:memoize-middleware? false` in the project map or user profile.