### PR TITLE
Update REPLy to 0.5.0

### DIFF
--- a/doc/PROFILES.md
+++ b/doc/PROFILES.md
@@ -260,8 +260,8 @@ plugin:
      :group "lein-pprint",
      :source-path ("/home/phil/src/leiningen/lein-pprint/src"),
      :dependencies
-     ([org.clojure/tools.nrepl "0.0.5" :exclusions [org.clojure/clojure]]
-      [clojure-complete "0.1.4" :exclusions [org.clojure/clojure]]
+     ([nrepl "0.8.3" :exclusions [org.clojure/clojure]]
+      [incomplete "0.1.0" :exclusions [org.clojure/clojure]]
       [org.thnetos/cd-client "0.3.3" :exclusions [org.clojure/clojure]]),
      :target-path "/home/phil/src/leiningen/lein-pprint/target",
      :name "lein-pprint",

--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -403,7 +403,7 @@ Enough setup; let's see some code running. Start with a REPL
     $ cd my-stuff
     $ lein repl
     nREPL server started on port 55568 on host 127.0.0.1 - nrepl://127.0.0.1:55568
-    REPL-y 0.4.4, nREPL 0.8.3
+    REPL-y 0.5.0, nREPL 0.8.3
     Clojure 1.10.1
     OpenJDK 64-Bit Server VM 1.8.0_222-b10
         Docs: (doc function-name-here)

--- a/leiningen-core/src/leiningen/core/project.clj
+++ b/leiningen-core/src/leiningen/core/project.clj
@@ -559,7 +559,7 @@
                 ;; bump deps in leiningen's own project.clj with these
                 :dependencies '[^:displace [nrepl/nrepl "0.8.3"
                                             :exclusions [org.clojure/clojure]]
-                                ^:displace [clojure-complete "0.2.5"
+                                ^:displace [org.nrepl/incomplete "0.1.0"
                                             :exclusions [org.clojure/clojure]]]
                 :checkout-deps-shares [:source-paths
                                        :test-paths

--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -46,7 +46,7 @@
                                [clj-http/clj-http "3.4.1"]
                                [nrepl/nrepl "0.8.3"
                                 :exclusions [[org.clojure/clojure]]]
-                               [clojure-complete/clojure-complete "0.2.5"
+                               [org.nrepl/incomplete "0.1.0"
                                 :exclusions [[org.clojure/clojure]]]],
                :twelve 12 ; testing unquote
 

--- a/resources/leiningen/bootclasspath-deps.clj
+++ b/resources/leiningen/bootclasspath-deps.clj
@@ -21,7 +21,7 @@
             (pp/pprint))))
 {
  clj-commons/pomegranate "1.2.0"
- clojure-complete "0.2.5"
+ org.nrepl/incomplete "0.1.0"
  com.hypirion/io "0.3.1"
  commons-codec "1.11"
  commons-io "2.8.0"

--- a/src/leiningen/repl.clj
+++ b/src/leiningen/repl.clj
@@ -252,8 +252,8 @@
 
 (def reply-profile
   {:dependencies
-   '[^:displace [reply "0.4.4" :exclusions [org.clojure/clojure ring/ring-core]]
-     [clojure-complete "0.2.5"]]})
+   '[^:displace [reply "0.5.0" :exclusions [org.clojure/clojure ring/ring-core]]
+     [org.nrepl/incomplete "0.1.0"]]})
 
 (defn- trampoline-repl [project port]
   (let [init-option (get-in project [:repl-options :init])


### PR DESCRIPTION
This version of REPLy replaces clojure-complete with the newer
incomplete library. More details - https://github.com/nrepl/incomplete

The end users shouldn't be affected negatively by the change, they'll just get better completion results. 