### PR TITLE
Make `utils/mkdirs` nil-safe

### DIFF
--- a/leiningen-core/src/leiningen/core/utils.clj
+++ b/leiningen-core/src/leiningen/core/utils.clj
@@ -67,8 +67,9 @@
 (defn mkdirs
   "Make a given directory and its parents, but throw an Exception on failure."
   [f] ; whyyyyy does .mkdirs fail silently ugh
-  (when-not (or (.mkdirs (io/file f)) (.exists (io/file f)))
-    (throw (Exception. (str "Couldn't create directories: " (io/file f))))))
+  (when f ; (io/file nil) returns nil, so we mimic a similar API instead of failing eagerly on nil inputs.
+    (when-not (or (.mkdirs (io/file f)) (.exists (io/file f)))
+      (throw (Exception. (str "Couldn't create directories: " (io/file f)))))))
 
 (defn relativize
   "Makes the filepath path relative to base. Assumes base is an ancestor to


### PR DESCRIPTION
> Part of https://github.com/technomancy/leiningen/issues/2777

If for whatever reason `(utils/mkdirs nil)` was invoked, one would get `java.lang.Exception: Couldn't create directories:` which is not a very informative error.

I'd propose to make this defn's API akin to `io/file`'s - which returns nil on nil inputs instead of throwing.

Unfortunately I'm not able to reproduce the bug that is causing these issues in the first place, namely https://github.com/clojure-emacs/cider/issues/3108. So I can't debug why `(utils/mkdirs nil)` was being invoked to begin with.