### PR TITLE
trim whitespace in .nrepl-port, providing compatibility for when user edits the file by hand

### DIFF
--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -82,7 +82,9 @@
   (let [port (repl-port project)]
     (if (= port 0)
       (try
-        (slurp (io/file (:root project) ".nrepl-port"))
+        (-> (io/file (:root project) ".nrepl-port")
+            slurp
+            s/trim)
         (catch Exception _))
       port)))
 


### PR DESCRIPTION
Editors like vim add a trailing newlines to files (`:set noendofline binary` in vim turns this off). Thus when editting the `.nrepl-port` file by hand, the port value sent downstream to `reply` is invalid, resulting in:

```
URISyntaxException Illegal character in authority at index 8: nrepl://127.0.0.1:35000

        java.net.URI$Parser.fail (URI.java:2847)
        java.net.URI$Parser.parseAuthority (URI.java:3185)
        java.net.URI$Parser.parseHierarchical (URI.java:3096)
        java.net.URI$Parser.parse (URI.java:3052)
        java.net.URI.<init> (URI.java:588)
        reply.eval-modes.nrepl/get-connection (nrepl.clj:164)
        reply.eval-modes.nrepl/get-connection (nrepl.clj:156)
        reply.eval-modes.nrepl/main (nrepl.clj:202)
        reply.eval-modes.nrepl/main (nrepl.clj:200)
        reply.main/launch-nrepl/fn--6010 (main.clj:79)
        clojure.core/with-redefs-fn (core.clj:7514)
        clojure.core/with-redefs-fn (core.clj:7498)
Bye for now!
```

This PR removes any whitespaces before sending the port downstream

I've come across this several times and it looks like at least one other user has as well: https://clojurians-log.clojureverse.org/boot/2016-01-12

I'm not sure if this is the proper place for the input sanitation, one could argue adding it around https://github.com/trptcolin/reply/blob/f0c730e7a6753494f9f90f02234bc040318da393/src/clj/reply/eval_modes/nrepl.clj#L146 would also suffice. 
Please let me know if this deserves test coverage and if so, what tests can I adapt to write mine.