### PR TITLE
Fix issue where deps :query shows a transitive dependency version

### DIFF
--- a/src/leiningen/deps.clj
+++ b/src/leiningen/deps.clj
@@ -96,9 +96,12 @@
 
 
 (defn query [project artifact version-string]
-  (->> (assoc project :query [[(symbol artifact) version-string]])
-       (classpath/get-dependencies :query nil)
-       keys first second println))
+  (let [artifact (symbol artifact)]
+    (->> (assoc project :query [[artifact version-string]])
+         (classpath/get-dependencies :query nil)
+         keys
+         (filter #(= artifact (first %)))
+         first second println)))
 
 
 


### PR DESCRIPTION
This changes fixes an issue where `lein deps :query <dep>` shows the version for a transitive dependency of `<dep>` rather than the resolved version of `<dep>` itself. Specifically, whatever dependency is first in the map returned by `get-dependencies` would have its version printed.

This change fixes the issue by explicitly searching the map for the user specified dependency.

Example output,

```
$ lein version
Leiningen 2.9.3 on Java 11.0.3 OpenJDK 64-Bit Server VM

$ lein deps :query io.grpc/grpc-api
2.5.5

$ lein-master deps :query io.grpc/grpc-api
1.29.0
```

(version `2.5.5` appears to correspond to the `org.checkerframework/checker-compat-qual` transitive dependency of `io.grpc/grpc-api`)