### PR TITLE
Remove openjdk 8 from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,6 @@
   "workflows": {
     "test-with-matrix": {
       "jobs": [
-        {"build": {"name": "openjdk8",  "java_version": "openjdk-8"}},
         {"build": {"name": "openjdk17", "java_version": "openjdk-17"}},
         {"build": {"name": "openjdk21", "java_version": "openjdk-21"}}
       ]


### PR DESCRIPTION
This isn't needed any more.