### PR TITLE
Update template code to reflect new Clojars verified group policy

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## 2.9.6 / ???
 
+* Look for templates in a way that reflects new Clojars group rules. (Phil Hagelberg)
+* Update template-generating template to reflect new Clojars rules. (Phil Hagelberg)
 * Don't `:reload` in tests unless connecting to an nrepl. (Ambrose Bonnaire-Sergeant)
 
 ## 2.9.5 / 2020-12-07

--- a/doc/TEMPLATES.md
+++ b/doc/TEMPLATES.md
@@ -41,16 +41,12 @@ Your new template would look like:
     ├── resources
     │   └── leiningen
     │       └── new
-    │           └── us
-    │               └── technomancy
-    │                   └── liquid_cool
-    │                       └── foo.clj
+    │           └── liquid_cool
+    │               └── foo.clj
     └── src
         └── leiningen
             └── new
-                └── us
-                    └── technomancy
-                        └── liquid_cool.clj
+                └── liquid_cool.clj
 
 Note that you'll now have a new and separate project named
 "liquid-cool-template". It will have a group-id of "us.technomancy", and
@@ -59,14 +55,14 @@ an artifact-id of "lein-template.liquid-cool".
 ## Structure
 
 The files that your template will provide to users are in
-`resources/leiningen/new/us/technomancy/liquid_cool`. The template generator
+`resources/leiningen/new/liquid_cool`. The template generator
 starts you off with just one, named "foo.clj". You can see it referenced in
-`src/leiningen/new/us/technomancy/liquid_cool.clj`, right underneath the
+`src/leiningen/new/liquid_cool.clj`, right underneath the
 `->files data` line.
 
 You can delete `foo.clj` if you like (and its corresponding line in
 `liquid_cool.clj`), and start populating that
-`resources/leiningen/new/us/technomancy/liquid_cool` directory with the files
+`resources/leiningen/new/liquid_cool` directory with the files
 you wish to be part of your template. For everything you add, make sure the
 `liquid_cool.clj` file receives corresponding entries in that `->files`
 call. For examples to follow, have a look inside [the \*.clj files for the
@@ -87,8 +83,8 @@ your system (without publishing your template to clojars yet), just run:
 
     $ lein install
 
-You should then be able to run `lein new us.technomancy/liquid-cool
-myproject` from any directory on your system.
+You should then be able to run `lein new us.technomancy/liquid-cool myproject`
+from any directory on your system.
 
 ## Templating System
 
@@ -104,7 +100,7 @@ and that we have a template file which looks up the key X by wrapping it in
 double mustaches like so: `{{X}}`. As for our input name, `data` already
 contains the line `:name name`, which means we can lookup the input name by
 writing `{{name}}` in the template file. To try it out, save the following
-contents in the file `resources/leiningen/new/us/technomancy/liquid_cool/README.md`:
+contents in the file `resources/leiningen/new/liquid_cool/README.md`:
 
 ```markdown
 # {{name}}
@@ -152,17 +148,18 @@ change the mustache delimiter temporarily, like so:
 
 ## Distributing your Template
 
-Templates are just maven artifacts. Particularly, they need only be on the
-classpath when `lein new` is called. So, as a side-effect, you can just put
-your templates in a jar and toss them on Clojars and have people install them
-like normal Leiningen plugins. Templates get dynamically fetched if they're not
-found. So for instance `lein new com.heroku/hello myproject` will find the
-latest version of the `com.heroku/lein-template.hello` project from Clojars and
-use that.
+Templates are just maven artifacts, aka dependencies. Particularly,
+they need only be on the classpath when `lein new` is called. So, as a
+side-effect, you can just put your templates in a jar and toss them on
+Clojars and have people install them like normal Leiningen
+plugins. Templates get fetched on demand if they're not found. So
+for instance `lein new com.heroku/hello myproject` will find the
+latest version of the `com.heroku/lein-template.hello` project from
+Clojars and use that.
 
 ## Legacy Templates
 
-Prior to Leiningen 2.6.2, templates defaulted to using the template
+Prior to Leiningen 2.9.6, templates defaulted to using the template
 name as the group-id and "lein-template" as the artifact-id. Changes
 to [Clojars policy](https://github.com/clojars/clojars-web/wiki/Verified-Group-Names)
 have necessitated using a new style where every template name includes

--- a/doc/TEMPLATES.md
+++ b/doc/TEMPLATES.md
@@ -20,51 +20,57 @@ on how one might best create a new project which uses liquid-cool, you
 might want to provide a template for it (just like how `lein` already
 provides built-in templates for "app", "plugin", and so on).
 
-Let's assume your library's project dir is `~/dev/liquid-cool`. Create
-a template for it like so:
+Let's assume you have a library called "liquid cool" which lives on
+Clojars as `us.technomancy/liquid-cool`. You can name your template
+after your library. You could also use a different name, but note that
+in order to comply with the new [Clojars
+policies](https://github.com/clojars/clojars-web/wiki/Verified-Group-Names)
+you can't create a new group-id unless you can verify ownership of it.
 
-    cd ~/dev
-    lein new template liquid-cool --to-dir liquid-cool-template
+Create a template for it like so:
+
+    lein new template us.technomancy/liquid-cool --to-dir liquid-cool-template
 
 Your new template would look like:
 
-    liquid-cool-template
+    liquid-cool-template/
+    ├── CHANGELOG.md
     ├── LICENSE
     ├── project.clj
     ├── README.md
     ├── resources
-    |   └── leiningen
-    |       └── new
-    |           └── liquid_cool
-    |               └── foo.clj
+    │   └── leiningen
+    │       └── new
+    │           └── us
+    │               └── technomancy
+    │                   └── liquid_cool
+    │                       └── foo.clj
     └── src
         └── leiningen
             └── new
-                └── liquid_cool.clj
+                └── us
+                    └── technomancy
+                        └── liquid_cool.clj
 
 Note that you'll now have a new and separate project named
-"liquid-cool-template". It will have a group-id of "liquid-cool", and
-an artifact-id of "lein-template".
-
-> All lein templates have an artifact-id of "lein-template", and are
-> differentiated by their group-id, which always should match the
-> project for which they provide a template.
+"liquid-cool-template". It will have a group-id of "us.technomancy", and
+an artifact-id of "lein-template.liquid-cool".
 
 ## Structure
 
 The files that your template will provide to users are in
-`resources/leiningen/new/liquid_cool`. The template generator starts you off
-with just one, named "foo.clj". You can see it referenced in
-`src/leiningen/new/liquid_cool.clj`, right underneath the
+`resources/leiningen/new/us/technomancy/liquid_cool`. The template generator
+starts you off with just one, named "foo.clj". You can see it referenced in
+`src/leiningen/new/us/technomancy/liquid_cool.clj`, right underneath the
 `->files data` line.
 
 You can delete `foo.clj` if you like (and its corresponding line in
 `liquid_cool.clj`), and start populating that
-`resources/leiningen/new/liquid_cool` directory with the files you wish to be
-part of your template. For everything you add, make sure the
+`resources/leiningen/new/us/technomancy/liquid_cool` directory with the files
+you wish to be part of your template. For everything you add, make sure the
 `liquid_cool.clj` file receives corresponding entries in that `->files`
-call. For examples to follow, have a look inside [the \*.clj files for
-the built-in
+call. For examples to follow, have a look inside [the \*.clj files for the
+built-in
 templates](https://github.com/technomancy/leiningen/tree/stable/resources/leiningen/new).
 
 ## Testing Your Template
@@ -73,7 +79,7 @@ While developing a template, if you're in the template project directory,
 leiningen will pick it up and you'll be able to test it.  e.g. from the
 `liquid-cool-template` dir:
 
-    $ lein new liquid-cool myproject
+    $ lein new us.technomancy/liquid-cool myproject
 
 will create a directory called `myproject`, built from your template.
 Alternately, if you want to test your template from another directory on
@@ -81,8 +87,8 @@ your system (without publishing your template to clojars yet), just run:
 
     $ lein install
 
-You should then be able to run `lein new liquid-cool myproject` from any
-directory on your system.
+You should then be able to run `lein new us.technomancy/liquid-cool
+myproject` from any directory on your system.
 
 ## Templating System
 
@@ -98,7 +104,7 @@ and that we have a template file which looks up the key X by wrapping it in
 double mustaches like so: `{{X}}`. As for our input name, `data` already
 contains the line `:name name`, which means we can lookup the input name by
 writing `{{name}}` in the template file. To try it out, save the following
-contents in the file `resources/leiningen/new/liquid_cool/README.md`:
+contents in the file `resources/leiningen/new/us/technomancy/liquid_cool/README.md`:
 
 ```markdown
 # {{name}}
@@ -112,9 +118,9 @@ And add the following line right underneath the `->files data` line:
 ["README.md" (render "README.md" data)]
 ```
 
-Now, if we for instance say `lein new liquid-cool liquid-cool-app`, the newly
-generated project will contain a file named `README.md` where the header is
-`liquid-cool-app`.
+Now, if we for instance say `lein new us.technomancy/liquid-cool
+liquid-cool-app`, the newly generated project will contain a file named
+`README.md` where the header is `liquid-cool-app`.
 
 [stencil]: https://github.com/davidsantiago/stencil
 [Mustache]: https://mustache.github.io/
@@ -146,19 +152,23 @@ change the mustache delimiter temporarily, like so:
 
 ## Distributing your Template
 
-Templates are just maven artifacts. Particularly, they need only be on
-the classpath when `lein new` is called. So, as a side-effect, you
-can just put your templates in a jar and toss them on clojars and have
-people install them like normal Leiningen plugins.
-
-In Leiningen 2.x, templates get dynamically fetched if they're not
-found. So for instance `lein new heroku myproject` will find the
-latest version of the `heroku/lein-template` project from Clojars and
+Templates are just maven artifacts. Particularly, they need only be on the
+classpath when `lein new` is called. So, as a side-effect, you can just put
+your templates in a jar and toss them on Clojars and have people install them
+like normal Leiningen plugins. Templates get dynamically fetched if they're not
+found. So for instance `lein new com.heroku/hello myproject` will find the
+latest version of the `com.heroku/lein-template.hello` project from Clojars and
 use that.
 
-Users of Leiningen 1.x (1.6.2 or later) can also use the template if
-they install the `lein-newnew` plugin:
+## Legacy Templates
 
-    $ lein plugin install lein-newnew 0.3.6
-    $ lein new foo
-    $ lein new plugin lein-foo
+Prior to Leiningen 2.6.2, templates defaulted to using the template
+name as the group-id and "lein-template" as the artifact-id. Changes
+to [Clojars policy](https://github.com/clojars/clojars-web/wiki/Verified-Group-Names)
+have necessitated using a new style where every template name includes
+a group-id and an artifact-id. The template artifact takes the
+group-id but prepends "lein-template." to the artifact-id given in the
+template name.
+
+The old style is still supported when using an existing template, but it is not
+recommended for creating new templates.

--- a/resources/leiningen/new/app/CHANGELOG.md
+++ b/resources/leiningen/new/app/CHANGELOG.md
@@ -20,5 +20,5 @@ All notable changes to this project will be documented in this file. This change
 - Files from the new template.
 - Widget maker public API - `make-widget-sync`.
 
-[Unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/your-name/{{name}}/compare/0.1.0...0.1.1
+[Unreleased]: https://sourcehost.site/your-name/{{name}}/compare/0.1.1...HEAD
+[0.1.1]: https://sourcehost.site/your-name/{{name}}/compare/0.1.0...0.1.1

--- a/resources/leiningen/new/default/CHANGELOG.md
+++ b/resources/leiningen/new/default/CHANGELOG.md
@@ -20,5 +20,5 @@ All notable changes to this project will be documented in this file. This change
 - Files from the new template.
 - Widget maker public API - `make-widget-sync`.
 
-[Unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/your-name/{{name}}/compare/0.1.0...0.1.1
+[Unreleased]: https://sourcehost.site/your-name/{{name}}/compare/0.1.1...HEAD
+[0.1.1]: https://sourcehost.site/your-name/{{name}}/compare/0.1.0...0.1.1

--- a/resources/leiningen/new/plugin/CHANGELOG.md
+++ b/resources/leiningen/new/plugin/CHANGELOG.md
@@ -20,5 +20,5 @@ All notable changes to this project will be documented in this file. This change
 - Files from the new template.
 - Widget maker public API - `make-widget-sync`.
 
-[Unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/your-name/{{name}}/compare/0.1.0...0.1.1
+[Unreleased]: https://sourcehost.site/your-name/{{name}}/compare/0.1.1...HEAD
+[0.1.1]: https://sourcehost.site/your-name/{{name}}/compare/0.1.0...0.1.1

--- a/resources/leiningen/new/template/CHANGELOG.md
+++ b/resources/leiningen/new/template/CHANGELOG.md
@@ -20,5 +20,5 @@ All notable changes to this project will be documented in this file. This change
 - Files from the new template.
 - Widget maker public API - `make-widget-sync`.
 
-[Unreleased]: https://github.com/your-name/{{name}}/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/your-name/{{name}}/compare/0.1.0...0.1.1
+[Unreleased]: https://source-host.site/your-name/{{name}}/compare/0.1.1...HEAD
+[0.1.1]: https://source-host.site/your-name/{{name}}/compare/0.1.0...0.1.1

--- a/resources/leiningen/new/template/project.clj
+++ b/resources/leiningen/new/template/project.clj
@@ -1,4 +1,4 @@
-(defproject {{name}}/lein-template "0.1.0-SNAPSHOT"
+(defproject {{group-id}}/lein-template.{{artifact-id}} "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/resources/leiningen/new/template/project.clj
+++ b/resources/leiningen/new/template/project.clj
@@ -1,4 +1,4 @@
-(defproject {{group-id}}/lein-template.{{artifact-id}} "0.1.0-SNAPSHOT"
+(defproject {{group-prefix}}lein-template.{{artifact-id}} "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/resources/leiningen/new/template/temp.clj
+++ b/resources/leiningen/new/template/temp.clj
@@ -1,14 +1,14 @@
-(ns leiningen.new.{{name}}
-  (:require [leiningen.new.templates :refer [renderer name-to-path ->files]]
+(ns leiningen.new.{{group-id}}.{{artifact-id}}
+  (:require [leiningen.new.templates :as tmpl]
             [leiningen.core.main :as main]))
 
-(def render (renderer "{{name}}"))
+(def render (tmpl/renderer "{{sanitized}}"))
 
-(defn {{name}}
+(defn {{artifact-id}}
   "FIXME: write documentation"
   [name]
   (let [data {:name name
-              :sanitized (name-to-path name)}]
+              :sanitized (tmpl/name-to-path name)}]
     (main/info "Generating fresh 'lein new' {{name}} project.")
-    (->files data
-             ["src/{{placeholder}}/foo.clj" (render "foo.clj" data)])))
+    (tmpl/->files data
+                  ["src/{{placeholder}}/foo.clj" (render "foo.clj" data)])))

--- a/resources/leiningen/new/template/temp.clj
+++ b/resources/leiningen/new/template/temp.clj
@@ -1,4 +1,4 @@
-(ns leiningen.new.{{group-id}}.{{artifact-id}}
+(ns leiningen.new.{{artifact-id}}
   (:require [leiningen.new.templates :as tmpl]
             [leiningen.core.main :as main]))
 

--- a/src/leiningen/new.clj
+++ b/src/leiningen/new.clj
@@ -50,7 +50,7 @@
          (debug (str e)))))
 
 (defn resolve-template [template-name]
-  (let [ns-sym (symbol (str "leiningen.new." (str/replace template-name "/" ".")))]
+  (let [ns-sym (symbol (str "leiningen.new." (name (symbol template-name))))]
     (if (try (require ns-sym)
              true
              (catch FileNotFoundException _

--- a/src/leiningen/new/template.clj
+++ b/src/leiningen/new/template.clj
@@ -16,8 +16,10 @@
         sym (symbol template-name)
         data {:name template-name
               :artifact-id (name sym)
-              :group-id (namespace sym)
-              :sanitized (t/name-to-path template-name)
+              ;; if there's no group-id we need to leave out the slash
+              :group-prefix (if-let [group-id (namespace sym)]
+                              (str group-id "/"))
+              :sanitized (t/name-to-path (name sym))
               :placeholder "{{sanitized}}"
               :year (t/year)
               :date (t/date)}]

--- a/src/leiningen/new/template.clj
+++ b/src/leiningen/new/template.clj
@@ -1,23 +1,33 @@
 (ns leiningen.new.template
-  (:require [leiningen.new.templates :refer [renderer sanitize year date ->files]]
+  (:require [clojure.string :as str]
+            [leiningen.new.templates :as t]
             [leiningen.core.main :as main]))
 
 (defn template
   "A meta-template for 'lein new' templates."
-  [name]
-  (let [render (renderer "template")
-        data {:name name
-              :sanitized (sanitize name)
+  [template-name]
+  (when-not (namespace (symbol template-name))
+    (main/warn (str "Template names must use a group-id to conform with new"
+                    " Clojars security policy:\n"
+                    "https://github.com/clojars/clojars-web/wiki/Verified-Group-Names"
+                    "\n\nYou may generate this template but you may not be"
+                    " able to publish it on Clojars.")))
+  (let [render (t/renderer "template")
+        sym (symbol template-name)
+        data {:name template-name
+              :artifact-id (name sym)
+              :group-id (namespace sym)
+              :sanitized (t/name-to-path template-name)
               :placeholder "{{sanitized}}"
-              :year (year)
-              :date (date)}]
+              :year (t/year)
+              :date (t/date)}]
     (main/info "Generating fresh 'lein new' template project.")
-    (->files data
-             ["README.md" (render "README.md" data)]
-             ["project.clj" (render "project.clj" data)]
-             [".gitignore" (render "gitignore" data)]
-             [".hgignore" (render "hgignore" data)]
-             ["src/leiningen/new/{{sanitized}}.clj" (render "temp.clj" data)]
-             ["resources/leiningen/new/{{sanitized}}/foo.clj" (render "foo.clj")]
-             ["LICENSE" (render "LICENSE" data)]
-             ["CHANGELOG.md" (render "CHANGELOG.md" data)])))
+    (t/->files data
+               ["README.md" (render "README.md" data)]
+               ["project.clj" (render "project.clj" data)]
+               [".gitignore" (render "gitignore" data)]
+               [".hgignore" (render "hgignore" data)]
+               ["src/leiningen/new/{{sanitized}}.clj" (render "temp.clj" data)]
+               ["resources/leiningen/new/{{sanitized}}/foo.clj" (render "foo.clj")]
+               ["LICENSE" (render "LICENSE" data)]
+               ["CHANGELOG.md" (render "CHANGELOG.md" data)])))

--- a/test/leiningen/test/new.clj
+++ b/test/leiningen/test/new.clj
@@ -1,8 +1,9 @@
 (ns leiningen.test.new
   (:require [leiningen.new :as new])
-  (:use [clojure.test]
-        [clojure.java.io :only [file]]
-        [leiningen.test.helper :only [delete-file-recursively abort-msg]]))
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :refer [file]]
+            [leiningen.test.helper :refer [delete-file-recursively abort-msg]]
+            [leiningen.new :as new]))
 
 (deftest test-new-with-just-project-name
   (leiningen.new/new nil "test-new-proj")
@@ -55,7 +56,7 @@
 
 (deftest test-new-with-nonexistent-template
   (is (re-find
-       #"Could not find template zzz"
+       #"Could not find template for zzz"
        (with-redefs [leiningen.new/resolve-remote-template (constantly false)]
          (abort-msg leiningen.new/new nil "zzz" "my-zzz")))))
 
@@ -70,6 +71,9 @@
          (let [name "luminus"
                sym (symbol (str "leiningen.new." name))]
            (leiningen.new/resolve-remote-template name sym))))))
+
+(deftest ^:online test-group-id-template
+  (is (fn? @(new/resolve-template "us.technomancy/liquid-cool"))))
 
 (deftest test-new-with-*-jure-project-name
   (is (re-find


### PR DESCRIPTION
Clojars is changing the rules around what kind of groups are allowed to be created: https://github.com/clojars/clojars-web/wiki/Verified-Group-Names

In particular, the current system of using the template name as the group-id and "lein-template" as the artifact-id will no longer be supported, since group-ids for new libraries must be verified using a reverse-domain scheme. The new scheme is to use a fully-qualified template name such as `us.technomancy/liquid-cool` which results in a lookup for the jar at `us.technomancy/lein-template.liquid-cool`.

This PR updates:
* the template used to create new templates
* the documentation around creating new templates
* the `new` task which looks for templates

Also includes a bonus commit removing assumptions in the template around what code hosting site is used.