### PR TITLE
Extend "lein change" to be able to edit versions in :dependencies and :managed-dependencies

### DIFF
--- a/src/leiningen/change.clj
+++ b/src/leiningen/change.clj
@@ -26,7 +26,7 @@
     (-> value sj/str-pt read-string)))
 
 (defn ^:internal normalize-path [value]
-  (if (coll? value) 
+  (if (coll? value)
     value
     (map keyword (remove empty? (str/split value #":")))))
 

--- a/test/leiningen/test/change.clj
+++ b/test/leiningen/test/change.clj
@@ -118,6 +118,18 @@
            (change-string "(defproject leingingen.change \"0.0.1\")"
                           ":license:url" "set" "http://example.com")))))
 
+(deftest test-set-dependency-value
+  (testing "can set dependency version"
+    (is (= "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.10.1\"]])"
+           (change-string "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.8.0\"]])"
+                          ":dependencies:org.clojure/clojure"  "set" "1.10.1")
+           )))
+  (testing "can append dependency version"
+    (is (= "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.8.0\"] [org.clojure/core.cache \"1.0.207\"]])"
+           (change-string "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.8.0\"]])"
+                          ":dependencies:org.clojure/core.cache"  "set" "1.0.207")
+           ))))
+
 (deftest test-normalize-path
   (is (= [:a]
          (normalize-path "a")
@@ -126,11 +138,8 @@
          (normalize-path "a:b")
          (normalize-path ":a:b")
          (normalize-path [:a :b])))
-  (is (= [:dependencies 'org.clojure/clojure]
-         (normalize-path "dependencies[org.clojure/clojure]")
-         (normalize-path ":dependencies[org.clojure/clojure]")
-         (normalize-path "dependencies:[org.clojure/clojure]")
-         (normalize-path ":dependencies:[org.clojure/clojure]")
+  (is (= [:dependencies :org.clojure/clojure]
+         (normalize-path ":dependencies:org.clojure/clojure")
          )))
 
 (def div-dinc (comp inc inc /))

--- a/test/leiningen/test/change.clj
+++ b/test/leiningen/test/change.clj
@@ -125,7 +125,13 @@
   (is (= [:a :b]
          (normalize-path "a:b")
          (normalize-path ":a:b")
-         (normalize-path [:a :b]))))
+         (normalize-path [:a :b])))
+  (is (= [:dependencies 'org.clojure/clojure]
+         (normalize-path "dependencies[org.clojure/clojure]")
+         (normalize-path ":dependencies[org.clojure/clojure]")
+         (normalize-path "dependencies:[org.clojure/clojure]")
+         (normalize-path ":dependencies:[org.clojure/clojure]")
+         )))
 
 (def div-dinc (comp inc inc /))
 

--- a/test/leiningen/test/change.clj
+++ b/test/leiningen/test/change.clj
@@ -122,13 +122,15 @@
   (testing "can set dependency version"
     (is (= "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.10.1\"]])"
            (change-string "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.8.0\"]])"
-                          ":dependencies:org.clojure/clojure"  "set" "1.10.1")
-           )))
+                          ":dependencies:org.clojure/clojure"  "set" "1.10.1"))))
+  (testing "can alter version without impacting the rest of a dependency vector"
+    (is (= "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.10.1\" :exclusions [group/artifact \"1.0.0\"]]])"
+          (change-string "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.8.0\" :exclusions [group/artifact \"1.0.0\"]]])"
+                         ":dependencies:org.clojure/clojure"  "set" "1.10.1"))))
   (testing "can append dependency version"
     (is (= "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.8.0\"] [org.clojure/core.cache \"1.0.207\"]])"
            (change-string "(defproject leiningen.change \"0.0.1\" :description \"a dynamic description\" :dependencies [[org.clojure/clojure \"1.8.0\"]])"
-                          ":dependencies:org.clojure/core.cache"  "set" "1.0.207")
-           ))))
+                          ":dependencies:org.clojure/core.cache"  "set" "1.0.207")))))
 
 (deftest test-normalize-path
   (is (= [:a]


### PR DESCRIPTION
Consider an application suite with parent and child projects (i.e., using lein-parent) and with a versioning policy that requires, for example, consistently bumping the patch version of the parent project and the versions a collection of libraries or applications when a change is made to a common shared library.  

It was already possible to use `lein change` to bump the version of the parent project, and to bump the version of the reference to the parent project in the children (e.g., `lein change :parent-project:coords leiningen.release/bump-version :patch` followed by `lein change :parent-project:coords leiningen.release/bump-version :release`)

However, it was not possible to automate updating version references in the :dependencies or :managed-dependencies vectors of projects or parent projects.  So, for example upon the release of a hotfix to a shared jar that's built into multiple uberjars, it was necessary to manually edit the :managed-dependency vector of the parent project to update the version of the shared jar.  

This PR adds to leiningen.change/change the ability to parse the sjacket DOM for vectors of vectors, and to match on the first element of an inner vector, as in:
```
:dependencies [[org.clojure/clojure "1.8.0"]
               [org.clojure/tools.cli "0.4.2"]]
```
and by generalizing slightly leiningen.change/normalize-path to handle specifications such as:

```
lein change :dependencies[org.clojure/clojure] set '"1.10.1"'
```

The above works in :dependencies and in :managed-dependencies vectors in project.clj files, and enables developers and devops processes to script the updates to version dependencies in project files. 
