### PR TITLE
Fix and expand the pom-addition section

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -497,9 +497,17 @@
   ;; Include xml in generated pom.xml file, as parsed by
   ;; clojure.data.xml/sexp-as-element. Resulting pom still needs to
   ;; validate according to the pom XML schema.
-  :pom-addition [:developers [:developer {:id "benbit"}
-                              [:name "Ben Bitdiddle"]
-                              [:url "http://www.example.com/benjamin"]]]
+  :pom-addition ([:developers [:developer
+                               [:id "technomancy"]
+                               [:name "Phil Hagelberg"]
+                               [:url "https://technomancy.us"]
+                               [:roles
+                                [:role "developer"]
+                                [:role "maintainer"]]]]
+                 [:contributors [:contributor
+                                 [:name "Ben Bitdiddle"]
+                                 [:url "http://www.example.com/benjamin"]
+                                 [:properties [:id "benbit"]]]])
 
 ;;; Safety flags
   ;; Indicate whether or not `lein install` should abort when trying to install


### PR DESCRIPTION
This PR makes two kinds of changes to the `pom-addition` section of the sample `project.clj`:

1. Specify the developer id as a sub-element rather than an attribute, [according to the Maven POM specification](https://maven.apache.org/pom.html#Developers). Putting it as an attribute is not correct and Maven-based tooling is not likely to understand it.
2. Add a [contributors section](https://maven.apache.org/pom.html#Contributors) illustrating how to add multiple different kinds of elements to the generated POM. I think this is valuable for folks like myself who are (sadly) Lisp-impaired; I had to consult my more Lisp-competent colleague @kephale to clue me in that parentheses were needed surrounding the two different things we needed to add to the generated POM.

I wasn't sure who would be a good choice to add as a contributor, so I moved benbit to contributors, and added technomancy as developer. Hopefully this is not contentious, but I'm happy to switch the actual people referenced to whoever the Leinengen team feels make most sense for this example.