### PR TITLE
Upgrade pomegranate from 1.2.0 -> 1.2.1

### DIFF
--- a/leiningen-core/project.clj
+++ b/leiningen-core/project.clj
@@ -9,7 +9,7 @@
                   :exclusions [org.clojure/clojure]]
                  [org.flatland/classlojure "0.7.1"]
                  [robert/hooke "1.3.0"]
-                 [clj-commons/pomegranate "1.2.0"
+                 [clj-commons/pomegranate "1.2.1"
                   :exclusions [org.slf4j/jcl-over-slf4j]]
                  [com.hypirion/io "0.3.1"]
                  [org.slf4j/slf4j-nop "1.7.25"] ; wagon-http uses slf4j


### PR DESCRIPTION
This is done to bring in org.apache.maven.wagon/wagon-http 3.3.4 (was
3.3.2) to restore displaying the reason phrases returned from a remote
repository. Clojars uses the reason phrase to return additional
context about deploy failures. Display of reason phrases was removed
in wagon-http 3.2.0, but restored in 3.3.4 due to user complaint.

See https://github.com/clojars/clojars-web/issues/774 for more details.

I confirmed this now shows the reason phrases:

```
$ lein-head deploy clojars
Created /Users/tcrawley/oss/clojars/deploytest/target/deploytest-0.1.0-SNAPSHOT.jar
Wrote /Users/tcrawley/oss/clojars/deploytest/pom.xml
Retrieving org/clojars/tcrawley/deploytest/0.1.0-SNAPSHOT/maven-metadata.xml (1k)
    from https://repo.clojars.org/
Sending org/clojars/tcrawley/deploytest/0.1.0-SNAPSHOT/deploytest-0.1.0-20210412.101402-9.jar (9k)
    to https://repo.clojars.org/
Could not transfer artifact org.clojars.tcrawley:deploytest:jar:0.1.0-20210412.101402-9 from/to clojars (https://repo.clojars.org/): Transfer failed for https://repo.clojars.org/org/clojars/tcrawley/deploytest/0.1.0-SNAPSHOT/deploytest-0.1.0-20210412.101402-9.jar 401 Unauthorized - a deploy token is required to deploy (see https://git.io/JfwjM)
```
