### PR TITLE
Don't use :reload when loading namespaces in `lein test`

### DIFF
--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -73,17 +73,23 @@
                            ~selectors))]
       ns#)))
 
-;; TODO: make this an arg to form-for-testing-namespaces in 3.0.
+;; TODO: make this an option to form-for-testing-namespaces in 3.0.
 (def ^:private ^:dynamic *monkeypatch?* true)
 
 (defn form-for-testing-namespaces
   "Return a form that when eval'd in the context of the project will test each
-  namespace and print an overall summary."
-  ([namespaces _ & [selectors]]
+  namespace and print an overall summary.
+  
+  Options:
+  - :reloading-require  if true, use :reload option for clojure.core/require calls"
+  ([namespaces opt & [selectors]]
      (let [ns-sym (gensym "namespaces")]
        `(let [~ns-sym ~(form-for-select-namespaces namespaces selectors)]
           (when (seq ~ns-sym)
-            (apply require ~ns-sym))
+            (apply require
+                   ~@(when (:reloading-require opt)
+                       [:reload])
+                   ~ns-sym))
           (let [failures# (atom {})
                 selected-namespaces# ~(form-for-nses-selectors-match selectors ns-sym)
                 _# (when ~*monkeypatch?*
@@ -214,7 +220,11 @@ tests are run. Test selector arguments must come after the list of namespaces.
 
 A default :only test-selector is available to run select tests. For example,
 `lein test :only leiningen.test.test/test-default-selector` only runs the
-specified test. A default :all test-selector is available to run all tests."
+specified test. A default :all test-selector is available to run all tests.
+  
+If :eval-in :nrepl is specified in the project, test namespaces may reload
+out-of-order. However, all test namespaces will be (re)loaded at least
+once (in *some* order)."
   [project & tests]
   (binding [main/*exit-process?* (if (= :leiningen (:eval-in project))
                                    false
@@ -226,7 +236,16 @@ specified test. A default :all test-selector is available to run all tests."
     (let [project (project/merge-profiles project [:leiningen/test :test])
           [nses selectors] (read-args tests project)
           _ (eval/prep project)
-          form (form-for-testing-namespaces nses nil (vec selectors))]
+          form (form-for-testing-namespaces
+                 nses
+                 {;; people running `lein test` with :eval-in :nrepl presumably
+                  ;; want the nrepl server to reevaluate code on each run.
+                  ;; while it's known to be buggy to use :reload, let's just
+                  ;; use it for now, because the alternative would be somewhat
+                  ;; underwhelming for users of :eval-in :nrepl (tests would
+                  ;; never reload).
+                  :reloading-require (= :nrepl (:eval-in project))}
+                 (vec selectors))]
       (try (when-let [n (eval/eval-in-project project form
                                               '(require 'clojure.test))]
              (when (and (number? n) (pos? n))

--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -83,7 +83,7 @@
      (let [ns-sym (gensym "namespaces")]
        `(let [~ns-sym ~(form-for-select-namespaces namespaces selectors)]
           (when (seq ~ns-sym)
-            (apply require :reload ~ns-sym))
+            (apply require ~ns-sym))
           (let [failures# (atom {})
                 selected-namespaces# ~(form-for-nses-selectors-match selectors ns-sym)
                 _# (when ~*monkeypatch?*

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -84,7 +84,7 @@
 
 (def with-pom-plugins-project (read-test-project "with-pom-plugins"))
 
-(def lein-test-reload-bug (read-test-project "lein-test-reload-bug"))
+(def lein-test-reload-bug-project (read-test-project "lein-test-reload-bug"))
 
 (defn abort-msg
   "Catches main/abort thrown by calling f on its args and returns its error

--- a/test/leiningen/test/helper.clj
+++ b/test/leiningen/test/helper.clj
@@ -84,6 +84,8 @@
 
 (def with-pom-plugins-project (read-test-project "with-pom-plugins"))
 
+(def lein-test-reload-bug (read-test-project "lein-test-reload-bug"))
+
 (defn abort-msg
   "Catches main/abort thrown by calling f on its args and returns its error
   message."

--- a/test/leiningen/test/test.clj
+++ b/test/leiningen/test/test.clj
@@ -3,7 +3,7 @@
   (:require [clojure.test :refer :all]
             [leiningen.test :refer :all]
             [leiningen.test.helper :refer [tmp-dir sample-no-aot-project
-                                           lein-test-reload-bug
+                                           lein-test-reload-bug-project
                                            sample-reader-cond-project
                                            sample-failing-project
                                            sample-fixture-error-project
@@ -77,8 +77,8 @@
 
 (deftest test-namespaces-load-in-order
   ;; Issue #2715
-  (test lein-test-reload-bug)
-  (is (= (ran?) #{:clj-test :cljc-test})))
+  (test lein-test-reload-bug-project)
+  (is (= (ran?) #{:lein-test-reload-bug.core-test})))
 
 (deftest test-invalid-namespace-argument
   (is (.contains

--- a/test/leiningen/test/test.clj
+++ b/test/leiningen/test/test.clj
@@ -77,8 +77,7 @@
 
 (deftest test-namespaces-load-in-order
   ;; Issue #2715
-  (test lein-test-reload-bug-project)
-  (is (= (ran?) #{:lein-test-reload-bug.core-test})))
+  (test lein-test-reload-bug-project))
 
 (deftest test-invalid-namespace-argument
   (is (.contains

--- a/test/leiningen/test/test.clj
+++ b/test/leiningen/test/test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.test :refer :all]
             [leiningen.test :refer :all]
             [leiningen.test.helper :refer [tmp-dir sample-no-aot-project
+                                           lein-test-reload-bug
                                            sample-reader-cond-project
                                            sample-failing-project
                                            sample-fixture-error-project
@@ -72,6 +73,11 @@
 
 (deftest test-reader-conditional-tests
   (test sample-reader-cond-project)
+  (is (= (ran?) #{:clj-test :cljc-test})))
+
+(deftest test-namespaces-load-in-order
+  ;; Issue #2715
+  (test lein-test-reload-bug)
   (is (= (ran?) #{:clj-test :cljc-test})))
 
 (deftest test-invalid-namespace-argument

--- a/test_projects/lein-test-reload-bug/project.clj
+++ b/test_projects/lein-test-reload-bug/project.clj
@@ -1,7 +1,2 @@
 (defproject lein-test-reload-bug "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
-            :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.10.1"]]
-  :repl-options {:init-ns lein-test-reload-bug.core})
+  :dependencies [[org.clojure/clojure "1.10.1"]])

--- a/test_projects/lein-test-reload-bug/project.clj
+++ b/test_projects/lein-test-reload-bug/project.clj
@@ -1,0 +1,7 @@
+(defproject lein-test-reload-bug "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+            :url "https://www.eclipse.org/legal/epl-2.0/"}
+  :dependencies [[org.clojure/clojure "1.10.1"]]
+  :repl-options {:init-ns lein-test-reload-bug.core})

--- a/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/a_deftype.clj
+++ b/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/a_deftype.clj
@@ -1,0 +1,9 @@
+(prn "loading" 'lein-test-reload-bug.a-deftype)
+
+(ns lein-test-reload-bug.a-deftype
+  (:require [lein-test-reload-bug.b-protocol
+             :refer [B]]))
+
+(deftype A []
+  B
+  (b [this]))

--- a/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/a_deftype.clj
+++ b/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/a_deftype.clj
@@ -6,4 +6,4 @@
 
 (deftype A []
   B
-  (b [this]))
+  (b [this] :ok))

--- a/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/b_protocol.clj
+++ b/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/b_protocol.clj
@@ -1,0 +1,6 @@
+(prn "loading" 'lein-test-reload-bug.b-protocol)
+
+(ns lein-test-reload-bug.b-protocol)
+
+(defprotocol B
+  (b [this]))

--- a/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/core_test.clj
+++ b/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/core_test.clj
@@ -1,0 +1,16 @@
+(prn "loading" 'lein-test-reload-bug.core-test)
+
+(ns lein-test-reload-bug.core-test
+  (:require [clojure.test :refer [deftest]]
+            [lein-test-reload-bug.a-deftype :refer [->A]]
+            [lein-test-reload-bug.b-protocol :refer [b]]))
+
+(deftest a-test
+  (let [a (->A)]
+    (prn "The current hash of interface lein_test_reload_bug.b_protocol.B is" (hash lein_test_reload_bug.b_protocol.B))
+    (prn "The current instance of A implements lein_test_reload_bug.b_protocol.B with [name hash]:"
+         (-> (into {}
+                   (map (juxt #(.getName ^Class %) hash))
+                   (-> a class supers))
+             (find "lein_test_reload_bug.b_protocol.B")))
+    (b a)))

--- a/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/core_test.clj
+++ b/test_projects/lein-test-reload-bug/test/lein_test_reload_bug/core_test.clj
@@ -1,7 +1,7 @@
 (prn "loading" 'lein-test-reload-bug.core-test)
 
 (ns lein-test-reload-bug.core-test
-  (:require [clojure.test :refer [deftest]]
+  (:require [clojure.test :refer [deftest is]]
             [lein-test-reload-bug.a-deftype :refer [->A]]
             [lein-test-reload-bug.b-protocol :refer [b]]))
 
@@ -13,4 +13,4 @@
                    (map (juxt #(.getName ^Class %) hash))
                    (-> a class supers))
              (find "lein_test_reload_bug.b_protocol.B")))
-    (b a)))
+    (is (= :ok (b a)))))


### PR DESCRIPTION
Closes https://github.com/technomancy/leiningen/issues/2715

See linked issue for implications of using reload.

We have an exception for `:eval-in :nrepl` users, because they are (probably) the only ones who run `lein test` in a dirty environment where the `:reload` option makes a significant difference.