### PR TITLE
Setup GNUPGHOME for :verify test. Add commons-io/:no-key to assertion

### DIFF
--- a/test/.gnupg/gpg.sh
+++ b/test/.gnupg/gpg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export GNUPGHOME=$(dirname $0)
+gpg $@

--- a/test/leiningen/test/deps.clj
+++ b/test/leiningen/test/deps.clj
@@ -6,6 +6,7 @@
                                       delete-file-recursively]])
   (:require [clojure.java.io :as io]
             [leiningen.core.utils :as utils]
+            [leiningen.core.user :as user]
             [leiningen.core.eval :as eval]
             [leiningen.core.classpath :as classpath]
             [cemerick.pomegranate.aether :as aether]
@@ -235,8 +236,12 @@
                                                    '[commons-io  "2.8.0"]))
                       (assoc :checksum :ignore))
           _ (deps project)
-          out (with-out-str (deps project ":verify"))]
+          out (with-out-str
+                ;; so that GNUPGHOME can be set to `test/.gnupg`
+                (with-redefs [user/gpg-program (constantly "test/.gnupg/gpg.sh")]
+                  (deps project ":verify")))]
       (doseq [[dep signed] '{[org.clojure/clojure "1.3.0"] :signed
+                             [commons-io "2.8.0"] :no-key
                              [rome "0.9"] :unsigned
                              [jdom "1.0"] :unsigned}]
         (is (.contains out (pr-str signed dep)))))))


### PR DESCRIPTION
As discussed, here's an attempt at setting up the environment for the test we added in #2741 

I thought it safest to add a `redef` for this particular test rather than try change the environment for all tests - I'm a little worried that it might break other local workflows with different gpg versions/configs like I did before.