### PR TITLE
Fix infinite loop when unpatched gpg used with openpgp keyservers

### DIFF
--- a/src/leiningen/deps.clj
+++ b/src/leiningen/deps.clj
@@ -44,8 +44,10 @@
   (if (or (re-find #"Can't check signature: public key not found" err)
           (re-find #"Can't check signature: No public key" err))
     (let [key (second (re-find #"using \w+ key(?: ID)? (.+)" err))
-          {:keys [exit]} (user/gpg "--recv-keys" "--" key)]
-      (if (zero? exit)
+          {:keys [err exit]} (user/gpg "--recv-keys" "--" key)]
+      (if (and
+           (zero? exit)
+           (not (re-find #"new key but contains no user ID - skipped" err)))
         (check-signature signature)
         :no-key))
     :bad-signature))

--- a/test/.gnupg/gpg.conf
+++ b/test/.gnupg/gpg.conf
@@ -1,0 +1,1 @@
+keyserver keys.openpgp.org


### PR DESCRIPTION
Opengpg servers don't return user-ids when `gpg --recv-keys <key>` is run, but `gpg` returns 0 exit code but does _not_ import the key, so Leiningen assumes success and enters an infinite loop.

Some background:
https://keys.openpgp.org/about/faq#older-gnupg
https://dev.gnupg.org/T4393#133689