### PR TITLE
remove deprecated make-pom-properties

### DIFF
--- a/src/leiningen/pom.clj
+++ b/src/leiningen/pom.clj
@@ -415,15 +415,6 @@
           (xml-tags :project (relativize project))))
         (if disclaimer? disclaimer)))))
 
-(def ^:private warning
-  (delay
-   (main/warn "WARNNG: leiningen.pom/make-pom-properties is deprecated."
-              "\nUse leiningen.core.project/make-project-properties instead.")))
-
-(defn ^:deprecated make-pom-properties [project]
-  (force warning)
-  (project/make-project-properties))
-
 (defn ^{:help-arglists '([])} pom
   "Write a pom.xml file to disk for Maven interoperability."
   ([project pom-location-or-properties]


### PR DESCRIPTION
`make-pom-properties` have never been working since 2014.
`make-pom-properties` was calling `project/make-project-properties`
without arguments while `project/make-project-properties` requires one argument.
So it's time to remove this.