### PR TITLE
fix race condition in utils/mkdirs

### DIFF
--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -67,9 +67,8 @@
 (defn mkdirs
   "Make a given directory and its parents, but throw an Exception on failure."
   [f] ; whyyyyy does .mkdirs fail silently ugh
-  (let [already-exists? (.exists (io/file f))]
-    (when-not (or (.mkdirs (io/file f)) already-exists?)
-      (throw (Exception. (str "Couldn't create directories: " (io/file f)))))))
+  (when-not (or (.mkdirs (io/file f)) (.exists (io/file f)))
+    (throw (Exception. (str "Couldn't create directories: " (io/file f))))))
 
 (defn relativize
   "Makes the filepath path relative to base. Assumes base is an ancestor to


### PR DESCRIPTION
There is a race condition in `mkdirs` that it tests for existence of directory first and then tries to create it. But if the directory is created between the test and the attempt at creation (by some other process) exception would be thrown even though there is no reason for it as the directory now does exist.

Normally this is rare to encounter. But if you run several `lein run ...` in parallel on one machine, it can occasionally crash.

In my case, a parallelized CI pipeline failed with exception once in about 20 runs.