### PR TITLE
Remove openjdk 8 from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,9 +45,6 @@ workflows:
   test-with-matrix:
     jobs:
       - build:
-          name: "openjdk8"
-          java_version: "openjdk-8"
-      - build:
           name: "openjdk11"
           java_version: "openjdk-11"
       - build:


### PR DESCRIPTION
It's old and we don't need it.