### PR TITLE
Corrected actual sha256 checksum displayed in the error message in the event of a checksum mismatch.

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -107,7 +107,7 @@ function self_install {
       if [ $? == 0 ]; then
         mv -f "$LEIN_JAR.pending" "$LEIN_JAR"
       else
-        got_sum="$($SHASUM_CMD "$LEIN_JAR.pending.shasum" | cut -f 1 -d ' ')"
+        got_sum="$($SHASUM_CMD "$LEIN_JAR.pending" | cut -f 1 -d ' ')"
         checksum_failed_message "$LEIN_URL" "$LEIN_CHECKSUM" "$got_sum"
         rm "$LEIN_JAR.pending" 2> /dev/null
         exit 1


### PR DESCRIPTION
Hi there,
I just spent an hour trying to figure out why the simple steps to install lein was failing for me, with the following:
```
Prefect:sandbox-clj jack$ curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o lein
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13369  100 13369    0     0  46264      0 --:--:-- --:--:-- --:--:-- 46420
Prefect:sandbox-clj jack$ chmod a+x lein 
Prefect:sandbox-clj jack$ ./lein
Downloading Leiningen to /Users/jack/.lein/self-installs/leiningen-2.9.2-standalone.jar now...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   618  100   618    0     0    826      0 --:--:-- --:--:-- --:--:--   826
100 13.9M  100 13.9M    0     0   169k      0  0:01:24  0:01:24 --:--:--  191k
shasum: /Users/jack/.lein/self-installs/leiningen-2.9.2-standalone.jar.pending.shasum: no properly formatted SHA1 checksum lines found
Failed to properly download https://github.com/technomancy/leiningen/releases/download/2.9.2/leiningen-2.9.2-standalone.zip
The checksum was mismatched. and we could not verify the downloaded
file. We expected a sha256 of
09805bd809656794cfe7d9155fd4b8bea2646092318690bf68e3c379574a2d3c and actually had
ab5f5556f3b0fee9b2d50b3e07bb833837da83538765012bfceb8d102a2eae80.
```
It turns out the blocking error has been resolved by @nihilismus here:
https://github.com/technomancy/leiningen/commit/7a756582c34942e486073c0c4f07f9822402b32f#diff-d85d18dd167817933c22dd959c84ddff

However, I noticed there was still an error with the reported expected vs actual checksum, which this commit fixes.

By the way, I do not want to get too preachy, and I'm sure you are already aware of this, but I think it bears repeating. (IOW, you don't have to read pass this if you are mainly interested in the gist of this pull request)...

I am new to Clojure, and was hoping to spend an hour this morning trying to tinker with it, and get to know it, instead I spent the hour troubleshooting why the installation has failed. If I were any less persistent, I would have gone back to the languages I'm comfortable with, and never give Clojure another look.

I guess what I'm saying is, I understand that checksum verification was a recently added feature (added 9 days ago, per Git history), and I do understand the value of performing such a check. But we need to be careful when adding new features.

Think about all the other people who tried to evaluate Clojure within the past 9 days, whom you haven't heard from (like you are hearing from me). These are the people who wanted to give Clojure a try, couldn't get past the installation step, and walked away.