### PR TITLE
Link to Libera.Chat in website instead of Freenode

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -136,8 +136,8 @@
         widely-contributed-to Clojure project. We welcome potential
         contributors and do our best to make it easy to help out.</p>
 
-      <p>Discussion occurs primarily <a href="irc://chat.freenode.net#leiningen">in
-          the <tt>#leiningen</tt> channel on Freenode</a>.</p>
+      <p>Discussion occurs primarily <a href="irc://irc.libera.chat#leiningen">in
+          the <tt>#leiningen</tt> channel on Libera.Chat</a>.</p>
 
       <p>Issues should
         be <a href="https://github.com/technomancy/leiningen/issues">reported


### PR DESCRIPTION
Commit 7369b6d6ce7476f667d4da3b2b031ec47644402b changed the listed IRC channel in the `CONTRIBUTORS.md` file; this pull request performs the same change on the sources for the [Leiningen website](https://leiningen.org/).