### PR TITLE
Strengthen leiningen.test's reporting to avoid (future) data race

### DIFF
--- a/src/leiningen/test.clj
+++ b/src/leiningen/test.clj
@@ -119,9 +119,7 @@
                           (when-let [first-var# (-> clojure.test/*testing-vars* first meta)]
                             (let [ns-name# (-> first-var# :ns ns-name name)
                                   test-name# (-> first-var# :name name)]
-                              (swap! failures#
-                                     (fn [_#]
-                                       (update-in @failures# [ns-name#] (fnil conj []) test-name#)))
+                              (swap! failures# update-in [ns-name#] (fnil conj []) test-name#)
                               (newline)
                               (println "lein test :only" (str ns-name# "/" test-name#)))))
                         (if (= :begin-test-ns (:type m#))


### PR DESCRIPTION
After some thought, I believe a race is impossible in this particular
code, however only by coincidence that every value written to the atom is pointer-distinct.

Regardless, IMO we can reduce the chance of future code introducing a race by
using atoms normally.

To understand why the existing code is fragile, consider the following
code:

```clojure
(let [a (atom true)]
  (doall
    (pmap (fn [_] (swap! a (fn [_] (not @a))))
          (range 3)))
  @a)
```

This atom simply alternates between true and false. Since 3 threads
are active, we can expect `a` to be `false` once the dust settles.

However, there's a data race in this interleaving of threads:

```
Time | Thread 1 | Thread 2 | Thread 3 | a
---------------------------------------------
0    | read     |          |          | true
1    |          | read     |          | true
2    |          | write    |          | false
3    | @a       |          |          | false
4    |          |          | read     | false
5    |          |          | write    | true
6    | write    |          |          | true
```

Notice `@a` is *true* after all threads have completed!

At t=3, Thread 1 gets an inconsistent view of the atom, but
by the time it writes to it at t=6, the compare-and-swap logic allows
the write because the current state is indistinguishable from t=0.