### PR TITLE
Update deploy documentation for Maven central

### DIFF
--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -407,11 +407,12 @@ properly in your `project.clj`:
   :license
   :scm
   :pom-addition
+  :classifiers
 ```
 
 Examples of OSS-acceptable values for these entries can be seen in this
 [`project.clj`
-file](https://github.com/cemerick/piggieback/blob/master/project.clj).
+file](https://github.com/operatr-io/kpow-streams-agent/blob/main/project.clj).
 Note that all of them should be appropriate for *your* project; blind
 copy/paste is not appropriate here.
 


### PR DESCRIPTION
I have just gone thru the process of getting a lein project deployed to Maven central. I found that the documentation was out of date with the current requirements, and that there weren't many resources online documenting anyone's experience.

The [current requirements](https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources) require a `-javadoc.jar` and `-sources.jar` to be provided: 

> If, for some reason (for example, license issue or it's a Scala project), you can not provide -sources.jar or -javadoc.jar , please make fake -sources.jar or -javadoc.jar with simple README inside to pass the checking

Given **most** Clojure projects are probably similar to Scala, we can provide a "fake" sources/javadoc jar using the `:classifiers` key, for example:

```clojure
:classifiers [["sources" {:source-paths      ^:replace []
                            :java-source-paths ^:replace []
                            :resource-paths    ^:replace []}]
                ["javadoc" {:source-paths      ^:replace []
                            :java-source-paths ^:replace []
                            :resource-paths    ^:replace []}]]
```

However, you could also use the `:classifiers` key + a prep-task to build/bundle javadocs if you actually have Java sources... Like the documentation says: "blind copy/paste is not appropriate here".

I also found the `nrepl/piggieback` sample `project.clj` to be out of date with the requirements, so updated the example with our OSS project that has successfully been deployed to maven using lein :)
