### PR TITLE
Exclude ranges which point to a single version from pedantic

### DIFF
--- a/leiningen-core/src/leiningen/core/pedantic.clj
+++ b/leiningen-core/src/leiningen/core/pedantic.clj
@@ -42,10 +42,16 @@
         (.transformGraph node context))))
 
 (defn- range?
-  "Does the path point to a DependencyNode asking for a version range?"
+  "Does the path point to a DependencyNode asking for a version range
+   which contains several versions?"
   [{:keys [node]}]
   (when-let [vc (.getVersionConstraint node)]
-    (not (nil? (.getRange vc)))))
+    (let [range (.getRange vc)
+          lb    (some-> range .getLowerBound)
+          ub    (some-> range .getUpperBound)]
+      (and (some? range)
+           (some? lb)
+           (not (.equals lb ub))))))
 
 (defn- set-ranges!
   "Set ranges to contain all paths that asks for a version range"


### PR DESCRIPTION
Pedantic rightly complains when version ranges introduce unclear
behavior. Some projects always use ranges and have the same
lower and upper bound when pointing to a single version.

This patch captures this behavior to avoid suggesting exclusions
in this case.

Any project using GRPC artifacts experiences this for instance.
I must admit I don't have a clear idea on how to implement tests for
this patch though