### PR TITLE
Ability to provide custom LEIN_JAR location

### DIFF
--- a/bin/lein
+++ b/bin/lein
@@ -142,7 +142,7 @@ if $cygwin; then
     export LEIN_HOME=$(cygpath -w "$LEIN_HOME")
 fi
 
-LEIN_JAR="${LEIN_JAR:-${LEIN_HOME}/self-installs/leiningen-$LEIN_VERSION-standalone.jar}"
+LEIN_JAR="${LEIN_JAR:-${LEIN_HOME}/self-installs/leiningen-${LEIN_VERSION}-standalone.jar}"
 
 # normalize $0 on certain BSDs
 if [ "$(dirname "$0")" = "." ]; then

--- a/bin/lein
+++ b/bin/lein
@@ -142,7 +142,7 @@ if $cygwin; then
     export LEIN_HOME=$(cygpath -w "$LEIN_HOME")
 fi
 
-LEIN_JAR="$LEIN_HOME/self-installs/leiningen-$LEIN_VERSION-standalone.jar"
+LEIN_JAR="${LEIN_JAR:-${LEIN_HOME}/self-installs/leiningen-$LEIN_VERSION-standalone.jar}"
 
 # normalize $0 on certain BSDs
 if [ "$(dirname "$0")" = "." ]; then


### PR DESCRIPTION
This is extremely useful when the JAR isn't available in the usual location. This is already implemented in other flavors. https://github.com/technomancy/leiningen/blob/f1921a55ae83c419ef4528f92c65a01f48603b80/bin/lein.bat#L31

This is particularly useful for when external build tools where JAR location path can't be the same as this script expects. This is will particularly help the case with Bazel's `http_jar` rule when running in sandbox mode. https://docs.bazel.build/versions/4.2.1/repo/http.html#http_jar