### PR TITLE
[PoC] Preserve :tag's safely in eval-in-project

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -17,5 +17,6 @@
                  [org.clojure/tools.macro "0.1.5"]]
   :scm {:dir ".."}
   :dev-resources-path "dev-resources"
+  :global-vars {*warn-on-reflection* true}
   :aliases {"bootstrap" ["with-profile" "base"
                          "do" "install," "classpath" ".lein-bootstrap"]})

--- a/project.clj
+++ b/project.clj
@@ -39,5 +39,6 @@
   :test-selectors {:default (complement :disabled)
                    :offline (comp (partial not-any? identity)
                                   (juxt :online :disabled))}
+  :global-vars {*warn-on-reflection* true}
   :source-paths ["leiningen-core/src" "src"]
   :eval-in :leiningen)

--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -214,6 +214,7 @@
                        :ack-port ~ack-port
                        :handler ~(handler-for project))
               port# (:port server#)
+              ^java.io.File
               repl-port-file# (apply io/file ~(repl-port-file-vector project))
               ;; TODO 3.0: remove legacy repl port support.
               legacy-repl-port# (if (.exists (io/file ~(:target-path project "")))
@@ -221,7 +222,8 @@
           (when ~start-msg?
             (println "nREPL server started on port" port# "on host" ~(:host cfg)
                      (str "- "
-                          (transport/uri-scheme ~(or (:transport cfg) #'transport/bencode))
+                          (transport/uri-scheme ~(or (:transport cfg)
+                                                     `(var transport/bencode)))
                           "://" ~(:host cfg) ":" port#)))
           (spit (doto repl-port-file# .deleteOnExit) port#)
           (when legacy-repl-port#

--- a/test/leiningen/test/run.clj
+++ b/test/leiningen/test/run.clj
@@ -45,9 +45,9 @@
                (helper/abort-msg run tricky-name-project "-m" "-1"))))
 
 (deftest test-nonexistant-ns-error-message
-  (is (re-find #"Can't find 'nonexistant.ns' as \.class or \.clj for lein run"
+  (is (re-find #"Can't find 'nonexistent.ns' as \.class or \.clj for lein run"
                (with-system-err-str
-                 (try (run tricky-name-project "-m" "nonexistant.ns")
+                 (try (run tricky-name-project "-m" "nonexistent.ns")
                       (catch Exception _))))))
 
 (deftest test-escape-args


### PR DESCRIPTION
Related https://github.com/technomancy/leiningen/issues/2695
Related https://github.com/technomancy/leiningen/pull/2696

This PR attempts to enhance `eval-in-project` with the ability to preserve metadata `:tag` forms in a backwards-compatible way. Please consider it a proof-of-concept at the moment, I would like some feedback before it's considered ready.

It seems less risky than previous attempts (discussed [here](https://github.com/technomancy/leiningen/pull/2696)).

The basic idea is to only `*print-meta* true` a form if you can guarantee all metadata is safe to print in a form (by stripping all but `:tag` metadata), otherwise point the user to reasons why `:tag` information was thrown away (eg., vars).

There's also a few other ideas for enhancements piled in that I found while I was developing, happy to move them out if needed.