### PR TITLE
Add type hint for invokeStatic method used in `lein run`

### DIFF
--- a/src/leiningen/run.clj
+++ b/src/leiningen/run.clj
@@ -77,7 +77,7 @@
          ;; If the class exists, run its main method.
          class#
          (Reflector/invokeStaticMethod
-          class# "main" (into-array [(into-array String '~args)]))
+          class# "main" ^"[Ljava.lang.Object;" (into-array [(into-array String '~args)]))
 
          ;; If the symbol didn't resolve, give a reasonable message
          (= :not-found ns-flag#)


### PR DESCRIPTION
Fixes https://github.com/technomancy/leiningen/issues/2695, reduces a reflection call.

Past work related to this:
- https://github.com/technomancy/leiningen/pull/2306
- Reverted here for another change in the above pull: https://github.com/technomancy/leiningen/issues/2328

