### PR TITLE
Update nREPL to 0.8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Leiningen News -- history of user-visible changes
 
+## 2.9.5
+
+* Update nREPL to 0.8. (Bozhidar Batsov)
+
 ## 2.9.4 / 2020-07-08
 
 * Fix a bug where dependency conflict resolution errors were wrong. (Phil Hagelberg)

--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -403,7 +403,7 @@ Enough setup; let's see some code running. Start with a REPL
     $ cd my-stuff
     $ lein repl
     nREPL server started on port 55568 on host 127.0.0.1 - nrepl://127.0.0.1:55568
-    REPL-y 0.4.4, nREPL 0.7.0
+    REPL-y 0.4.4, nREPL 0.8.3
     Clojure 1.10.1
     OpenJDK 64-Bit Server VM 1.8.0_222-b10
         Docs: (doc function-name-here)

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -557,7 +557,7 @@
                 :test-selectors {:default (with-meta '(constantly true)
                                             {:displace true})}
                 ;; bump deps in leiningen's own project.clj with these
-                :dependencies '[^:displace [nrepl/nrepl "0.7.0"
+                :dependencies '[^:displace [nrepl/nrepl "0.8.3"
                                             :exclusions [org.clojure/clojure]]
                                 ^:displace [clojure-complete "0.2.5"
                                             :exclusions [org.clojure/clojure]]]

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -44,7 +44,7 @@
                                [stencil/stencil "0.2.0"]
                                [~(symbol "net.3scale" "3scale-api") "3.0.2"]
                                [clj-http/clj-http "3.4.1"]
-                               [nrepl/nrepl "0.7.0"
+                               [nrepl/nrepl "0.8.3"
                                 :exclusions [[org.clojure/clojure]]]
                                [clojure-complete/clojure-complete "0.2.5"
                                 :exclusions [[org.clojure/clojure]]]],

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  ;; needed for uberjar
                  [commons-lang "2.6"]
                  ;; needed for repl
-                 [nrepl "0.7.0"]
+                 [nrepl "0.8.3"]
                  ;; needed for change
                  [org.clojars.trptcolin/sjacket "0.1.1.1" :exclusions [org.clojure/clojure]]
                  ;; bump versions of various common transitive deps

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -31,7 +31,7 @@
  net.cgrand/parsley "0.9.3"
  net.cgrand/regex "1.1.0"
  net.cgrand/sjacket "0.1.1"
- nrepl "0.7.0"
+ nrepl "0.8.3"
  org.apache.commons/commons-lang3 "3.8.1"
  org.apache.httpcomponents/httpclient "4.5.8"
  org.apache.httpcomponents/httpcore "4.4.11"


### PR DESCRIPTION
The new version adds support for dynamic middleware loading, plus built-in code completion and lookup ops. More details https://metaredux.com/posts/2020/06/15/nrepl-0-8-evolving-the-protocol.html