### PR TITLE
Fix global :exclusions in profile not applying to root :dependencies

### DIFF
--- a/leiningen-core/test/leiningen/core/test/project.clj
+++ b/leiningen-core/test/leiningen/core/test/project.clj
@@ -410,7 +410,8 @@
 
 (deftest test-global-exclusions
   (let [project {:dependencies
-                 '[[lancet "1.0.1"]
+                 '[[org.clojure/clojure "1.11.1"]
+                   [lancet "1.0.1"]
                    [leiningen-core "2.0.0-SNAPSHOT" :exclusions [pomegranate]]
                    [clucy "0.2.2" :exclusions [org.clojure/clojure]]]
                  :exclusions '[org.clojure/clojure]}
@@ -418,7 +419,11 @@
     (is (= '[[[org.clojure/clojure]]
              [[org.clojure/clojure] [pomegranate/pomegranate]]
              [[org.clojure/clojure]]]
-           (map #(distinct (:exclusions (apply hash-map %))) dependencies)))))
+           (map #(distinct (:exclusions (apply hash-map %))) dependencies)))
+    (is (= '[[lancet/lancet "1.0.1" :exclusions ([org.clojure/clojure])]
+             [leiningen-core/leiningen-core "2.0.0-SNAPSHOT" :exclusions ([org.clojure/clojure] [pomegranate/pomegranate])]
+             [clucy/clucy "0.2.2" :exclusions ([org.clojure/clojure])]]
+           dependencies))))
 
 (defn add-seven [project]
   (assoc project :seven 7))

--- a/test/leiningen/test/pom.clj
+++ b/test/leiningen/test/pom.clj
@@ -380,7 +380,7 @@
              ((partial mapcat :content))))))
 
 (deftest test-pom-handles-global-exclusions
-  (is (= [["clojure"] ["clojure"] ["clojure"]]
+  (is (= [["clojure"] ["clojure"]]
          (-> (make-pom (with-profile-merged sample-project
                          ^:leaky {:exclusions '[org.clojure/clojure]}))
              parse-xml


### PR DESCRIPTION
This fixes https://github.com/technomancy/leiningen/issues/2811

I ended adding a `remove-self-excluded-deps` instead of modifying `add-global-exclusions` to `add-and-apply-global-exclusions` because I think  `add-and-apply-global-exclusions` conveys that it will somehow apply the exclusions to the deps tree there which is misleading.