### PR TITLE
Makes the default JVM options version aware

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -165,9 +165,24 @@ while [ -h "$SCRIPT" ] ; do
     fi
 done
 
+if [ ! -x "$JAVA_CMD" ] && ! type -f java >/dev/null
+then
+    msg "Leiningen couldn't find 'java' executable, which is required."
+    msg "Please either set JAVA_CMD or put java (>=1.6) in your \$PATH ($PATH)."
+    exit 1
+fi
+
+export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-${JAVA_CMD:-java}}"
+
+DEF_LEIN_JVM_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+JAVA_VERSION=$($LEIN_JAVA_CMD -version 2>&1 | awk -F '"' '/version/ {split($2, v, "."); print v[1] }')
+if [[ $JAVA_VERSION -lt 13 ]]; then
+    DEF_LEIN_JVM_OPTS+=" -Xverify:none"
+fi
+
 BIN_DIR="$(dirname "$SCRIPT")"
 
-export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-Xverify:none -XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
+export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-$DEF_LEIN_JVM_OPTS}"
 
 # This needs to be defined before we call HTTP_CLIENT below
 if [ "$HTTP_CLIENT" = "" ]; then
@@ -251,15 +266,6 @@ else # Not running from a checkout
         self_install
     fi
 fi
-
-if [ ! -x "$JAVA_CMD" ] && ! type -f java >/dev/null
-then
-    msg "Leiningen couldn't find 'java' executable, which is required."
-    msg "Please either set JAVA_CMD or put java (>=1.6) in your \$PATH ($PATH)."
-    exit 1
-fi
-
-export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-${JAVA_CMD:-java}}"
 
 if [[ -z "${DRIP_INIT+x}" && "$(basename "$LEIN_JAVA_CMD")" == *drip* ]]; then
     export DRIP_INIT="$(printf -- '-e\n(require (quote leiningen.repl))')"

--- a/bin/lein-pkg
+++ b/bin/lein-pkg
@@ -35,10 +35,21 @@ for f in "/etc/leinrc" "$LEIN_HOME/leinrc" ".leinrc"; do
     fi
 done
 
-export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-Xverify:none -XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
+# Which Java?
 
-grep -E -q '^\s*:eval-in\s+:classloader\s*$' project.clj 2> /dev/null &&
-LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-'-Xms64m -Xmx512m'}"
+export JAVA_CMD="${JAVA_CMD:-"java"}"
+export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-$JAVA_CMD}"
+
+DEF_LEIN_JVM_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+JAVA_VERSION=$($LEIN_JAVA_CMD -version 2>&1 | awk -F '"' '/version/ {split($2, v, "."); print v[1] }')
+echo Java version $JAVA_VERSION
+if [[ $JAVA_VERSION -lt 13 ]]; then
+    DEF_LEIN_JVM_OPTS+=" -Xverify:none"
+fi
+export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-$DEF_LEIN_JVM_OPTS}"
+
+grep -E -q '^\s*:eval-in\s+:classloader\s*$' project.clj 2> /dev/null && \
+    LEIN_JVM_OPTS="$LEIN_JVM_OPTS -Xms64m -Xmx512m"
 
 # If you're not using an uberjar you'll need to list each dependency
 # and add them individually to the classpath/bootclasspath as well.
@@ -64,11 +75,6 @@ if [ -n "$DEBUG" ]; then
     echo "Leiningen's classpath: $CLASSPATH"
 fi
 
-# Which Java?
-
-export JAVA_CMD="${JAVA_CMD:-"java"}"
-export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-$JAVA_CMD}"
-
 if [[ "$(basename "$LEIN_JAVA_CMD")" == *drip* ]]; then
     export DRIP_INIT="$(printf -- '-e\n(require (quote leiningen.repl))')"
 fi
@@ -86,7 +92,7 @@ if [ -r .lein-fast-trampoline ]; then
 fi
 
 if [ "$LEIN_FAST_TRAMPOLINE" != "" ] && [ -r project.clj ]; then
-    INPUTS="$* $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj") $(test -f profiles.clj && cat profiles.clj)
+    INPUTS="$* $(cat project.clj) $LEIN_VERSION $(test -f "$LEIN_HOME/profiles.clj" && cat "$LEIN_HOME/profiles.clj") $(test -f profiles.clj && cat profiles.clj)"
 
     if command -v shasum >/dev/null 2>&1; then
         SUM="shasum"

--- a/bin/lein-sdkman
+++ b/bin/lein-sdkman
@@ -99,7 +99,23 @@ LEIN_JAR="$(dirname "$BIN_DIR")/lib/leiningen-$LEIN_VERSION-standalone.jar"
 ## echo $LEIN_JAR
 ## exit 1
 
-export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-Xverify:none -XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
+if [ ! -x "$JAVA_CMD" ] && ! type -f java >/dev/null
+then
+    >&2 echo "Leiningen couldn't find 'java' executable, which is required."
+    >&2 echo "Please either set JAVA_CMD or put java (>=1.6) in your \$PATH ($PATH)."
+    exit 1
+fi
+
+export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-${JAVA_CMD:-java}}"
+
+DEF_LEIN_JVM_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+JAVA_VERSION=$($LEIN_JAVA_CMD -version 2>&1 | awk -F '"' '/version/ {split($2, v, "."); print v[1] }')
+echo Java version $JAVA_VERSION
+if [[ $JAVA_VERSION -lt 13 ]]; then
+    DEF_LEIN_JVM_OPTS+=" -Xverify:none"
+fi
+export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-$DEF_LEIN_JVM_OPTS}"
+echo $LEIN_JVM_OPTS
 
 # When :eval-in :classloader we need more memory
 grep -E -q '^\s*:eval-in\s+:classloader\s*$' project.clj 2> /dev/null && \
@@ -110,15 +126,6 @@ add_path CLASSPATH "$LEIN_JAR"
 if [ "$LEIN_USE_BOOTCLASSPATH" != "no" ]; then
     LEIN_JVM_OPTS="-Xbootclasspath/a:$LEIN_JAR $LEIN_JVM_OPTS"
 fi
-
-if [ ! -x "$JAVA_CMD" ] && ! type -f java >/dev/null
-then
-    >&2 echo "Leiningen couldn't find 'java' executable, which is required."
-    >&2 echo "Please either set JAVA_CMD or put java (>=1.6) in your \$PATH ($PATH)."
-    exit 1
-fi
-
-export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-${JAVA_CMD:-java}}"
 
 if [[ -z "${DRIP_INIT+x}" && "$(basename "$LEIN_JAVA_CMD")" == *drip* ]]; then
     export DRIP_INIT="$(printf -- '-e\n(require (quote leiningen.repl))')"

--- a/bin/lein-sdkman
+++ b/bin/lein-sdkman
@@ -110,12 +110,10 @@ export LEIN_JAVA_CMD="${LEIN_JAVA_CMD:-${JAVA_CMD:-java}}"
 
 DEF_LEIN_JVM_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
 JAVA_VERSION=$($LEIN_JAVA_CMD -version 2>&1 | awk -F '"' '/version/ {split($2, v, "."); print v[1] }')
-echo Java version $JAVA_VERSION
 if [[ $JAVA_VERSION -lt 13 ]]; then
     DEF_LEIN_JVM_OPTS+=" -Xverify:none"
 fi
 export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-$DEF_LEIN_JVM_OPTS}"
-echo $LEIN_JVM_OPTS
 
 # When :eval-in :classloader we need more memory
 grep -E -q '^\s*:eval-in\s+:classloader\s*$' project.clj 2> /dev/null && \


### PR DESCRIPTION
- Moves up the java cmd declaration
- Conditionally adds the java 13 depreceated `-Xverify:none` on environments with lower java versions.
- Fix the JVM memory flags of lein-pkg
- Fix missing **"** on lein-pkg