### PR TITLE
Make leiningen.core.project/meta-merge public

### DIFF
--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -583,7 +583,7 @@
    :provided {:pom-scope :provided}
    :repl {:repl true}})
 
-(defn- meta-merge
+(defn meta-merge
   "Recursively merge values based on the information in their metadata."
   [left right]
   (cond (different-priority? left right)


### PR DESCRIPTION
`meta-merge` is such a useful function that there's even a [standalone version of it available](https://github.com/weavejester/meta-merge). When writing Leiningen plugins that modify the project map, having this handy function available without having to spelunk private vars could be very useful.