### PR TITLE
LEIN_FAST_TRAMPOLINE should respect local profiles.clj

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -361,7 +361,7 @@ else
     fi
 
     if [ "$LEIN_FAST_TRAMPOLINE" != "" ] && [ -r project.clj ]; then
-        INPUTS="$* $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj")"
+        INPUTS="$* $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj") $(test -f profiles.clj && cat profiles.clj)"
 
         INPUT_CHECKSUM=$(echo "$INPUTS" | $SHASUM_CMD | cut -f 1 -d " ")
         # Just don't change :target-path in project.clj, mkay?

--- a/bin/lein-pkg
+++ b/bin/lein-pkg
@@ -86,7 +86,7 @@ if [ -r .lein-fast-trampoline ]; then
 fi
 
 if [ "$LEIN_FAST_TRAMPOLINE" != "" ] && [ -r project.clj ]; then
-    INPUTS="$* $(cat project.clj) $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj")"
+    INPUTS="$* $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj") $(test -f profiles.clj && cat profiles.clj)
 
     if command -v shasum >/dev/null 2>&1; then
         SUM="shasum"

--- a/bin/lein-sdkman
+++ b/bin/lein-sdkman
@@ -160,7 +160,7 @@ if [ -r .lein-fast-trampoline ]; then
 fi
 
 if [ "$LEIN_FAST_TRAMPOLINE" != "" ] && [ -r project.clj ]; then
-    INPUTS="$* $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj")"
+    INPUTS="$* $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj") $(test -f profiles.clj && cat profiles.clj)"
 
     if command -v shasum >/dev/null 2>&1; then
         SUM="shasum"


### PR DESCRIPTION
fixes https://github.com/technomancy/leiningen/issues/2519

With this change, lein-pkg will also respect $LEIN_VERSION.

I checked if this PR works with following steps.

```
[t@DESKTOP-ORU04L0 proj]$ alias lein="/home/t/proj/leiningen/bin/lein"
[t@DESKTOP-ORU04L0 proj]$ lein -v
Leiningen 2.9.4-SNAPSHOT on Java 11.0.3 OpenJDK 64-Bit Server VM
[t@DESKTOP-ORU04L0 proj]$ lein new fast-trampoline-bug
Generating a project called fast-trampoline-bug based on the 'default' template.
The default template is intended for library projects, not applications.
To see other templates (app, plugin, etc), try `lein help new`.
[t@DESKTOP-ORU04L0 proj]$ cat ~/.lein/profiles.clj
{:user {:aliases {"myrepl" ["trampoline" "repl"]}}}
[t@DESKTOP-ORU04L0 proj]$ export LEIN_FAST_TRAMPOLINE=1
[t@DESKTOP-ORU04L0 proj]$ cd fast-trampoline-bug/
[t@DESKTOP-ORU04L0 fast-trampoline-bug]$ rm -rf target
[t@DESKTOP-ORU04L0 fast-trampoline-bug]$ lein myrepl
REPL-y 0.4.4, nREPL 0.6.0
Clojure 1.10.1
OpenJDK 64-Bit Server VM 11.0.3+7-Ubuntu-1ubuntu218.04.1
    Docs: (doc function-name-here)
          (find-doc "part-of-name-here")
  Source: (source function-name-here)
 Javadoc: (javadoc java-object-or-class-here)
    Exit: Control+D or (exit) or (quit)
 Results: Stored in vars *1, *2, *3, an exception in *e

fast-trampoline-bug.core=> WARNING: cat already refers to: #'clojure.core/cat in namespace: net.cgrand.parsley.fold, being replaced by: #'net.cgrand.parsley.fold/cat
Bye for now!
[t@DESKTOP-ORU04L0 fast-trampoline-bug]$ echo '{:user {}}' > profiles.clj
[t@DESKTOP-ORU04L0 fast-trampoline-bug]$
[t@DESKTOP-ORU04L0 fast-trampoline-bug]$ lein myrepl
WARNING: user-level profile defined in project files.
'myrepl' is not a task. See 'lein help'.

Did you mean this?
         repl
```