### PR TITLE
Apply test selectors to test vars only

### DIFF
--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -61,15 +61,16 @@
   `(distinct
     (for [ns# ~ns-sym
           [_# var#] (ns-publics ns#)
-          :when (some (fn [[selector# args#]]
+          :when (and (-> var# meta :test)
+                     (some (fn [[selector# args#]]
 
-                        (apply (if (vector? selector#)
-                                 (second selector#)
-                                 selector#)
-                               (merge (-> var# meta :ns meta)
-                                      (assoc (meta var#) ::var var#))
-                               args#))
-                      ~selectors)]
+                             (apply (if (vector? selector#)
+                                      (second selector#)
+                                      selector#)
+                                    (merge (-> var# meta :ns meta)
+                                           (assoc (meta var#) ::var var#))
+                                    args#))
+                           ~selectors))]
       ns#)))
 
 ;; TODO: make this an arg to form-for-testing-namespaces in 3.0.


### PR DESCRIPTION
If test selectors select no test var but there is another var in the namespace, then the test namespace is considered and sent to `clojure.test/run-tests` causing once fixtures to run. Since `clojure.test/run-tests` only consider vars with the `:test` metadata, Leiningen could also use that only to select tests.